### PR TITLE
[#653] Fixes misalignment issues in the Plan detail list when download log is in progress

### DIFF
--- a/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
+++ b/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
@@ -639,27 +639,41 @@ class PlanRequestDetailList extends React.Component {
                     </ListView.InfoItem>
                   ]}
                   actions={
-                    downloadLogInProgressTaskIds &&
-                    downloadLogInProgressTaskIds.find(element => element === task.id) ? (
-                      <label htmlFor="downloadLog">
-                        <span id="downloadLogInProgress">{__('Download log in progress...')}</span>
-                      </label>
-                    ) : (
-                      <DropdownButton
-                        id={`${task.id}-${task.descriptionPrefix}_download_log_dropdown`}
-                        title={__('Download Log')}
-                        pullRight
-                        onSelect={eventKey => this.onSelect(eventKey, task)}
+                    <DropdownButton
+                      id={`${task.id}-${task.descriptionPrefix}_download_log_dropdown`}
+                      title={__('Download Log')}
+                      pullRight
+                      onSelect={eventKey => this.onSelect(eventKey, task)}
+                      disabled={
+                        downloadLogInProgressTaskIds &&
+                        downloadLogInProgressTaskIds.find(element => element === task.id) &&
+                        !task.options.prePlaybookComplete &&
+                        !task.options.postPlaybookComplete
+                      }
+                    >
+                      {task.options.prePlaybookComplete && (
+                        <MenuItem
+                          eventKey="preMigration"
+                          disabled={downloadLogInProgressTaskIds && downloadLogInProgressTaskIds.indexOf(task.id) > -1}
+                        >
+                          {__('Pre-migration log')}
+                        </MenuItem>
+                      )}
+                      <MenuItem
+                        eventKey="migration"
+                        disabled={downloadLogInProgressTaskIds && downloadLogInProgressTaskIds.indexOf(task.id) > -1}
                       >
-                        {task.options.prePlaybookComplete && (
-                          <MenuItem eventKey="preMigration">{__('Pre-migration log')}</MenuItem>
-                        )}
-                        <MenuItem eventKey="migration">{__('Migration log')}</MenuItem>
-                        {task.options.postPlaybookComplete && (
-                          <MenuItem eventKey="postMigration">{__('Post-migration log')}</MenuItem>
-                        )}
-                      </DropdownButton>
-                    )
+                        {__('Migration log')}
+                      </MenuItem>
+                      {task.options.postPlaybookComplete && (
+                        <MenuItem
+                          eventKey="postMigration"
+                          disabled={downloadLogInProgressTaskIds && downloadLogInProgressTaskIds.indexOf(task.id) > -1}
+                        >
+                          {__('Post-migration log')}
+                        </MenuItem>
+                      )}
+                    </DropdownButton>
                   }
                   stacked
                 />


### PR DESCRIPTION
Fixes #653

The Download log button or the Migration log/Pre-migration log/Post-migration log menu items would be disabled when the download log is in progress, as shown below -

<img width="1213" alt="screen shot 2018-09-26 at 12 24 36 pm" src="https://user-images.githubusercontent.com/1538216/46104041-2fb5f600-c187-11e8-8f44-c91ebd8c191d.png">

@michaelkro @mturley ~The second commit is for a bug that I came across while working on this issue.
I noticed that for every little component update in the Plan Detail page, the notification toasts for the tasks were being emitted. 
With the fix made in d1e6fbf, the notification toasts would be emitted only when there are `planRequestTasks` changes -- something that you would see when a migration is in progress and there are Task status updates as a result of polling.~ ---> I will be taking a look at this issue in a separate PR





