### PR TITLE
[#689] Preserve playbook selections

### DIFF
--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/PlanWizard.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/PlanWizard.js
@@ -81,7 +81,7 @@ class PlanWizard extends React.Component {
   };
 
   prevStep = () => {
-    const { resetVmStepAction, resetAdvancedOptionsStepAction, setMetadataWithBackButtonClickedAction } = this.props;
+    const { resetVmStepAction, setMetadataWithBackButtonClickedAction } = this.props;
     const { activeStepIndex } = this.state;
 
     const activeStep = this.getActiveWizardStep();
@@ -91,8 +91,6 @@ class PlanWizard extends React.Component {
     if (activeStep.id === stepIDs.vmStep) {
       // reset all vm step values if going back from that step
       resetVmStepAction();
-    } else if (activeStep.id === stepIDs.advancedOptionsStep) {
-      resetAdvancedOptionsStepAction();
     }
     this.setState({ activeStepIndex: Math.max(activeStepIndex - 1, 0) });
   };
@@ -292,7 +290,6 @@ PlanWizard.propTypes = {
   setMigrationsFilterAction: PropTypes.func,
   showConfirmModalAction: PropTypes.func,
   hideConfirmModalAction: PropTypes.func,
-  resetAdvancedOptionsStepAction: PropTypes.func,
   showAlertAction: PropTypes.func,
   hideAlertAction: PropTypes.func,
   alertText: PropTypes.string,

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardAdvancedOptionsStep/PlanWizardAdvancedOptionsStep.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardAdvancedOptionsStep/PlanWizardAdvancedOptionsStep.js
@@ -5,18 +5,27 @@ import { Form, Spinner } from 'patternfly-react';
 
 import PlanWizardAdvancedOptionsStepTable from './components/PlanWizardAdvancedOptionsStepTable/PlanWizardAdvancedOptionsStepTable';
 import { BootstrapSelect } from '../../../../../common/forms/BootstrapSelect';
-import { preselectPlaybooksForVms } from './helpers';
+import { preselectPlaybooksForVms, applyPlaybookSelections, updatePlaybookSelections } from './helpers';
 
 class PlanWizardAdvancedOptionsStep extends Component {
   constructor(props) {
     super(props);
 
-    if (props.vms.length === 0) {
+    if (props.pristine) {
       if (!props.editingPlan) {
         props.setVmsAction(props.vmStepSelectedVms);
       } else {
         props.setVmsAction(preselectPlaybooksForVms(props.editingPlan, props.vmStepSelectedVms));
       }
+    } else {
+      const {
+        vmStepSelectedVms,
+        advancedOptionsStepForm: {
+          values: { playbookVms }
+        }
+      } = props;
+      props.change('playbookVms', updatePlaybookSelections(vmStepSelectedVms, playbookVms));
+      props.setVmsAction(applyPlaybookSelections(vmStepSelectedVms, playbookVms));
     }
   }
 
@@ -96,7 +105,8 @@ PlanWizardAdvancedOptionsStep.propTypes = {
   setVmsAction: PropTypes.func,
   vmStepSelectedVms: PropTypes.array,
   change: PropTypes.func,
-  editingPlan: PropTypes.object
+  editingPlan: PropTypes.object,
+  pristine: PropTypes.bool
 };
 
 PlanWizardAdvancedOptionsStep.defaultProps = {

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardAdvancedOptionsStep/helpers.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardAdvancedOptionsStep/helpers.js
@@ -20,3 +20,18 @@ export const preselectPlaybooksForVms = (editingPlan, vms) => {
     postMigration: vmIdsWithPostService.some(id => id === vm.id)
   }));
 };
+
+export const applyPlaybookSelections = (vms, playbookVms) =>
+  vms.map(vm => ({
+    ...vm,
+    preMigration: playbookVms.preMigration.includes(vm.id),
+    postMigration: playbookVms.postMigration.includes(vm.id)
+  }));
+
+export const updatePlaybookSelections = (vms, playbookVms) => {
+  const vmIds = vms.map(vm => vm.id);
+  return {
+    preMigration: playbookVms.preMigration.filter(id => vmIds.includes(id)),
+    postMigration: playbookVms.postMigration.filter(id => vmIds.includes(id))
+  };
+};


### PR DESCRIPTION
Fixes #689 

If the Advanced Options Step VMs table has been modified and the user
has navigated away and is returning
  * If VMs have been removed, also remove them from playbook selections
  * Reapply the playbook selections that were made before leaving the
    step 