### PR TITLE
Keep the Download Log button disabled until v2v log is available

### DIFF
--- a/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
+++ b/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
@@ -541,16 +541,14 @@ class PlanRequestDetailList extends React.Component {
                       <b>{__('Conversion Host')}: </b>
                       {task.transformation_host_name}
                     </div>
-                    {task.completed &&
-                      task.options.virtv2v_wrapper &&
-                      task.options.virtv2v_wrapper.v2v_log.length > 0 && (
-                        <div>
-                          <br />
-                          <strong>{__('Log:')}</strong>
-                          <br />
-                          {task.options.virtv2v_wrapper.v2v_log}
-                        </div>
-                      )}
+                    {task.log_available && (
+                      <div>
+                        <br />
+                        <strong>{__('Log:')}</strong>
+                        <br />
+                        {task.options.virtv2v_wrapper.v2v_log}
+                      </div>
+                    )}
                   </div>
                 </Popover>
               );
@@ -647,10 +645,11 @@ class PlanRequestDetailList extends React.Component {
                       pullRight
                       onSelect={eventKey => this.onSelect(eventKey, task)}
                       disabled={
-                        downloadLogInProgressTaskIds &&
-                        downloadLogInProgressTaskIds.find(element => element === task.id) &&
-                        !task.options.prePlaybookComplete &&
-                        !task.options.postPlaybookComplete
+                        !task.log_available ||
+                        (downloadLogInProgressTaskIds &&
+                          downloadLogInProgressTaskIds.find(element => element === task.id) &&
+                          !task.options.prePlaybookComplete &&
+                          !task.options.postPlaybookComplete)
                       }
                     >
                       {task.options.prePlaybookComplete && (

--- a/app/javascript/react/screens/App/Plan/helpers.js
+++ b/app/javascript/react/screens/App/Plan/helpers.js
@@ -26,7 +26,8 @@ const processVMTasks = vmTasks => {
       status: task.status,
       options: {},
       cancel_requested: task.options.cancel_requested,
-      source_id: task.source_id
+      source_id: task.source_id,
+      log_available: task.options.virtv2v_wrapper && task.options.virtv2v_wrapper.v2v_log.length > 0
     };
 
     if (task.options.playbooks) {


### PR DESCRIPTION
- Display the Log file name in the popover as soon as it is available in `task.options`
(previously we displayed the Log file name only when the task completed)

- Keep the Download log button disabled until the Log file name is available

Fixes a part of https://github.com/ManageIQ/manageiq-v2v/issues/478

https://bugzilla.redhat.com/show_bug.cgi?id=1589265