### PR TITLE
[WIP][#690] Add warning to admin tenant when it has no conversion host

### DIFF
--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardClustersStep/MappingWizardClustersStep.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardClustersStep/MappingWizardClustersStep.js
@@ -130,7 +130,7 @@ MappingWizardClustersStep.defaultProps = {
       '/api/clusters?expand=resources' +
       '&attributes=ext_management_system.emstype,v_parent_datacenter,ext_management_system.name,hosts' +
       '&filter[]=ext_management_system.emstype=rhevm',
-    openstack: '/api/cloud_tenants?expand=resources&attributes=ext_management_system.name'
+    openstack: '/api/cloud_tenants?expand=resources&attributes=ext_management_system.name,tags'
   }
 };
 

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardClustersStep/components/ClustersStepForm/ClustersStepForm.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardClustersStep/components/ClustersStepForm/ClustersStepForm.js
@@ -136,6 +136,7 @@ class ClustersStepForm extends React.Component {
     const adminTenant = targetProvider === 'openstack' && targetClusters.find(cluster => cluster.name === 'admin');
     const adminTenantConversionHostEnabled =
       adminTenant && adminTenant.tags.some(tag => tag.name === '/managed/v2v_transformation_host/true');
+      // TODO this is probably not the tag we are looking for, we need to look at tags on the VMs of the admin tenant
 
     return (
       <div className="dual-pane-mapper-form">


### PR DESCRIPTION
Closes #690.

![screenshot 2018-10-08 15 10 43](https://user-images.githubusercontent.com/811963/46629176-ee6e0080-cb0d-11e8-8f83-0874bc60f0f2.png)


Currently, this PR identifies the admin tenant by `tenant.name === 'admin'`, and looks for a tag with `tag.name === '/managed/v2v_transformation_host/true'`. I'm not sure if that is the actual tag we are looking for, I'm waiting to hear back from Brett + Marek about that.

In my database, my admin tenant doesn't have any tags. We'll need a new database to test this. @michaelkro do you know where I can find a database with an OSP admin tenant that has a configured conversion host? Should I ask Brett for that too?