### PR TITLE
[#610] Migration tasks in progress: Move description/playbook out of tooltip

### DIFF
--- a/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
+++ b/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
@@ -553,7 +553,7 @@ class PlanRequestDetailList extends React.Component {
                 </Popover>
               );
 
-              const descriptionMessage =
+              const statusMessage =
                 task.options.prePlaybookRunning || task.options.postPlaybookRunning ? (
                   <div>
                     <b>{__('Running playbook service')}: </b>
@@ -561,7 +561,7 @@ class PlanRequestDetailList extends React.Component {
                   </div>
                 ) : (
                   <div>
-                    <b>{__('Description')}: </b>
+                    <b>{__('Status')}: </b>
                     {task.options.progress && V2V_MIGRATION_STATUS_MESSAGES[task.options.progress.current_description]}
                   </div>
                 );
@@ -593,7 +593,7 @@ class PlanRequestDetailList extends React.Component {
                       <div>
                         <div style={{ display: 'inline-block', textAlign: 'left' }}>
                           <span>{taskMessage}</span>
-                          {descriptionMessage}
+                          {statusMessage}
                         </div>
                         &nbsp;
                         {/* Todo: revisit FieldLevelHelp props in patternfly-react to support this */}

--- a/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
+++ b/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
@@ -535,18 +535,6 @@ class PlanRequestDetailList extends React.Component {
                       <b>{__('Start Time')}: </b>
                       {formatDateTime(task.startDateTime)}
                     </div>
-                    {task.options.prePlaybookRunning || task.options.postPlaybookRunning ? (
-                      <div>
-                        <b>{__('Running playbook service')}: </b>
-                        {ansiblePlaybookTemplate.name}
-                      </div>
-                    ) : (
-                      <div>
-                        <b>{__('Description')}: </b>
-                        {task.options.progress &&
-                          V2V_MIGRATION_STATUS_MESSAGES[task.options.progress.current_description]}
-                      </div>
-                    )}
                     <div>
                       <b>{__('Conversion Host')}: </b>
                       {task.transformation_host_name}
@@ -564,6 +552,19 @@ class PlanRequestDetailList extends React.Component {
                   </div>
                 </Popover>
               );
+
+              const descriptionMessage =
+                task.options.prePlaybookRunning || task.options.postPlaybookRunning ? (
+                  <div>
+                    <b>{__('Running playbook service')}: </b>
+                    {ansiblePlaybookTemplate.name}
+                  </div>
+                ) : (
+                  <div>
+                    <b>{__('Description')}: </b>
+                    {task.options.progress && V2V_MIGRATION_STATUS_MESSAGES[task.options.progress.current_description]}
+                  </div>
+                );
               return (
                 <ListView.Item
                   key={task.id}
@@ -590,7 +591,10 @@ class PlanRequestDetailList extends React.Component {
                       }}
                     >
                       <div>
-                        <span>{taskMessage}</span>
+                        <div style={{ display: 'inline-block', textAlign: 'left' }}>
+                          <span>{taskMessage}</span>
+                          {descriptionMessage}
+                        </div>
                         &nbsp;
                         {/* Todo: revisit FieldLevelHelp props in patternfly-react to support this */}
                         <OverlayTrigger


### PR DESCRIPTION
After:
![screenshot 2018-08-30 15 16 53](https://user-images.githubusercontent.com/811963/44874000-c6b28f80-ac67-11e8-8971-d7d12445c247.png)

(moved the After image to the top here so it appears in the project board)

Before:
![screenshot 2018-08-30 15 14 34](https://user-images.githubusercontent.com/811963/44873970-b4385600-ac67-11e8-96f2-a49f81b6bdb6.png)

Closes #610 