### PR TITLE
Prefill with default security group(from API) and largest disk size flavor for no bestfit flavor cases

### DIFF
--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardInstancePropertiesStep/PlanWizardInstancePropertiesStep.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardInstancePropertiesStep/PlanWizardInstancePropertiesStep.js
@@ -109,7 +109,7 @@ PlanWizardInstancePropertiesStep.propTypes = {
 PlanWizardInstancePropertiesStep.defaultProps = {
   fetchOpenstackTenantUrl: '/api/cloud_tenants',
   bestFitFlavorUrl: 'api/transformation_mappings',
-  queryOpenstackTenantAttributes: ['flavors', 'security_groups']
+  queryOpenstackTenantAttributes: ['flavors', 'security_groups', 'default_security_group']
 };
 
 export default reduxForm({

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardInstancePropertiesStep/PlanWizardInstancePropertiesStepReducer.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardInstancePropertiesStep/PlanWizardInstancePropertiesStepReducer.js
@@ -64,7 +64,18 @@ export default (state = initialState, action) => {
           tenantsWithAttribute => tenantsWithAttribute.id === vmFlavor.tenant_id
         );
         const tenantFlavors = tenant && tenant.flavors;
-        const bestFitFlavor = tenantFlavors && tenantFlavors.find(flavor => flavor.id === vmFlavor.flavor_id);
+
+        let bestFitFlavor;
+        let bestFitFlavorId = vmFlavor.flavor_id;
+        if (bestFitFlavorId) {
+          bestFitFlavor = tenantFlavors && tenantFlavors.find(flavor => flavor.id === bestFitFlavorId);
+        } else {
+          bestFitFlavor =
+            tenantFlavors &&
+            tenantFlavors.reduce((prev, current) => (prev.root_disk_size > current.root_disk_size ? prev : current));
+          bestFitFlavorId = bestFitFlavor && bestFitFlavor.id;
+        }
+
         const bestFitFlavorName = bestFitFlavor && bestFitFlavor.name;
         const defaultSecurityGroup = tenant && tenant.default_security_group;
         const defaultSecurityGroupId = defaultSecurityGroup && defaultSecurityGroup.id;
@@ -72,7 +83,7 @@ export default (state = initialState, action) => {
 
         const rowUpdatedWithBestFlavor = {
           ...existingInstancePropertiesRow,
-          osp_flavor: { name: bestFitFlavorName, id: vmFlavor.flavor_id },
+          osp_flavor: { name: bestFitFlavorName, id: bestFitFlavorId },
           osp_security_group: { name: defaultSecurityGroupName, id: defaultSecurityGroupId },
           target_cluster_name: tenant.name
         };

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardInstancePropertiesStep/PlanWizardInstancePropertiesStepReducer.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardInstancePropertiesStep/PlanWizardInstancePropertiesStepReducer.js
@@ -64,14 +64,12 @@ export default (state = initialState, action) => {
           tenantsWithAttribute => tenantsWithAttribute.id === vmFlavor.tenant_id
         );
         const tenantFlavors = tenant && tenant.flavors;
-        const tenantSecurityGroups = tenant && tenant.security_groups;
         const bestFitFlavor = tenantFlavors && tenantFlavors.find(flavor => flavor.id === vmFlavor.flavor_id);
         const bestFitFlavorName = bestFitFlavor && bestFitFlavor.name;
-        const defaultSecurityGroupName = 'default';
-        const defaultSecurityGroup = tenantSecurityGroups.find(
-          securityGroup => securityGroup.name === defaultSecurityGroupName
-        );
+        const defaultSecurityGroup = tenant && tenant.default_security_group;
         const defaultSecurityGroupId = defaultSecurityGroup && defaultSecurityGroup.id;
+        const defaultSecurityGroupName = defaultSecurityGroup && defaultSecurityGroup.name;
+
         const rowUpdatedWithBestFlavor = {
           ...existingInstancePropertiesRow,
           osp_flavor: { name: bestFitFlavorName, id: vmFlavor.flavor_id },


### PR DESCRIPTION
- Uses API to get `default_security_group` for a Tenant
- Uses largest `root_disk_size` if no best fit flavor found

Fixes https://github.com/ManageIQ/manageiq-v2v/issues/642 and https://github.com/ManageIQ/manageiq-v2v/issues/643