### PR TITLE
[#576] Fix Mapping Wizard Name Validation

### DIFF
--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardGeneralStep/MappingWizardGeneralStep.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardGeneralStep/MappingWizardGeneralStep.js
@@ -8,7 +8,7 @@ import { FormField } from '../../../../../common/forms/FormField';
 import { BootstrapSelect } from '../../../../../common/forms/BootstrapSelect';
 import { validation } from '../../../../../../../../common/constants';
 import { V2V_TARGET_PROVIDERS } from '../../MappingWizardConstants';
-import { asyncValidate, onChange } from '../helpers';
+import { asyncValidate, onChange } from './helpers';
 
 const MappingWizardGeneralStep = props => {
   const onSelect = selection => {


### PR DESCRIPTION
Fixes #576 

Mapping Wizard name validation is not working because wrong helpers
file is being referenced in the component

# Steps to Reproduce Bug
- Attempt to create a new transformation mapping with an already existing name

# Notes
- Reverting this fix will allow @AllenBW to recreate the scenario for #577 