### PR TITLE
Request completion notifications would now be backend-initiated hence remove the frontend request completion notifications

### DIFF
--- a/app/javascript/react/screens/App/Overview/Overview.js
+++ b/app/javascript/react/screens/App/Overview/Overview.js
@@ -7,7 +7,6 @@ import * as AggregateCards from './components/AggregateCards';
 import Migrations from './components/Migrations/Migrations';
 import ShowWizardEmptyState from '../common/ShowWizardEmptyState/ShowWizardEmptyState';
 import componentRegistry from '../../../../components/componentRegistry';
-import getMostRecentRequest from '../common/getMostRecentRequest';
 import ConfirmModal from '../common/ConfirmModal';
 import EditPlanNameModal from './components/EditPlanNameModal';
 import {
@@ -88,39 +87,6 @@ class Overview extends React.Component {
         archived: false
       });
       this.startPolling();
-    }
-  }
-
-  componentDidUpdate(prevProps) {
-    const { finishedTransformationPlans, addNotificationAction } = this.props;
-    const { hasMadeInitialPlansFetch } = this.state;
-
-    if (hasMadeInitialPlansFetch && finishedTransformationPlans.length > prevProps.finishedTransformationPlans.length) {
-      const oldTransformationPlanIds = prevProps.finishedTransformationPlans.map(plan => plan.id);
-      const freshTransformationPlans = finishedTransformationPlans.filter(
-        plan => !oldTransformationPlanIds.includes(plan.id)
-      );
-
-      freshTransformationPlans.forEach(plan => {
-        const mostRecentRequest = getMostRecentRequest(plan.miq_requests);
-
-        let planStatusMessage = sprintf(__('%s completed with errors'), plan.name);
-        let planStatus = false;
-        if (mostRecentRequest.status === 'Ok') {
-          planStatusMessage = sprintf(__('%s completed successfully'), plan.name);
-          planStatus = true;
-        }
-
-        addNotificationAction({
-          message: planStatusMessage,
-          notificationType: planStatus ? 'success' : 'error',
-          data: {
-            id: plan.id
-          },
-          persistent: !planStatus,
-          actionEnabled: true
-        });
-      });
     }
   }
 


### PR DESCRIPTION
Removing frontend Request completion notifications since they would now be emitted by the backend.

The advantage that we now get is that the Migration Plan completion notifications would be visible from any part of the UI.

To be merged after - https://github.com/ManageIQ/manageiq/pull/18012 has been merged.

Fixes #265 
Fixes #578 

<img width="1428" alt="screen shot 2018-09-21 at 12 53 09 pm" src="https://user-images.githubusercontent.com/1538216/45965599-c2b32c80-bfdd-11e8-90bc-20d787b44204.png">

https://bugzilla.redhat.com/show_bug.cgi?id=1642573
