### PR TITLE
[#585] Add hosts attribute to API endpoint

### DIFF
--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardClustersStep/MappingWizardClustersStep.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardClustersStep/MappingWizardClustersStep.js
@@ -123,7 +123,7 @@ MappingWizardClustersStep.defaultProps = {
   fetchTargetComputeUrls: {
     rhevm:
       '/api/clusters?expand=resources' +
-      '&attributes=ext_management_system.emstype,v_parent_datacenter,ext_management_system.name' +
+      '&attributes=ext_management_system.emstype,v_parent_datacenter,ext_management_system.name,hosts' +
       '&filter[]=ext_management_system.emstype=rhevm',
     openstack: '/api/cloud_tenants?expand=resources&attributes=ext_management_system.name'
   }


### PR DESCRIPTION
This was dropped when refactoring to move API URLs to defaultProps

This is a follow-up PR for https://github.com/ManageIQ/manageiq-v2v/issues/585