### PR TITLE
[#564] Map VMWare Storages to OSP CloudVolumeTypes

### DIFF
--- a/app/javascript/react/screens/App/Overview/OverviewConstants.js
+++ b/app/javascript/react/screens/App/Overview/OverviewConstants.js
@@ -51,6 +51,6 @@ export const MIGRATIONS_FILTERS = {
 };
 
 export const OSP_TENANT = 'CloudTenant';
-export const OSP_VOLUME = 'CloudVolume';
+export const OSP_VOLUME = 'CloudVolumeType';
 export const OSP_NETWORK = 'CloudNetwork';
 export const EMS_CLUSTER = 'EmsCluster';

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/MappingWizardConstants.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/MappingWizardConstants.js
@@ -25,7 +25,7 @@ export const TRANSFORMATION_MAPPING_ITEM_SOURCE_TYPES = {
 export const TRANSFORMATION_MAPPING_ITEM_DESTINATION_TYPES = {
   openstack: {
     cluster: 'CloudTenant',
-    datastore: 'CloudVolume',
+    datastore: 'CloudVolumeType',
     network: 'CloudNetwork'
   },
   rhevm: {

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/MappingWizardConstants.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/MappingWizardConstants.js
@@ -9,7 +9,10 @@ export const V2V_TARGET_PROVIDERS = [
   { name: __('Red Hat OpenStack Platform'), id: 'openstack' }
 ];
 
-export const V2V_TARGET_PROVIDER_STORAGE_KEYS = { rhevm: 'storages', openstack: 'cloud_volumes' };
+export const V2V_TARGET_PROVIDER_STORAGE_KEYS = {
+  rhevm: 'storages',
+  openstack: 'cloud_volume_types'
+};
 
 export const V2V_TARGET_PROVIDER_NETWORK_KEYS = { rhevm: 'lans', openstack: 'cloud_networks' };
 

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStepActions.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStepActions.js
@@ -1,5 +1,6 @@
 import URI from 'urijs';
 import API from '../../../../../../../../common/API';
+import objectNavigator from '../../../../../common/objectNavigator';
 import {
   FETCH_V2V_SOURCE_DATASTORES,
   FETCH_V2V_TARGET_DATASTORES,
@@ -49,8 +50,8 @@ export const fetchSourceDatastoresAction = (url, id) => {
 const _filterTargetDatastores = (response, targetProvider) => {
   const { data } = response;
 
-  if (data[V2V_TARGET_PROVIDER_STORAGE_KEYS[targetProvider]]) {
-    const targetDatastores = data[V2V_TARGET_PROVIDER_STORAGE_KEYS[targetProvider]].map(storage => ({
+  if (objectNavigator(V2V_TARGET_PROVIDER_STORAGE_KEYS[targetProvider], data)) {
+    const targetDatastores = objectNavigator(V2V_TARGET_PROVIDER_STORAGE_KEYS[targetProvider], data).map(storage => ({
       ...storage,
       providerName: data.ext_management_system.name
     }));

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStepActions.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStepActions.js
@@ -1,6 +1,6 @@
 import URI from 'urijs';
+
 import API from '../../../../../../../../common/API';
-import objectNavigator from '../../../../../common/objectNavigator';
 import {
   FETCH_V2V_SOURCE_DATASTORES,
   FETCH_V2V_TARGET_DATASTORES,
@@ -50,8 +50,8 @@ export const fetchSourceDatastoresAction = (url, id) => {
 const _filterTargetDatastores = (response, targetProvider) => {
   const { data } = response;
 
-  if (objectNavigator(V2V_TARGET_PROVIDER_STORAGE_KEYS[targetProvider], data)) {
-    const targetDatastores = objectNavigator(V2V_TARGET_PROVIDER_STORAGE_KEYS[targetProvider], data).map(storage => ({
+  if (data[V2V_TARGET_PROVIDER_STORAGE_KEYS[targetProvider]]) {
+    const targetDatastores = data[V2V_TARGET_PROVIDER_STORAGE_KEYS[targetProvider]].map(storage => ({
       ...storage,
       providerName: data.ext_management_system.name
     }));

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStepConstants.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStepConstants.js
@@ -14,6 +14,6 @@ export const FETCH_STORAGE_URLS = {
 };
 
 export const STORAGE_ATTRIBUTES = {
-  openstack: 'cloud_volumes',
+  openstack: 'cloud_volume_types',
   rhevm: 'storages'
 };

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStepConstants.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStepConstants.js
@@ -4,7 +4,7 @@ export const FETCH_V2V_TARGET_DATASTORES = 'FETCH_V2V_TARGET_DATASTORES';
 export const QUERY_ATTRIBUTES = {
   source: 'storages,ext_management_system.name,v_parent_datacenter',
   rhevm: 'storages,ext_management_system.name',
-  openstack: 'cloud_volumes,ext_management_system.name'
+  openstack: 'cloud_volume_types,ext_management_system.name'
 };
 
 export const FETCH_STORAGE_URLS = {

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/components/DatastoresStepForm/DatastoresStepForm.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/components/DatastoresStepForm/DatastoresStepForm.js
@@ -310,7 +310,7 @@ class DatastoresStepForm extends React.Component {
               targetDatastores.map(item => (
                 <DualPaneMapperListItem
                   item={item}
-                  text={targetDatastoreInfo(item, input.value)}
+                  text={targetDatastoreInfo(item)}
                   key={item.id}
                   selected={selectedTargetDatastore && selectedTargetDatastore.id === item.id}
                   handleClick={this.selectTargetDatastore}

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/components/DatastoresStepForm/helpers.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/components/DatastoresStepForm/helpers.js
@@ -35,7 +35,7 @@ export const targetDatastoreAvailableSpace = (targetDatastore, datastoresStepMap
 export const sourceDatastoreInfo = sourceDatastore =>
   sprintf(__('%s \\ %s \\ %s'), sourceDatastore.providerName, sourceDatastore.datacenterName, sourceDatastore.name);
 
-export const targetDatastoreInfo = (targetDatastore, datastoresStepMappings) =>
+export const targetDatastoreInfo = targetDatastore =>
   sprintf(__('%s \\ %s'), targetDatastore.providerName, targetDatastore.name);
 
 export const targetDatastoreTreeViewInfo = targetDatastore => targetDatastore.name;

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardGeneralStep/MappingWizardGeneralStep.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardGeneralStep/MappingWizardGeneralStep.js
@@ -76,7 +76,6 @@ class MappingWizardGeneralStep extends React.Component {
           inline_label
           onSelect={this.onSelect}
           disabled={!!editingMapping}
-          style={{ visibility: 'hidden' }}
         />
       </Form>
     );

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardResultsStep/MappingWizardResultsStepConstants.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardResultsStep/MappingWizardResultsStepConstants.js
@@ -10,7 +10,7 @@ export const SOURCE_HREF_SLUGS = {
 export const DESTINATION_HREF_SLUGS = {
   openstack: {
     CloudTenant: '/api/cloud_tenants/',
-    CloudVolume: '/api/cloud_volumes/',
+    CloudVolumeType: '/api/cloud_volume_types/',
     CloudNetwork: '/api/cloud_networks/'
   },
   rhevm: {

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/helpers.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/helpers.js
@@ -29,7 +29,7 @@ export const multiProviderTargetLabel = (providerType, wizardStep) => {
         case 'cluster':
           return __('Target Provider \\ Project');
         case 'storage':
-          return __('Target Provider \\ Cloud Volume');
+          return __('Target Provider \\ Volume Type');
         case 'network':
           return __('Target Project \\ Network');
         default:

--- a/app/javascript/react/screens/App/common/forms/BootstrapSelect.js
+++ b/app/javascript/react/screens/App/common/forms/BootstrapSelect.js
@@ -4,6 +4,14 @@ import { Form, FormGroup, Grid, ControlLabel } from 'patternfly-react';
 import { focus } from 'redux-form';
 
 export class BootstrapSelect extends React.Component {
+  componentDidUpdate(prevProps) {
+    const { input } = this.props;
+
+    if (prevProps.pre_selected_value !== this.props.pre_selected_value) {
+      $(`#${input.name}`).selectpicker('val', this.props.pre_selected_value);
+    }
+  }
+
   componentDidMount() {
     const {
       input,

--- a/app/javascript/react/screens/App/common/objectNavigator.js
+++ b/app/javascript/react/screens/App/common/objectNavigator.js
@@ -1,0 +1,2 @@
+export default (path, object) =>
+  path.split('.').reduce((previous, current) => (previous ? previous[current] : null), object);

--- a/app/javascript/react/screens/App/common/objectNavigator.js
+++ b/app/javascript/react/screens/App/common/objectNavigator.js
@@ -1,2 +1,0 @@
-export default (path, object) =>
-  path.split('.').reduce((previous, current) => (previous ? previous[current] : null), object);


### PR DESCRIPTION
# Notes
- We had been using `cloud_volume` as a placeholder while waiting for `cloud_volume_type` to be exposed via API.
- ~Depends on https://github.com/ManageIQ/manageiq-providers-openstack/pull/366~
    ***EDIT:*** Has been merged