### PR TITLE
[#592] Change text to `Start Time` in the popover

### DIFF
--- a/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
+++ b/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
@@ -532,7 +532,7 @@ class PlanRequestDetailList extends React.Component {
                 >
                   <div>
                     <div>
-                      <b>{__('Elapsed Time')}: </b>
+                      <b>{__('Start Time')}: </b>
                       {formatDateTime(task.startDateTime)}
                     </div>
                     {task.options.prePlaybookRunning || task.options.postPlaybookRunning ? (


### PR DESCRIPTION
Fixes #592

<img width="1211" alt="screen shot 2018-08-20 at 2 21 26 pm" src="https://user-images.githubusercontent.com/1538216/44367355-5ac07200-a484-11e8-9f2e-65410df7b85b.png">
