### PR TITLE
[#585] Fix fetching hosts

### DIFF
--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardClustersStep/MappingWizardClustersStep.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardClustersStep/MappingWizardClustersStep.js
@@ -24,7 +24,7 @@ class MappingWizardClustersStep extends React.Component {
 
     fetchSourceClustersAction(fetchSourceClustersUrl);
     fetchTargetClustersAction(fetchTargetComputeUrls[targetProvider]).then(result => {
-      if (result.length > 0) {
+      if (result.value && result.value.data && result.value.data.resources.length > 0) {
         const hostIDsByClusterID = result.value.data.resources.reduce(
           (newObject, cluster) => ({
             ...newObject,


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq-v2v/issues/585
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1571778

When promise chaining onto a redux-thunk action, the resolved value will
not have passed through the reducer. So, in this case, it is not an
array, but the entire response object from the API