### PR TITLE
Rename the `osp_` attributes to reflect that they are id's

### DIFF
--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/helpers.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/helpers.js
@@ -22,8 +22,8 @@ export const createMigrationPlans = (
     vm_id: vmId,
     pre_service: preMigration.includes(vmId),
     post_service: postMigration.includes(vmId),
-    osp_security_group: ospInstanceProperties && ospInstanceProperties[vmId].osp_security_group_id,
-    osp_flavor: ospInstanceProperties && ospInstanceProperties[vmId].osp_flavor_id
+    osp_security_group_id: ospInstanceProperties && ospInstanceProperties[vmId].osp_security_group_id,
+    osp_flavor_id: ospInstanceProperties && ospInstanceProperties[vmId].osp_flavor_id
   }));
 
   return {


### PR DESCRIPTION
Rename the `osp_` attributes to reflect that they are id's, in order to stay consistent with the backend naming convention

Related PR - https://github.com/ManageIQ/manageiq/pull/18045