### PR TITLE
[#591] Show Migrations section if archived plans exist

### DIFF
--- a/app/javascript/react/screens/App/Overview/Overview.js
+++ b/app/javascript/react/screens/App/Overview/Overview.js
@@ -310,7 +310,7 @@ class Overview extends React.Component {
           }
           style={{ marginTop: 200 }}
         >
-          {(transformationMappings.length > 0 || transformationPlans.length > 0) && (
+          {(transformationMappings.length > 0 || transformationPlans.length > 0 || archivedTransformationPlans) && (
             <Migrations
               activeFilter={migrationsFilter}
               setActiveFilter={setMigrationsFilterAction}


### PR DESCRIPTION
Fixes #591 
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1614243

Currently the migrations section is not shown if all plans have been
archived (and all transformation mappings have been deleted)

# Steps to Reproduce Bug
- Ensure that the only type of plan you have is `archived`
- Delete all transformation mappings
- The migrations section will inaccessible, making it impossible to view your `archived` plans
- _**NOTE**_:  This does not occur if you have any other type of plan (active, completed, or not started)