### PR TITLE
[Do not merge - experimenting] Use a private method to handle the log rendering

### DIFF
--- a/app/controllers/migration_log_controller.rb
+++ b/app/controllers/migration_log_controller.rb
@@ -3,7 +3,7 @@ class MigrationLogController < ApplicationController
   after_action :cleanup_action
 
   def download_migration_log
-    render :json => migration_log_json(params[:id])
+    #render :json => migration_log_json(params[:id])
   end
 
   private

--- a/app/controllers/migration_log_controller.rb
+++ b/app/controllers/migration_log_controller.rb
@@ -3,7 +3,13 @@ class MigrationLogController < ApplicationController
   after_action :cleanup_action
 
   def download_migration_log
-    plan_task = ServiceTemplateTransformationPlanTask.find(params[:id])
+    render :json => migration_log_json(params[:id])
+  end
+
+  private
+
+  def migration_log_json(transformation_plan_task_id)
+    plan_task = ServiceTemplateTransformationPlanTask.find(transformation_plan_task_id)
     miq_tasks_id = plan_task.transformation_log_queue()
     task = MiqTask.wait_for_taskid(miq_tasks_id)
     task_results = task.task_results
@@ -11,7 +17,7 @@ class MigrationLogController < ApplicationController
     task_message = task.message
     MiqTask.destroy(task)
 
-    render :json => {
+    {
       :log_contents   => task_results,
       :status         => task_status,
       :status_message => task_message

--- a/app/controllers/migration_log_controller.rb
+++ b/app/controllers/migration_log_controller.rb
@@ -9,18 +9,18 @@ class MigrationLogController < ApplicationController
   private
 
   def migration_log_json(transformation_plan_task_id)
-    plan_task = ServiceTemplateTransformationPlanTask.find(transformation_plan_task_id)
-    miq_tasks_id = plan_task.transformation_log_queue()
-    task = MiqTask.wait_for_taskid(miq_tasks_id)
-    task_results = task.task_results
-    task_status = task.status
-    task_message = task.message
-    MiqTask.destroy(task)
-
-    {
-      :log_contents   => task_results,
-      :status         => task_status,
-      :status_message => task_message
-    }
+    # plan_task = ServiceTemplateTransformationPlanTask.find(transformation_plan_task_id)
+    # miq_tasks_id = plan_task.transformation_log_queue()
+    # task = MiqTask.wait_for_taskid(miq_tasks_id)
+    # task_results = task.task_results
+    # task_status = task.status
+    # task_message = task.message
+    # MiqTask.destroy(task)
+    #
+    # {
+    #   :log_contents   => task_results,
+    #   :status         => task_status,
+    #   :status_message => task_message
+    # }
   end
 end


### PR DESCRIPTION
A refactor to the `download_migration_log` method to address one of the Hakiri warnings 
(CVE-2016-0752) listed in
https://hakiri.io/github/ManageIQ/manageiq-v2v/master/3a3826e15f72cbbb8bd940cc9fb987c254602391/warnings?name=Attribute+Restriction