### PR TITLE
Use new ManageIQ.redux.addReducer.

### DIFF
--- a/app/javascript/react/index.js
+++ b/app/javascript/react/index.js
@@ -7,13 +7,10 @@ import Routes from './config/Routes';
 import NotificationList from './screens/App/common/NotificationList';
 import createReducers from '../redux/reducers';
 
-// todo: convert this to use ManageIQ.redux.addReducer, ManageIQ.redux.store
-// <Provider store={store}>{componentRegistry.markup(component, data, store)}</Provider>,
 class App extends React.Component {
   constructor(props) {
     super(props);
     ManageIQ.redux.addReducer(createReducers());
-    ManageIQ.redux.store.dispatch({ type: 'init' });
   }
 
   render() {

--- a/app/javascript/redux/reducers/index.js
+++ b/app/javascript/redux/reducers/index.js
@@ -1,4 +1,3 @@
-import { combineReducers } from 'redux';
 import { reducer as formReducer } from 'redux-form';
 import { reducers as notificationListReducers } from '../../react/screens/App/common/NotificationList';
 import { reducers as planReducers } from '../../react/screens/App/Plan';
@@ -16,22 +15,21 @@ import { reducers as planWizardAdvancedOptionsStepReducers } from '../../react/s
 import { reducers as planWizardInstancePropertiesStepReducers } from '../../react/screens/App/Overview/screens/PlanWizard/components/PlanWizardInstancePropertiesStep';
 import { reducers as editPlanNameReducers } from '../../react/screens/App/Overview/components/EditPlanNameModal';
 
-export default () =>
-  combineReducers({
-    ...notificationListReducers,
-    ...planReducers,
-    ...overviewReducers,
-    ...mappingWizardReducers,
-    ...mappingWizardGeneralStepReducers,
-    ...mappingWizardClustersStepReducers,
-    ...mappingWizardDatastoresStepReducers,
-    ...mappingWizardNetworksStepReducers,
-    ...mappingWizardResultsStepReducers,
-    ...planWizardReducers,
-    ...planWizardVMStepReducers,
-    ...planWizardResultsStepReducers,
-    ...planWizardAdvancedOptionsStepReducers,
-    ...planWizardInstancePropertiesStepReducers,
-    ...editPlanNameReducers,
-    form: formReducer
-  });
+export default () => ({
+  ...notificationListReducers,
+  ...planReducers,
+  ...overviewReducers,
+  ...mappingWizardReducers,
+  ...mappingWizardGeneralStepReducers,
+  ...mappingWizardClustersStepReducers,
+  ...mappingWizardDatastoresStepReducers,
+  ...mappingWizardNetworksStepReducers,
+  ...mappingWizardResultsStepReducers,
+  ...planWizardReducers,
+  ...planWizardVMStepReducers,
+  ...planWizardResultsStepReducers,
+  ...planWizardAdvancedOptionsStepReducers,
+  ...planWizardInstancePropertiesStepReducers,
+  ...editPlanNameReducers,
+  form: formReducer
+});


### PR DESCRIPTION
Update addReducer call to match the new interface. Details are described here https://github.com/ManageIQ/manageiq-ui-classic/pull/4744

This should be merged as soon as possible, after the https://github.com/ManageIQ/manageiq-ui-classic/pull/4744 gets merged, otherwise adding reducers will fail. 
