### PR TITLE
[#376] Add Reschedule feature, move Schedule/Unschedule buttons to kebab menu

### DIFF
--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
@@ -7,7 +7,7 @@ import getMostRecentRequest from '../../../common/getMostRecentRequest';
 import getMostRecentVMTasksFromRequests from './helpers/getMostRecentVMTasksFromRequests';
 import sortFilter from '../../../Plan/components/sortFilter';
 import { MIGRATIONS_COMPLETED_SORT_FIELDS } from './MigrationsConstants';
-import ScheduleMigrationButton from './ScheduleMigrationButton';
+import ScheduleMigrationMenuItems from './ScheduleMigrationMenuItems';
 import ScheduleMigrationModal from '../ScheduleMigrationModal/ScheduleMigrationModal';
 import { formatDateTime } from '../../../../../../components/dates/MomentDate';
 import DeleteMigrationMenuItem from './DeleteMigrationMenuItem';
@@ -268,7 +268,7 @@ class MigrationsCompletedList extends React.Component {
                             {!archived &&
                               failed && (
                                 <React.Fragment>
-                                  <ScheduleMigrationButton
+                                  <ScheduleMigrationMenuItems
                                     showConfirmModalAction={showConfirmModalAction}
                                     hideConfirmModalAction={hideConfirmModalAction}
                                     loading={loading}

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
@@ -267,28 +267,15 @@ class MigrationsCompletedList extends React.Component {
                           <div>
                             {!archived &&
                               failed && (
-                                <React.Fragment>
-                                  <ScheduleMigrationMenuItems
-                                    showConfirmModalAction={showConfirmModalAction}
-                                    hideConfirmModalAction={hideConfirmModalAction}
-                                    loading={loading}
-                                    toggleScheduleMigrationModal={toggleScheduleMigrationModal}
-                                    scheduleMigration={scheduleMigration}
-                                    fetchTransformationPlansAction={fetchTransformationPlansAction}
-                                    fetchTransformationPlansUrl={fetchTransformationPlansUrl}
-                                    plan={plan}
-                                    isMissingMapping={isMissingMapping}
-                                  />
-                                  <Button
-                                    onClick={e => {
-                                      e.stopPropagation();
-                                      retryClick(plan.href, plan.id);
-                                    }}
-                                    disabled={isMissingMapping || loading === plan.href}
-                                  >
-                                    {__('Retry')}
-                                  </Button>
-                                </React.Fragment>
+                                <Button
+                                  onClick={e => {
+                                    e.stopPropagation();
+                                    retryClick(plan.href, plan.id);
+                                  }}
+                                  disabled={isMissingMapping || loading === plan.href}
+                                >
+                                  {__('Retry')}
+                                </Button>
                               )}
                             <StopPropagationOnClick>
                               <DropdownKebab id={`${plan.id}-kebab`} pullRight>
@@ -325,6 +312,20 @@ class MigrationsCompletedList extends React.Component {
                                   fetchTransformationMappingsAction={fetchTransformationMappingsAction}
                                   fetchTransformationMappingsUrl={fetchTransformationMappingsUrl}
                                 />
+                                {!archived &&
+                                  failed && (
+                                    <ScheduleMigrationMenuItems
+                                      showConfirmModalAction={showConfirmModalAction}
+                                      hideConfirmModalAction={hideConfirmModalAction}
+                                      loading={loading}
+                                      toggleScheduleMigrationModal={toggleScheduleMigrationModal}
+                                      scheduleMigration={scheduleMigration}
+                                      fetchTransformationPlansAction={fetchTransformationPlansAction}
+                                      fetchTransformationPlansUrl={fetchTransformationPlansUrl}
+                                      plan={plan}
+                                      isMissingMapping={isMissingMapping}
+                                    />
+                                  )}
                               </DropdownKebab>
                             </StopPropagationOnClick>
                           </div>

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
@@ -7,7 +7,7 @@ import ScheduleMigrationModal from '../ScheduleMigrationModal/ScheduleMigrationM
 import { formatDateTime } from '../../../../../../components/dates/MomentDate';
 import { MIGRATIONS_NOT_STARTED_SORT_FIELDS } from './MigrationsConstants';
 import sortFilter from '../../../Plan/components/sortFilter';
-import ScheduleMigrationButton from './ScheduleMigrationButton';
+import ScheduleMigrationMenuItems from './ScheduleMigrationMenuItems';
 import StopPropagationOnClick from '../../../common/StopPropagationOnClick';
 import DeleteMigrationMenuItem from './DeleteMigrationMenuItem';
 
@@ -105,7 +105,7 @@ class MigrationsNotStartedList extends React.Component {
                         }}
                         actions={
                           <div>
-                            <ScheduleMigrationButton
+                            <ScheduleMigrationMenuItems
                               showConfirmModalAction={showConfirmModalAction}
                               hideConfirmModalAction={hideConfirmModalAction}
                               loading={loading}

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
@@ -105,17 +105,6 @@ class MigrationsNotStartedList extends React.Component {
                         }}
                         actions={
                           <div>
-                            <ScheduleMigrationMenuItems
-                              showConfirmModalAction={showConfirmModalAction}
-                              hideConfirmModalAction={hideConfirmModalAction}
-                              loading={loading}
-                              toggleScheduleMigrationModal={toggleScheduleMigrationModal}
-                              scheduleMigration={scheduleMigration}
-                              fetchTransformationPlansAction={fetchTransformationPlansAction}
-                              fetchTransformationPlansUrl={fetchTransformationPlansUrl}
-                              plan={plan}
-                              isMissingMapping={isMissingMapping}
-                            />
                             <Button
                               id={`migrate_${plan.id}`}
                               onClick={e => {
@@ -149,6 +138,17 @@ class MigrationsNotStartedList extends React.Component {
                                   planName={plan.name}
                                   fetchTransformationMappingsAction={fetchTransformationMappingsAction}
                                   fetchTransformationMappingsUrl={fetchTransformationMappingsUrl}
+                                />
+                                <ScheduleMigrationMenuItems
+                                  showConfirmModalAction={showConfirmModalAction}
+                                  hideConfirmModalAction={hideConfirmModalAction}
+                                  loading={loading}
+                                  toggleScheduleMigrationModal={toggleScheduleMigrationModal}
+                                  scheduleMigration={scheduleMigration}
+                                  fetchTransformationPlansAction={fetchTransformationPlansAction}
+                                  fetchTransformationPlansUrl={fetchTransformationPlansUrl}
+                                  plan={plan}
+                                  isMissingMapping={isMissingMapping}
                                 />
                               </DropdownKebab>
                             </StopPropagationOnClick>

--- a/app/javascript/react/screens/App/Overview/components/Migrations/ScheduleMigrationButton.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/ScheduleMigrationButton.js
@@ -62,20 +62,32 @@ const ScheduleMigrationButton = ({
         </Button>
       )}
       {!staleMigrationSchedule && (
-        <Button
-          id={`unschedule_${plan.id}`}
-          onClick={e => {
-            e.stopPropagation();
+        <React.Fragment>
+          <Button
+            id={`unschedule_${plan.id}`}
+            onClick={e => {
+              e.stopPropagation();
 
-            showConfirmModalAction({
-              ...confirmModalProps,
-              onConfirm
-            });
-          }}
-          disabled={isMissingMapping || loading === plan.href}
-        >
-          {__('Unschedule')}
-        </Button>
+              showConfirmModalAction({
+                ...confirmModalProps,
+                onConfirm
+              });
+            }}
+            disabled={isMissingMapping || loading === plan.href}
+          >
+            {__('Unschedule')}
+          </Button>
+          <Button
+            id={`reschedule_${plan.id}`}
+            onClick={e => {
+              e.stopPropagation();
+              toggleScheduleMigrationModal({ plan });
+            }}
+            disabled={isMissingMapping || loading === plan.href}
+          >
+            {__('Reschedule')}
+          </Button>
+        </React.Fragment>
       )}
     </React.Fragment>
   );

--- a/app/javascript/react/screens/App/Overview/components/Migrations/ScheduleMigrationMenuItems.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/ScheduleMigrationMenuItems.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button, Icon } from 'patternfly-react';
+import { MenuItem, Icon } from 'patternfly-react';
 import { formatDateTime } from '../../../../../../components/dates/MomentDate';
 
 const ScheduleMigrationMenuItems = ({
@@ -47,46 +47,55 @@ const ScheduleMigrationMenuItems = ({
     hideConfirmModalAction();
   };
 
+  const scheduleDisabled = isMissingMapping || loading === plan.href || plan.schedule_type;
+  const rescheduleDisabled = isMissingMapping || loading === plan.href;
+
   return (
     <React.Fragment>
       {staleMigrationSchedule && (
-        <Button
+        <MenuItem
           id={`schedule_${plan.id}`}
           onClick={e => {
             e.stopPropagation();
-            toggleScheduleMigrationModal({ plan });
+            if (!scheduleDisabled) {
+              toggleScheduleMigrationModal({ plan });
+            }
           }}
-          disabled={isMissingMapping || loading === plan.href || plan.schedule_type}
+          disabled={scheduleDisabled}
         >
           {__('Schedule')}
-        </Button>
+        </MenuItem>
       )}
       {!staleMigrationSchedule && (
         <React.Fragment>
-          <Button
+          <MenuItem
             id={`unschedule_${plan.id}`}
             onClick={e => {
               e.stopPropagation();
 
-              showConfirmModalAction({
-                ...confirmModalProps,
-                onConfirm
-              });
+              if (!rescheduleDisabled) {
+                showConfirmModalAction({
+                  ...confirmModalProps,
+                  onConfirm
+                });
+              }
             }}
-            disabled={isMissingMapping || loading === plan.href}
+            disabled={rescheduleDisabled}
           >
             {__('Unschedule')}
-          </Button>
-          <Button
+          </MenuItem>
+          <MenuItem
             id={`reschedule_${plan.id}`}
             onClick={e => {
               e.stopPropagation();
-              toggleScheduleMigrationModal({ plan });
+              if (!rescheduleDisabled) {
+                toggleScheduleMigrationModal({ plan });
+              }
             }}
-            disabled={isMissingMapping || loading === plan.href}
+            disabled={rescheduleDisabled}
           >
             {__('Reschedule')}
-          </Button>
+          </MenuItem>
         </React.Fragment>
       )}
     </React.Fragment>

--- a/app/javascript/react/screens/App/Overview/components/Migrations/ScheduleMigrationMenuItems.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/ScheduleMigrationMenuItems.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Button, Icon } from 'patternfly-react';
 import { formatDateTime } from '../../../../../../components/dates/MomentDate';
 
-const ScheduleMigrationButton = ({
+const ScheduleMigrationMenuItems = ({
   showConfirmModalAction,
   hideConfirmModalAction,
   loading,
@@ -93,7 +93,7 @@ const ScheduleMigrationButton = ({
   );
 };
 
-ScheduleMigrationButton.propTypes = {
+ScheduleMigrationMenuItems.propTypes = {
   showConfirmModalAction: PropTypes.func,
   hideConfirmModalAction: PropTypes.func,
   loading: PropTypes.string,
@@ -105,4 +105,4 @@ ScheduleMigrationButton.propTypes = {
   isMissingMapping: PropTypes.bool
 };
 
-export default ScheduleMigrationButton;
+export default ScheduleMigrationMenuItems;

--- a/app/javascript/react/screens/App/Overview/components/ScheduleMigrationModal/ScheduleMigrationModal.js
+++ b/app/javascript/react/screens/App/Overview/components/ScheduleMigrationModal/ScheduleMigrationModal.js
@@ -4,7 +4,9 @@ import { Button, Modal } from 'patternfly-react';
 import ScheduleMigrationModalBody from './ScheduleMigrationModalBody';
 
 class ScheduleMigrationModal extends React.Component {
-  state = { dateTimeInput: '' };
+  state = {
+    dateTimeInput: ''
+  };
 
   render() {
     const {
@@ -15,6 +17,12 @@ class ScheduleMigrationModal extends React.Component {
       fetchTransformationPlansAction,
       fetchTransformationPlansUrl
     } = this.props;
+
+    const migrationScheduled =
+      (scheduleMigrationPlan &&
+        scheduleMigrationPlan.schedules &&
+        scheduleMigrationPlan.schedules[0].run_at.start_time) ||
+      '';
 
     const handleChange = event => {
       this.setState({ dateTimeInput: event });
@@ -32,7 +40,7 @@ class ScheduleMigrationModal extends React.Component {
           <Modal.Title>{__('Schedule Migration Plan')}</Modal.Title>
         </Modal.Header>
         <Modal.Body>
-          <ScheduleMigrationModalBody handleChange={handleChange} />
+          <ScheduleMigrationModalBody handleChange={handleChange} defaultDate={migrationScheduled} />
         </Modal.Body>
         <Modal.Footer>
           <Button bsStyle="default" className="btn-cancel" onClick={modalClose}>

--- a/app/javascript/react/screens/App/Overview/components/ScheduleMigrationModal/ScheduleMigrationModalBody.js
+++ b/app/javascript/react/screens/App/Overview/components/ScheduleMigrationModal/ScheduleMigrationModalBody.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 
 class ScheduleMigrationModalBody extends React.Component {
   componentDidMount() {
-    const { handleChange } = this.props;
+    const { handleChange, defaultDate } = this.props;
     const datetimeSelector = $('#dateTimePicker');
 
     datetimeSelector.datetimepicker({
@@ -17,6 +17,10 @@ class ScheduleMigrationModalBody extends React.Component {
         today: 'today-button-pf'
       }
     });
+
+    if (defaultDate) {
+      datetimeSelector.data("DateTimePicker").date(new Date(defaultDate));
+    }
 
     datetimeSelector.on('dp.change', e => {
       handleChange(e.date._d);

--- a/app/javascript/react/screens/App/Overview/components/ScheduleMigrationModal/ScheduleMigrationModalBody.js
+++ b/app/javascript/react/screens/App/Overview/components/ScheduleMigrationModal/ScheduleMigrationModalBody.js
@@ -19,7 +19,7 @@ class ScheduleMigrationModalBody extends React.Component {
     });
 
     if (defaultDate) {
-      datetimeSelector.data("DateTimePicker").date(new Date(defaultDate));
+      datetimeSelector.data('DateTimePicker').date(new Date(defaultDate));
     }
 
     datetimeSelector.on('dp.change', e => {
@@ -45,7 +45,8 @@ class ScheduleMigrationModalBody extends React.Component {
 }
 
 ScheduleMigrationModalBody.propTypes = {
-  handleChange: PropTypes.func
+  handleChange: PropTypes.func,
+  defaultDate: PropTypes.string
 };
 
 export default ScheduleMigrationModalBody;


### PR DESCRIPTION
Closes #376.

After discussion with @vconzola, we decided to move the Schedule functionality for a migration plan into the kebab menu underneath Edit and Delete. For a Not Started plan or a Failed plan, the kebab menu will now include either a Schedule menu item or both Unschedule and Reschedule menu items. When Reschedule is selected, the date picker is pre-filled to the previously scheduled time.

<img width="1202" alt="screenshot 2018-10-12 14 24 56" src="https://user-images.githubusercontent.com/811963/46887241-153c7780-ce2b-11e8-991f-fa5b75cb1eac.png">

<img width="1198" alt="screenshot 2018-10-12 14 25 03" src="https://user-images.githubusercontent.com/811963/46887246-1a012b80-ce2b-11e8-9083-0d353414323f.png">

Thanks to @AllenBW for making my life easier by building the action creator in such a way that it already supported editing a schedule! 🥇 