### PR TITLE
[#687][#688] Add VM power warnings for OpenStack to Plan wizard

### DIFF
--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/PlanWizard.scss
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/PlanWizard.scss
@@ -9,3 +9,27 @@
 .plan-wizard-confirm-modal {
   margin-top: 140px;
 }
+
+.plan-wizard-vm-power-warning {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  text-align: left;
+}
+
+.wizard-pf-complete .plan-wizard-vm-power-warning {
+  margin-top: 20px;
+  justify-content: center;
+}
+
+.plan-wizard-vm-power-warning .pficon {
+  font-size: 24px;
+}
+
+.wizard-pf-complete .plan-wizard-vm-power-warning .pficon::before {
+  color: #ec7a08; /* overrides grey color from .blank-slate-pf */
+}
+
+.plan-wizard-vm-power-warning p {
+  margin: 0 10px;
+}

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/PlanWizard.scss
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/PlanWizard.scss
@@ -27,7 +27,7 @@
 }
 
 .wizard-pf-complete .plan-wizard-vm-power-warning .pficon::before {
-  color: #ec7a08; /* overrides grey color from .blank-slate-pf */
+  color: $color-pf-orange-400; /* overrides grey color from .blank-slate-pf */
 }
 
 .plan-wizard-vm-power-warning p {

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/PlanWizardSelectors.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/PlanWizardSelectors.js
@@ -1,3 +1,5 @@
+import { getMappingType } from '../../components/InfrastructureMappingsList/helpers';
+
 export const findEditingPlan = (transformationPlans, editingPlanId) =>
   editingPlanId && transformationPlans.find(plan => plan.id === editingPlanId);
 
@@ -14,3 +16,9 @@ export const planWizardFormFilter = form => ({
   planWizardAdvancedOptionsStep: form.planWizardAdvancedOptionsStep,
   planWizardScheduleStep: form.planWizardScheduleStep
 });
+
+export const getCurrentTargetProvider = (form, transformationMappings) => {
+  const mappingId = form.planWizardGeneralStep.values.infrastructure_mapping;
+  const selectedMapping = transformationMappings.find(mapping => mapping.id === mappingId);
+  return getMappingType(selectedMapping.transformation_mapping_items);
+};

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardResultsStep/PlanWizardResultsStep.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardResultsStep/PlanWizardResultsStep.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { noop, Spinner } from 'patternfly-react';
+import { noop, Spinner, Icon } from 'patternfly-react';
 import { planHasBeenEdited } from './helpers';
 
 class PlanWizardResultsStep extends React.Component {
@@ -39,7 +39,7 @@ class PlanWizardResultsStep extends React.Component {
       </button>
     </div>
   );
-  renderResult = (migrationPlanMessage, migrationPlanFollowupMessage, migrationPlanIcon) => (
+  renderResult = (migrationPlanMessage, migrationPlanFollowupMessage, migrationPlanIcon, showVmPowerWarning) => (
     <div className="wizard-pf-complete blank-slate-pf">
       <div className="plan-wizard-results-step-icon">
         <span className={migrationPlanIcon} />
@@ -48,6 +48,16 @@ class PlanWizardResultsStep extends React.Component {
         {migrationPlanMessage}
       </h3>
       <p className="blank-slate-pf-secondary-action">{migrationPlanFollowupMessage}</p>
+      {showVmPowerWarning && (
+        <div className="plan-wizard-vm-power-warning">
+          <Icon type="pf" name="warning-triangle-o" />
+          <p>
+            {__('VMs must be powered on in order to migrate.')}
+            <br />
+            {__('Ensure that all VMs in the Migration Plan are powered on before starting migration.')}
+          </p>
+        </div>
+      )}
     </div>
   );
 
@@ -63,7 +73,8 @@ class PlanWizardResultsStep extends React.Component {
       errorPuttingPlans,
       plansBody,
       planSchedule,
-      hidePlanWizardAction
+      hidePlanWizardAction,
+      targetProvider
     } = this.props;
 
     if (isPostingPlans) {
@@ -84,7 +95,13 @@ class PlanWizardResultsStep extends React.Component {
     } else if (planSchedule === 'migration_plan_later' && migrationPlansResult) {
       const migrationPlanSaved = sprintf(__(" Migration Plan: '%s' has been saved"), plansBody.name);
       const migrationPlanFollowupMessage = __('Select Migrate on the Overview page to begin migration');
-      return this.renderResult(migrationPlanSaved, migrationPlanFollowupMessage, 'pficon pficon-ok');
+      const showVmPowerWarning = targetProvider === 'openstack';
+      return this.renderResult(
+        migrationPlanSaved,
+        migrationPlanFollowupMessage,
+        'pficon pficon-ok',
+        showVmPowerWarning
+      );
     } else if (planSchedule === 'migration_plan_now' && migrationPlansResult && migrationRequestsResult) {
       const migrationPlanProgress = sprintf(__(" Migration Plan: '%s' is in progress"), plansBody.name);
       const migrationPlanFollowupMessage = __('This may take a long time. Progress of the plan will be shown in the Migration area'); // prettier-ignore
@@ -109,7 +126,8 @@ PlanWizardResultsStep.propTypes = {
   migrationPlansResult: PropTypes.object,
   migrationRequestsResult: PropTypes.object,
   hidePlanWizardAction: PropTypes.func,
-  editingPlan: PropTypes.object
+  editingPlan: PropTypes.object,
+  targetProvider: PropTypes.string
 };
 PlanWizardResultsStep.defaultProps = {
   postPlansUrl: '/api/service_templates',

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardResultsStep/index.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardResultsStep/index.js
@@ -1,28 +1,22 @@
 import { connect } from 'react-redux';
 import PlanWizardResultsStep from './PlanWizardResultsStep';
 import * as PlanWizardResultsStepActions from './PlanWizardResultsStepActions';
-import { getMappingType } from '../../../../components/InfrastructureMappingsList/helpers';
 
 import reducer from './PlanWizardResultsStepReducer';
-import { findEditingPlan } from '../../PlanWizardSelectors';
+import { findEditingPlan, getCurrentTargetProvider } from '../../PlanWizardSelectors';
 
 export const reducers = { planWizardResultsStep: reducer };
 
 const mapStateToProps = (
   { planWizardResultsStep, planWizard, overview: { transformationPlans, transformationMappings, editingPlanId }, form },
   ownProps
-) => {
-  const mappingId = form.planWizardGeneralStep.values.infrastructure_mapping;
-  const selectedMapping = transformationMappings.find(mapping => mapping.id === mappingId);
-  const targetProvider = getMappingType(selectedMapping.transformation_mapping_items);
-  return {
-    ...planWizardResultsStep,
-    ...planWizard,
-    ...ownProps.data,
-    targetProvider,
-    editingPlan: findEditingPlan(transformationPlans, editingPlanId)
-  };
-};
+) => ({
+  ...planWizardResultsStep,
+  ...planWizard,
+  ...ownProps.data,
+  targetProvider: getCurrentTargetProvider(form, transformationMappings),
+  editingPlan: findEditingPlan(transformationPlans, editingPlanId)
+});
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => Object.assign(stateProps, ownProps.data, dispatchProps);
 

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardResultsStep/index.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardResultsStep/index.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux';
 import PlanWizardResultsStep from './PlanWizardResultsStep';
 import * as PlanWizardResultsStepActions from './PlanWizardResultsStepActions';
+import { getMappingType } from '../../../../components/InfrastructureMappingsList/helpers';
 
 import reducer from './PlanWizardResultsStepReducer';
 import { findEditingPlan } from '../../PlanWizardSelectors';
@@ -8,14 +9,20 @@ import { findEditingPlan } from '../../PlanWizardSelectors';
 export const reducers = { planWizardResultsStep: reducer };
 
 const mapStateToProps = (
-  { planWizardResultsStep, planWizard, overview: { transformationPlans, editingPlanId } },
+  { planWizardResultsStep, planWizard, overview: { transformationPlans, transformationMappings, editingPlanId }, form },
   ownProps
-) => ({
-  ...planWizardResultsStep,
-  ...planWizard,
-  ...ownProps.data,
-  editingPlan: findEditingPlan(transformationPlans, editingPlanId)
-});
+) => {
+  const mappingId = form.planWizardGeneralStep.values.infrastructure_mapping;
+  const selectedMapping = transformationMappings.find(mapping => mapping.id === mappingId);
+  const targetProvider = getMappingType(selectedMapping.transformation_mapping_items);
+  return {
+    ...planWizardResultsStep,
+    ...planWizard,
+    ...ownProps.data,
+    targetProvider,
+    editingPlan: findEditingPlan(transformationPlans, editingPlanId)
+  };
+};
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => Object.assign(stateProps, ownProps.data, dispatchProps);
 

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardScheduleStep/PlanWizardScheduleStep.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardScheduleStep/PlanWizardScheduleStep.js
@@ -1,9 +1,10 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Field, reduxForm } from 'redux-form';
-import { Form } from 'patternfly-react';
+import { Form, Icon } from 'patternfly-react';
 import { FormField } from '../../../../../common/forms/FormField';
 
-const PlanWizardScheduleStep = () => (
+const PlanWizardScheduleStep = ({ targetProvider, migration_plan_choice_radio }) => (
   <Form className="form-horizontal">
     <Field
       name="migration_plan_choice_radio"
@@ -21,9 +22,26 @@ const PlanWizardScheduleStep = () => (
           id: 'migration_plan_now'
         }
       ]}
+      help={
+        targetProvider === 'openstack' && migration_plan_choice_radio === 'migration_plan_now' ? (
+          <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center' }}>
+            <span style={{ fontSize: '24px' }}><Icon type="pf" name="warning-triangle-o" /></span>
+            <span style={{ paddingLeft: 10 }}>
+              {__('VMs must be powered on in order to migrate.')}
+              <br />
+              {__('Ensure that all VMs in the Migration Plan are powered on before selecting Create.')}
+            </span>
+          </div>
+        ) : null
+      }
     />
   </Form>
 );
+
+PlanWizardScheduleStep.propTypes = {
+  targetProvider: PropTypes.string,
+  migration_plan_choice_radio: PropTypes.string
+};
 
 export default reduxForm({
   form: 'planWizardScheduleStep',

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardScheduleStep/PlanWizardScheduleStep.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardScheduleStep/PlanWizardScheduleStep.js
@@ -24,13 +24,13 @@ const PlanWizardScheduleStep = ({ targetProvider, migration_plan_choice_radio })
       ]}
       help={
         targetProvider === 'openstack' && migration_plan_choice_radio === 'migration_plan_now' ? (
-          <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center' }}>
-            <span style={{ fontSize: '24px' }}><Icon type="pf" name="warning-triangle-o" /></span>
-            <span style={{ paddingLeft: 10 }}>
+          <div className="plan-wizard-vm-power-warning">
+            <Icon type="pf" name="warning-triangle-o" />
+            <p>
               {__('VMs must be powered on in order to migrate.')}
               <br />
               {__('Ensure that all VMs in the Migration Plan are powered on before selecting Create.')}
-            </span>
+            </p>
           </div>
         ) : null
       }

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardScheduleStep/index.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardScheduleStep/index.js
@@ -1,19 +1,14 @@
 import { connect } from 'react-redux';
 import PlanWizardScheduleStep from './PlanWizardScheduleStep';
-import { getMappingType } from '../../../../components/InfrastructureMappingsList/helpers';
+import { getCurrentTargetProvider } from '../../PlanWizardSelectors';
 
-const mapStateToProps = ({ overview, form }) => {
-  const mappingId = form.planWizardGeneralStep.values.infrastructure_mapping;
-  const selectedMapping = overview.transformationMappings.find(mapping => mapping.id === mappingId);
-  const targetProvider = getMappingType(selectedMapping.transformation_mapping_items);
-  return {
-    targetProvider,
-    migration_plan_choice_radio:
-      form.planWizardScheduleStep && form.planWizardScheduleStep.values.migration_plan_choice_radio,
-    initialValues: {
-      migration_plan_choice_radio: 'migration_plan_later'
-    }
-  };
-};
+const mapStateToProps = ({ overview: { transformationMappings }, form }) => ({
+  targetProvider: getCurrentTargetProvider(form, transformationMappings),
+  migration_plan_choice_radio:
+    form.planWizardScheduleStep && form.planWizardScheduleStep.values.migration_plan_choice_radio,
+  initialValues: {
+    migration_plan_choice_radio: 'migration_plan_later'
+  }
+});
 
 export default connect(mapStateToProps)(PlanWizardScheduleStep);

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardScheduleStep/index.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardScheduleStep/index.js
@@ -1,10 +1,19 @@
 import { connect } from 'react-redux';
 import PlanWizardScheduleStep from './PlanWizardScheduleStep';
+import { getMappingType } from '../../../../components/InfrastructureMappingsList/helpers';
 
-const mapStateToProps = () => ({
-  initialValues: {
-    migration_plan_choice_radio: 'migration_plan_later'
-  }
-});
+const mapStateToProps = ({ overview, form }) => {
+  const mappingId = form.planWizardGeneralStep.values.infrastructure_mapping;
+  const selectedMapping = overview.transformationMappings.find(mapping => mapping.id === mappingId);
+  const targetProvider = getMappingType(selectedMapping.transformation_mapping_items);
+  return {
+    targetProvider,
+    migration_plan_choice_radio:
+      form.planWizardScheduleStep && form.planWizardScheduleStep.values.migration_plan_choice_radio,
+    initialValues: {
+      migration_plan_choice_radio: 'migration_plan_later'
+    }
+  };
+};
 
 export default connect(mapStateToProps)(PlanWizardScheduleStep);

--- a/app/javascript/react/screens/App/common/forms/FormField.js
+++ b/app/javascript/react/screens/App/common/forms/FormField.js
@@ -101,7 +101,7 @@ FormField.propTypes = {
   optionValue: PropTypes.string,
   labelWidth: PropTypes.string,
   meta: PropTypes.object,
-  help: PropTypes.string,
+  help: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   maxLength: PropTypes.number,
   maxLengthWarning: PropTypes.string
 };


### PR DESCRIPTION
Closes #687.
Closes #688.

Upon selecting "start migration immediately", a warning appears on the Schedule step:
![screenshot 2018-10-11 17 27 01](https://user-images.githubusercontent.com/811963/46835364-f6cb7300-cd7b-11e8-9c48-40166497c999.png)

Upon selecting "save migration plan to run later", a warning appears on the Results step:
![screenshot 2018-10-11 17 31 47](https://user-images.githubusercontent.com/811963/46835366-faf79080-cd7b-11e8-8fb8-aa8665be785b.png)

@vconzola, let me know if this looks ok, I styled it slightly differently from the mockups because the text ended up wrapping and looking ugly when I put it all on one line.
