### PR TITLE
Load mapping info for a plan only when available

### DIFF
--- a/app/javascript/react/screens/App/Overview/Overview.js
+++ b/app/javascript/react/screens/App/Overview/Overview.js
@@ -251,7 +251,8 @@ class Overview extends React.Component {
       toggleScheduleMigrationModal,
       scheduleMigrationModal,
       scheduleMigrationPlan,
-      scheduleMigration
+      scheduleMigration,
+      plansMutatedWithMappingInfo
     } = this.props;
 
     const inProgressRequestsTransformationMappings = () => {
@@ -340,6 +341,7 @@ class Overview extends React.Component {
               scheduleMigrationModal={scheduleMigrationModal}
               scheduleMigrationPlan={scheduleMigrationPlan}
               scheduleMigration={scheduleMigration}
+              plansMutatedWithMappingInfo={plansMutatedWithMappingInfo}
             />
           )}
           {hasSufficientProviders ? (
@@ -472,7 +474,8 @@ Overview.propTypes = {
   fetchServiceTemplateAnsiblePlaybooksAction: PropTypes.func,
   fetchServiceTemplateAnsiblePlaybooksUrl: PropTypes.string,
   serviceTemplatePlaybooks: PropTypes.array,
-  redirectTo: PropTypes.func.isRequired
+  redirectTo: PropTypes.func.isRequired,
+  plansMutatedWithMappingInfo: PropTypes.bool
 };
 
 Overview.defaultProps = {

--- a/app/javascript/react/screens/App/Overview/OverviewReducer.js
+++ b/app/javascript/react/screens/App/Overview/OverviewReducer.js
@@ -107,7 +107,8 @@ export const initialState = Immutable({
   serviceTemplatePlaybooks: [],
   isFetchingServiceTemplatePlaybooks: false,
   isRejectedServiceTemplatePlaybooks: false,
-  errorServiceTemplatePlaybooks: null
+  errorServiceTemplatePlaybooks: null,
+  plansMutatedWithMappingInfo: false
 });
 
 export default (state = initialState, action) => {
@@ -191,6 +192,7 @@ export default (state = initialState, action) => {
         .set('transformationPlans', planTransmutation(action.payload.data.resources, state.transformationMappings))
         .set('isFetchingTransformationPlans', false)
         .set('isRejectedTransformationPlans', false)
+        .set('plansMutatedWithMappingInfo', state.transformationMappings.length > 0)
         .set('errorTransformationPlans', null);
     }
     case `${FETCH_V2V_TRANSFORMATION_PLANS}_REJECTED`:

--- a/app/javascript/react/screens/App/Overview/__test__/OverviewReducer.test.js
+++ b/app/javascript/react/screens/App/Overview/__test__/OverviewReducer.test.js
@@ -18,7 +18,8 @@ describe('fetching transformation plans', () => {
 
     expect(state).toEqual({
       ...initialStateWithInfraMapping,
-      isFetchingTransformationPlans: true
+      isFetchingTransformationPlans: true,
+      plansMutatedWithMappingInfo: false
     });
   });
 
@@ -40,7 +41,8 @@ describe('fetching transformation plans', () => {
 
     expect(state).toEqual({
       ...initialStateWithInfraMapping,
-      transformationPlans: payload.data.resources
+      transformationPlans: payload.data.resources,
+      plansMutatedWithMappingInfo: true
     });
   });
 

--- a/app/javascript/react/screens/App/Overview/components/Migrations/Migrations.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/Migrations.js
@@ -36,7 +36,8 @@ const Migrations = ({
   toggleScheduleMigrationModal,
   scheduleMigrationModal,
   scheduleMigrationPlan,
-  scheduleMigration
+  scheduleMigration,
+  plansMutatedWithMappingInfo
 }) => {
   const filterOptions = [
     MIGRATIONS_FILTERS.notStarted,
@@ -118,6 +119,7 @@ const Migrations = ({
               scheduleMigration={scheduleMigration}
               fetchTransformationPlansAction={fetchTransformationPlansAction}
               fetchTransformationPlansUrl={fetchTransformationPlansUrl}
+              plansMutatedWithMappingInfo={plansMutatedWithMappingInfo}
             />
           )}
           {activeFilter === MIGRATIONS_FILTERS.inProgress && (
@@ -148,6 +150,7 @@ const Migrations = ({
               scheduleMigrationModal={scheduleMigrationModal}
               scheduleMigrationPlan={scheduleMigrationPlan}
               scheduleMigration={scheduleMigration}
+              plansMutatedWithMappingInfo={plansMutatedWithMappingInfo}
             />
           )}
           {activeFilter === MIGRATIONS_FILTERS.archived && (
@@ -157,6 +160,7 @@ const Migrations = ({
               redirectTo={redirectTo}
               loading={isFetchingArchivedTransformationPlans}
               archived
+              plansMutatedWithMappingInfo={plansMutatedWithMappingInfo}
             />
           )}
         </div>
@@ -193,7 +197,8 @@ Migrations.propTypes = {
   toggleScheduleMigrationModal: PropTypes.func,
   scheduleMigrationModal: PropTypes.bool,
   scheduleMigrationPlan: PropTypes.object,
-  scheduleMigration: PropTypes.func
+  scheduleMigration: PropTypes.func,
+  plansMutatedWithMappingInfo: PropTypes.bool
 };
 Migrations.defaultProps = {
   transformationPlans: [],

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
@@ -62,7 +62,8 @@ class MigrationsCompletedList extends React.Component {
       toggleScheduleMigrationModal,
       scheduleMigrationModal,
       scheduleMigrationPlan,
-      scheduleMigration
+      scheduleMigration,
+      plansMutatedWithMappingInfo
     } = this.props;
     const sortedMigrations = this.sortedMigrations();
 
@@ -227,13 +228,22 @@ class MigrationsCompletedList extends React.Component {
                             <strong>{Object.keys(tasks).length} </strong>
                             {__('VMs successfully migrated.')}
                           </ListView.InfoItem>,
-                          plan.infraMappingName ? (
+                          plansMutatedWithMappingInfo &&
+                            isMissingMapping && (
+                              <ListView.InfoItem key={`${plan.id}-infraMappingWarning`}>
+                                <Icon type="pf" name="warning-triangle-o" />{' '}
+                                {__('Infrastucture mapping does not exist.')}
+                              </ListView.InfoItem>
+                            ),
+                          plansMutatedWithMappingInfo &&
+                            !isMissingMapping && (
+                              <ListView.InfoItem key={`${plan.id}-infraMappingName`}>
+                                {plan.infraMappingName}
+                              </ListView.InfoItem>
+                            ),
+                          !plansMutatedWithMappingInfo && (
                             <ListView.InfoItem key={`${plan.id}-infraMappingName`}>
-                              {plan.infraMappingName}
-                            </ListView.InfoItem>
-                          ) : (
-                            <ListView.InfoItem key={`${plan.id}-infraMappingWarning`}>
-                              <Icon type="pf" name="warning-triangle-o" /> {__('Infrastructure mapping does not exist')}
+                              {__('Loading Infrastructure Mapping info...')}
                             </ListView.InfoItem>
                           ),
                           <ListView.InfoItem key={`${plan.id}-elapsed`}>
@@ -343,7 +353,8 @@ MigrationsCompletedList.propTypes = {
   toggleScheduleMigrationModal: PropTypes.func,
   scheduleMigrationModal: PropTypes.bool,
   scheduleMigrationPlan: PropTypes.object,
-  scheduleMigration: PropTypes.func
+  scheduleMigration: PropTypes.func,
+  plansMutatedWithMappingInfo: PropTypes.bool
 };
 MigrationsCompletedList.defaultProps = {
   finishedTransformationPlans: [],

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
@@ -55,7 +55,8 @@ class MigrationsNotStartedList extends React.Component {
       scheduleMigrationPlan,
       scheduleMigration,
       fetchTransformationPlansAction,
-      fetchTransformationPlansUrl
+      fetchTransformationPlansUrl,
+      plansMutatedWithMappingInfo
     } = this.props;
     const sortedMigrations = this.sortedMigrations();
 
@@ -130,13 +131,22 @@ class MigrationsNotStartedList extends React.Component {
                             <Icon type="pf" name="virtual-machine" />
                             <strong>{plan.options.config_info.actions.length}</strong> {__('VMs')}
                           </ListView.InfoItem>,
-                          isMissingMapping ? (
-                            <ListView.InfoItem key={`${plan.id}-infraMappingWarning`}>
-                              <Icon type="pf" name="warning-triangle-o" /> {__('Infrastucture mapping does not exist.')}
-                            </ListView.InfoItem>
-                          ) : (
+                          plansMutatedWithMappingInfo &&
+                            isMissingMapping && (
+                              <ListView.InfoItem key={`${plan.id}-infraMappingWarning`}>
+                                <Icon type="pf" name="warning-triangle-o" />{' '}
+                                {__('Infrastucture mapping does not exist.')}
+                              </ListView.InfoItem>
+                            ),
+                          plansMutatedWithMappingInfo &&
+                            !isMissingMapping && (
+                              <ListView.InfoItem key={`${plan.id}-infraMappingName`}>
+                                {plan.infraMappingName}
+                              </ListView.InfoItem>
+                            ),
+                          !plansMutatedWithMappingInfo && (
                             <ListView.InfoItem key={`${plan.id}-infraMappingName`}>
-                              {plan.infraMappingName}
+                              {__('Loading Infrastructure Mapping info...')}
                             </ListView.InfoItem>
                           ),
                           migrationScheduled && (
@@ -194,7 +204,8 @@ MigrationsNotStartedList.propTypes = {
   scheduleMigrationPlan: PropTypes.object,
   scheduleMigration: PropTypes.func,
   fetchTransformationPlansAction: PropTypes.func,
-  fetchTransformationPlansUrl: PropTypes.string
+  fetchTransformationPlansUrl: PropTypes.string,
+  plansMutatedWithMappingInfo: PropTypes.bool
 };
 MigrationsNotStartedList.defaultProps = {
   migrateClick: noop,


### PR DESCRIPTION
Infrastructure mapping is displayed as unavailable for a plan although it *is* available.

The reason can be attributed to the dependency of one redux state `transformationPlans` with the other `transformationMappings`

Introduced a new state `plansMutatedWithMappingInfo` which tracks if the plans were mutated with the transformation mapping info based on a simple indicator - `state.transformationMappings.length > 0`

While we are waiting for the Mapping info to be available, we can display the `Loading...` message as shown below -
<img width="1213" alt="screen shot 2018-08-24 at 12 38 49 pm" src="https://user-images.githubusercontent.com/1538216/44604483-e1ce5c80-a79a-11e8-8462-b8e232f05b3f.png">

Only after the Mapping info is available, we display it -
<img width="1207" alt="screen shot 2018-08-24 at 12 46 52 pm" src="https://user-images.githubusercontent.com/1538216/44604758-d0398480-a79b-11e8-85a9-9c7ec9e4c16b.png">
