### PR TITLE
Reset state when leaving Plan details page

### DIFF
--- a/app/javascript/react/screens/App/Plan/PlanReducer.js
+++ b/app/javascript/react/screens/App/Plan/PlanReducer.js
@@ -247,7 +247,8 @@ export default (state = initialState, action) => {
         .set('vms', [])
         .set('planRequestPreviouslyFetched', false)
         .set('markedForCancellation', [])
-        .set('selectedTasksForCancel', []);
+        .set('selectedTasksForCancel', [])
+        .set('planRequestFailed', false);
 
     case `${FETCH_V2V_MIGRATION_TASK_LOG}_PENDING`:
       return state.set('isFetchingMigrationTaskLog', true).set('isRejectedMigrationTaskLog', false);


### PR DESCRIPTION
Fixes #594 
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1618844

planRequestFailed is being persisted between page visits, causing the
error icon to appear on the Plan Not Started page when visiting after
viewing a failed plan.

# Steps to Reproduce Bug
- Create a new migration plan, but do not run
- Visit the details page of a failed migration plan
- Visit the details page of the not started plan
- You should see the error icon in the breadcrumb area