### PR TITLE
[633] Fix the button text in the last step in Plan Wizard

### DIFF
--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/PlanWizard.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/PlanWizard.js
@@ -241,7 +241,7 @@ class PlanWizard extends React.Component {
             onClick={onFinalStep ? hidePlanWizardAction : this.nextStep}
             disabled={disableNextStep}
           >
-            {onFinalStep ? __('Close') : activeStep.id === stepIDs.scheduleStep ? __('Create') : __('Next')}
+            {onFinalStep ? __('Close') : currentStepProp === stepIDs.scheduleStep ? __('Create') : __('Next')}
             <Icon type="fa" name="angle-right" />
           </Button>
         </Wizard.Footer>


### PR DESCRIPTION
Fixes #633

Replace `activeStep.id` with `currentStepProp` to fix last step button text.

Related commit that may have introduced the issue https://github.com/ManageIQ/manageiq-v2v/commit/4f69e12f411dccb7917fb0a521a831fa9c682156
