### PR TITLE
[#611] When no clusters are discovered (and loading is done) display message

### DIFF
--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardClustersStep/components/ClustersStepForm/ClustersStepForm.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardClustersStep/components/ClustersStepForm/ClustersStepForm.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Icon } from 'patternfly-react';
 
 import DualPaneMapper from '../../../DualPaneMapper/DualPaneMapper';
 import DualPaneMapperList from '../../../DualPaneMapper/DualPaneMapperList';
@@ -97,6 +98,14 @@ class ClustersStepForm extends React.Component {
     input.onChange([]);
   };
 
+  noClustersFound = (clusters, loading) =>
+    !clusters.length &&
+    !loading && (
+      <div className="dual-pane-mapper-item">
+        <Icon type="pf" name="error-circle-o" /> {__('No clusters found.')}
+      </div>
+    );
+
   render() {
     const {
       sourceClusters,
@@ -155,6 +164,7 @@ class ClustersStepForm extends React.Component {
                   handleKeyPress={this.selectSourceCluster}
                 />
               ))}
+              {this.noClustersFound(sourceClusters, isFetchingSourceClusters)}
             </DualPaneMapperList>
           )}
           {targetClusters && (
@@ -185,6 +195,7 @@ class ClustersStepForm extends React.Component {
                   />
                 );
               })}
+              {this.noClustersFound(targetClusters, isFetchingTargetClusters)}
             </DualPaneMapperList>
           )}
         </DualPaneMapper>


### PR DESCRIPTION
fixes #611

### here's the message we show (with this pr)
<img width="926" alt="screen shot 2018-08-30 at 7 09 45 am" src="https://user-images.githubusercontent.com/6640236/44848272-1ff8cf80-ac24-11e8-98f9-98b5e4e89194.png">
