### PR TITLE
[WIP][#564] Map VMWare Storages to OSP CloudVolumeTypes

### DIFF
--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/MappingWizardConstants.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/MappingWizardConstants.js
@@ -9,6 +9,9 @@ export const V2V_TARGET_PROVIDERS = [
   { name: __('Red Hat OpenStack Platform'), id: 'openstack' }
 ];
 
-export const V2V_TARGET_PROVIDER_STORAGE_KEYS = { rhevm: 'storages', openstack: 'cloud_volumes' };
+export const V2V_TARGET_PROVIDER_STORAGE_KEYS = {
+  rhevm: 'storages',
+  openstack: 'ext_management_system.cloud_volume_types'
+};
 
 export const V2V_TARGET_PROVIDER_NETWORK_KEYS = { rhevm: 'lans', openstack: 'cloud_networks' };

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStepActions.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStepActions.js
@@ -1,5 +1,6 @@
 import URI from 'urijs';
 import API from '../../../../../../../../common/API';
+import objectNavigator from '../../../../../common/objectNavigator';
 import {
   FETCH_V2V_SOURCE_DATASTORES,
   FETCH_V2V_TARGET_DATASTORES,
@@ -49,8 +50,8 @@ export const fetchSourceDatastoresAction = (url, id) => {
 const _filterTargetDatastores = (response, targetProvider) => {
   const { data } = response;
 
-  if (data[V2V_TARGET_PROVIDER_STORAGE_KEYS[targetProvider]]) {
-    const targetDatastores = data[V2V_TARGET_PROVIDER_STORAGE_KEYS[targetProvider]].map(storage => ({
+  if (objectNavigator(V2V_TARGET_PROVIDER_STORAGE_KEYS[targetProvider], data)) {
+    const targetDatastores = objectNavigator(V2V_TARGET_PROVIDER_STORAGE_KEYS[targetProvider], data).map(storage => ({
       ...storage,
       providerName: data.ext_management_system.name
     }));

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStepConstants.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStepConstants.js
@@ -4,5 +4,5 @@ export const FETCH_V2V_TARGET_DATASTORES = 'FETCH_V2V_TARGET_DATASTORES';
 export const QUERY_ATTRIBUTES = {
   source: 'storages,ext_management_system.name',
   rhevm: 'storages,ext_management_system.name',
-  openstack: 'cloud_volumes,ext_management_system.name'
+  openstack: 'ext_management_system.cloud_volume_types,ext_management_system.name'
 };

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/components/DatastoresStepForm/DatastoresStepForm.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/components/DatastoresStepForm/DatastoresStepForm.js
@@ -306,7 +306,7 @@ class DatastoresStepForm extends React.Component {
               targetDatastores.map(item => (
                 <DualPaneMapperListItem
                   item={item}
-                  text={targetDatastoreInfo(item, input.value)}
+                  text={targetDatastoreInfo(item)}
                   key={item.id}
                   selected={selectedTargetDatastore && selectedTargetDatastore.id === item.id}
                   handleClick={this.selectTargetDatastore}

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/components/DatastoresStepForm/helpers.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/components/DatastoresStepForm/helpers.js
@@ -22,7 +22,7 @@ export const targetDatastoreAvailableSpace = (targetDatastore, datastoresStepMap
 export const sourceDatastoreInfo = sourceDatastore =>
   sprintf(__('%s \\ %s \\ %s'), sourceDatastore.providerName, sourceDatastore.datacenterName, sourceDatastore.name);
 
-export const targetDatastoreInfo = (targetDatastore, datastoresStepMappings) =>
+export const targetDatastoreInfo = targetDatastore =>
   sprintf(__('%s \\ %s'), targetDatastore.providerName, targetDatastore.name);
 
 export const targetDatastoreTreeViewInfo = targetDatastore => targetDatastore.name;

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/helpers.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/helpers.js
@@ -29,7 +29,7 @@ export const multiProviderTargetLabel = (providerType, wizardStep) => {
         case 'cluster':
           return __('Target Provider \\ Project');
         case 'storage':
-          return __('Target Provider \\ Cloud Volume');
+          return __('Target Provider \\ Volume Type');
         case 'network':
           return __('Target Project \\ Network');
         default:

--- a/app/javascript/react/screens/App/common/objectNavigator.js
+++ b/app/javascript/react/screens/App/common/objectNavigator.js
@@ -1,0 +1,2 @@
+export default (path, object) =>
+  path.split('.').reduce((previous, current) => (previous ? previous[current] : null), object);


### PR DESCRIPTION
# Notes
- We had been using `cloud_volume` as a placeholder while waiting for `cloud_volume_type` to be exposed via API.
- Depends on https://github.com/ManageIQ/manageiq-providers-openstack/pull/366