### PR TITLE
Display Toast notifications in Plan detail page only on task changes

### DIFF
--- a/app/javascript/react/screens/App/Plan/PlanReducer.js
+++ b/app/javascript/react/screens/App/Plan/PlanReducer.js
@@ -84,7 +84,24 @@ export default (state = initialState, action) => {
           action.payload.data.results,
           state.plan.options.config_info.actions
         );
+
+        const tasksOfMostRecentRequest = commonUtilitiesHelper.getMostRecentEntityByCreationDate(
+          action.payload.data.results
+        ).miq_request_tasks;
+        const vmsBeingProcessedInCurrentRun = tasksOfMostRecentRequest.map(task => task.source_id);
+        const tasksCompletedSuccessfullyInPriorRuns = vmTasksForRequestOfPlan.filter(
+          task => vmsBeingProcessedInCurrentRun.indexOf(task.source_id) === -1
+        );
+
+        const addTaskToNotificationAlreadySentList = [];
+        tasksCompletedSuccessfullyInPriorRuns.forEach(task => {
+          if (state.notificationsSentList.indexOf(task.id) === -1) {
+            addTaskToNotificationAlreadySentList.push(task.id);
+          }
+        });
+
         return state
+          .set('notificationsSentList', state.notificationsSentList.concat(addTaskToNotificationAlreadySentList))
           .set('planRequestTasks', vmTasksForRequestOfPlan)
           .set(
             'selectedTasksForCancel',

--- a/app/javascript/react/screens/App/Plan/PlanReducer.js
+++ b/app/javascript/react/screens/App/Plan/PlanReducer.js
@@ -85,10 +85,7 @@ export default (state = initialState, action) => {
           state.plan.options.config_info.actions
         );
         return state
-          .set(
-            'planRequestTasks',
-            allVMTasksForRequestOfPlan(action.payload.data.results, state.plan.options.config_info.actions)
-          )
+          .set('planRequestTasks', vmTasksForRequestOfPlan)
           .set(
             'selectedTasksForCancel',
             incompleteCancellationTasks(

--- a/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
+++ b/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
@@ -68,14 +68,16 @@ class PlanRequestDetailList extends React.Component {
     pageChangeValue: 1
   };
 
-  componentDidUpdate() {
-    const {
-      failedMigrations,
-      successfulMigrations,
-      notificationsSentList,
-      dispatchVMTasksCompletionNotificationAction
-    } = this.props;
-    dispatchVMTasksCompletionNotificationAction(failedMigrations, successfulMigrations, notificationsSentList);
+  componentDidUpdate(prevProps, prevState) {
+    if (prevProps.planRequestTasks !== this.props.planRequestTasks) {
+      const {
+        failedMigrations,
+        successfulMigrations,
+        notificationsSentList,
+        dispatchVMTasksCompletionNotificationAction
+      } = this.props;
+      dispatchVMTasksCompletionNotificationAction(failedMigrations, successfulMigrations, notificationsSentList);
+    }
   }
 
   onValueKeyPress = keyEvent => {

--- a/app/javascript/react/screens/App/Plan/helpers.js
+++ b/app/javascript/react/screens/App/Plan/helpers.js
@@ -25,7 +25,8 @@ const processVMTasks = vmTasks => {
       state: task.state,
       status: task.status,
       options: {},
-      cancel_requested: task.options.cancel_requested
+      cancel_requested: task.options.cancel_requested,
+      source_id: task.source_id
     };
 
     if (task.options.playbooks) {


### PR DESCRIPTION
- Currently the toast notifications in Plan detail page of a completed Plan are being triggered by any component update such as clicking on Download Log or clicking on the checkbox for canceling a migration -- this is undesired, since the toasts are supposed to trigger only during migration. 

- The other issue with the toast notifications is visible during a Retry operation.
During Retry only the failed tasks from a plan are processed by the backend. So if a plan has 2 tasks - one successful (from a prior run) and one failed -- then only the failed task would be picked up by the backend.In this scenario, we need to display toasts for only those tasks that are currently being processed by the backend. Successful task completion toasts from prior runs should not be displayed.

Above issues were fixed here.