### PR TITLE
[#710] Don't show Schedule button when scheduled migration is about to start

### DIFF
--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
@@ -10,6 +10,7 @@ import sortFilter from '../../../Plan/components/sortFilter';
 import ScheduleMigrationButton from './ScheduleMigrationButton';
 import StopPropagationOnClick from '../../../common/StopPropagationOnClick';
 import DeleteMigrationMenuItem from './DeleteMigrationMenuItem';
+import getPlanScheduleInfo from './helpers/getPlanScheduleInfo';
 
 class MigrationsNotStartedList extends React.Component {
   state = {
@@ -91,7 +92,7 @@ class MigrationsNotStartedList extends React.Component {
                 </Grid.Row>
                 <ListView className="plans-not-started-list" style={{ marginTop: 0 }}>
                   {sortedMigrations.map(plan => {
-                    const migrationScheduled = plan.schedules && plan.schedules[0].run_at.start_time;
+                    const { migrationScheduled, migrationStarting } = getPlanScheduleInfo(plan);
                     const isMissingMapping = !plan.infraMappingName;
 
                     const editPlanDisabled = isMissingMapping || loading === plan.href;
@@ -122,7 +123,9 @@ class MigrationsNotStartedList extends React.Component {
                                 e.stopPropagation();
                                 migrateClick(plan.href);
                               }}
-                              disabled={isMissingMapping || loading === plan.href || plan.schedule_type}
+                              disabled={
+                                isMissingMapping || loading === plan.href || plan.schedule_type || migrationStarting
+                              }
                             >
                               {__('Migrate')}
                             </Button>
@@ -176,12 +179,18 @@ class MigrationsNotStartedList extends React.Component {
                               {plan.infraMappingName}
                             </ListView.InfoItem>
                           ),
-                          migrationScheduled && (
-                            <ListView.InfoItem key={plan.id + 1} style={{ textAlign: 'left' }}>
-                              <Icon type="fa" name="clock-o" />
-                              {__(`Migration scheduled`)}
-                              <br />
-                              {formatDateTime(migrationScheduled)}
+                          migrationScheduled &&
+                            !migrationStarting && (
+                              <ListView.InfoItem key={`${plan.id}-scheduledTime`} style={{ textAlign: 'left' }}>
+                                <Icon type="fa" name="clock-o" />
+                                {__(`Migration scheduled`)}
+                                <br />
+                                {formatDateTime(migrationScheduled)}
+                              </ListView.InfoItem>
+                            ),
+                          migrationStarting && (
+                            <ListView.InfoItem key={`${plan.id}-starting`} style={{ textAlign: 'left' }}>
+                              {__(`Migration in progress`)}
                             </ListView.InfoItem>
                           )
                         ]}

--- a/app/javascript/react/screens/App/Overview/components/Migrations/ScheduleMigrationButton.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/ScheduleMigrationButton.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Button, Icon } from 'patternfly-react';
 import { formatDateTime } from '../../../../../../components/dates/MomentDate';
+import getPlanScheduleInfo from './helpers/getPlanScheduleInfo';
 
 const ScheduleMigrationButton = ({
   showConfirmModalAction,
@@ -14,13 +15,14 @@ const ScheduleMigrationButton = ({
   plan,
   isMissingMapping
 }) => {
-  const migrationScheduled = (plan.schedules && plan.schedules[0].run_at.start_time) || 0;
-  const staleMigrationSchedule = new Date(migrationScheduled).getTime() < Date.now();
+  const { migrationScheduled, staleMigrationSchedule, migrationStarting } = getPlanScheduleInfo(plan);
+  const showScheduleButton = staleMigrationSchedule && !migrationStarting;
+
   const confirmationWarningText = (
     <React.Fragment>
       <p>
         {sprintf(
-          __('Are you sure you want to unschedule plan %s  targted to run on %s ?'),
+          __('Are you sure you want to unschedule plan %s  targeted to run on %s ?'),
           plan.name,
           formatDateTime(migrationScheduled)
         )}
@@ -49,7 +51,7 @@ const ScheduleMigrationButton = ({
 
   return (
     <React.Fragment>
-      {staleMigrationSchedule && (
+      {showScheduleButton && (
         <Button
           id={`schedule_${plan.id}`}
           onClick={e => {
@@ -61,7 +63,7 @@ const ScheduleMigrationButton = ({
           {__('Schedule')}
         </Button>
       )}
-      {!staleMigrationSchedule && (
+      {!showScheduleButton && (
         <Button
           id={`unschedule_${plan.id}`}
           onClick={e => {
@@ -72,7 +74,7 @@ const ScheduleMigrationButton = ({
               onConfirm
             });
           }}
-          disabled={isMissingMapping || loading === plan.href}
+          disabled={isMissingMapping || loading === plan.href || migrationStarting}
         >
           {__('Unschedule')}
         </Button>

--- a/app/javascript/react/screens/App/Overview/components/Migrations/helpers/getPlanScheduleInfo.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/helpers/getPlanScheduleInfo.js
@@ -1,0 +1,12 @@
+const getPlanScheduleInfo = plan => {
+  const migrationScheduled = (plan.schedules && plan.schedules[0].run_at.start_time) || 0;
+  const staleMigrationSchedule = new Date(migrationScheduled).getTime() < Date.now();
+  const migrationStarting = staleMigrationSchedule && new Date(migrationScheduled).getTime() > Date.now() - 120000;
+  return {
+    migrationScheduled,
+    staleMigrationSchedule,
+    migrationStarting
+  };
+};
+
+export default getPlanScheduleInfo;


### PR DESCRIPTION
Fixes #710.

When a scheduled migration's time comes to run, there are 5-10 seconds of lag before the API recognizes that the migration has started. When we poll during this period, we were displaying the Schedule button again.

With this change, during that lag period, the scheduled time will be replaced by "Migration in progress" and the Unschedule and Migrate/Retry buttons will be disabled.

Not Started plan before the scheduled time:
![screenshot 2018-10-15 16 30 01](https://user-images.githubusercontent.com/811963/46977191-82eddb00-d099-11e8-976b-0c57ff45051e.png)

Not Started plan during the lag period:
![screenshot 2018-10-15 16 31 49](https://user-images.githubusercontent.com/811963/46977209-8c774300-d099-11e8-99f7-caa9470e4fd4.png)

Failed plan before the scheduled time:
![screenshot 2018-10-15 16 32 53](https://user-images.githubusercontent.com/811963/46977223-97ca6e80-d099-11e8-9729-4b6d6e7e054e.png)

Failed plan during the lag period:
![screenshot 2018-10-15 16 34 34](https://user-images.githubusercontent.com/811963/46977246-a7e24e00-d099-11e8-9af4-535a41c4126e.png)

