### PR TITLE
[#563] Clickable aggregate cards on Overview

### DIFF
--- a/app/javascript/react/screens/App/Overview/Overview.js
+++ b/app/javascript/react/screens/App/Overview/Overview.js
@@ -171,9 +171,11 @@ class Overview extends React.Component {
       archivedTransformationPlans,
       finishedTransformationPlans,
       isFetchingAllRequestsWithTasks,
+      migrationsFilter,
       notStartedTransformationPlans,
       reloadCard,
-      requestsWithTasksPreviouslyFetched
+      requestsWithTasksPreviouslyFetched,
+      setMigrationsFilterAction
     } = this.props;
     return (
       <div className="row-cards-pf">
@@ -182,6 +184,8 @@ class Overview extends React.Component {
             <AggregateCards.NotStartedTransformationPlans
               notStartedPlans={notStartedTransformationPlans}
               loading={isFetchingAllRequestsWithTasks && !requestsWithTasksPreviouslyFetched}
+              migrationsFilter={migrationsFilter}
+              setMigrationsFilterAction={setMigrationsFilterAction}
             />
           </CardGrid.Col>
           <CardGrid.Col xs={6} sm={3}>
@@ -190,18 +194,24 @@ class Overview extends React.Component {
               allRequestsWithTasks={allRequestsWithTasks}
               reloadCard={reloadCard}
               loading={isFetchingAllRequestsWithTasks && !requestsWithTasksPreviouslyFetched}
+              migrationsFilter={migrationsFilter}
+              setMigrationsFilterAction={setMigrationsFilterAction}
             />
           </CardGrid.Col>
           <CardGrid.Col xs={6} sm={3}>
             <AggregateCards.FinishedTransformationPlans
               finishedPlans={finishedTransformationPlans}
               loading={isFetchingAllRequestsWithTasks && !requestsWithTasksPreviouslyFetched}
+              migrationsFilter={migrationsFilter}
+              setMigrationsFilterAction={setMigrationsFilterAction}
             />
           </CardGrid.Col>
           <CardGrid.Col xs={6} sm={3}>
             <AggregateCards.ArchivedTransformationPlans
               archivedPlans={archivedTransformationPlans}
               loading={isFetchingAllRequestsWithTasks && !requestsWithTasksPreviouslyFetched}
+              migrationsFilter={migrationsFilter}
+              setMigrationsFilterAction={setMigrationsFilterAction}
             />
           </CardGrid.Col>
         </Card.HeightMatching>
@@ -234,7 +244,6 @@ class Overview extends React.Component {
       finishedTransformationPlans,
       isCreatingTransformationPlanRequest,
       migrationsFilter,
-      setMigrationsFilterAction,
       confirmModalVisible,
       confirmModalOptions,
       showConfirmModalAction,

--- a/app/javascript/react/screens/App/Overview/Overview.js
+++ b/app/javascript/react/screens/App/Overview/Overview.js
@@ -64,6 +64,7 @@ class Overview extends React.Component {
       }
     });
   }
+
   componentWillReceiveProps(nextProps) {
     const {
       isContinuingToPlan,
@@ -163,6 +164,51 @@ class Overview extends React.Component {
     });
   };
 
+  renderAggregateDataCards = () => {
+    const {
+      activeTransformationPlans,
+      allRequestsWithTasks,
+      archivedTransformationPlans,
+      finishedTransformationPlans,
+      isFetchingAllRequestsWithTasks,
+      notStartedTransformationPlans,
+      reloadCard,
+      requestsWithTasksPreviouslyFetched
+    } = this.props;
+    return (
+      <div className="row-cards-pf">
+        <Card.HeightMatching selector={['.card-pf-match-height']}>
+          <CardGrid.Col xs={6} sm={3}>
+            <AggregateCards.NotStartedTransformationPlans
+              notStartedPlans={notStartedTransformationPlans}
+              loading={isFetchingAllRequestsWithTasks && !requestsWithTasksPreviouslyFetched}
+            />
+          </CardGrid.Col>
+          <CardGrid.Col xs={6} sm={3}>
+            <AggregateCards.ActiveTransformationPlans
+              activePlans={activeTransformationPlans}
+              allRequestsWithTasks={allRequestsWithTasks}
+              reloadCard={reloadCard}
+              loading={isFetchingAllRequestsWithTasks && !requestsWithTasksPreviouslyFetched}
+            />
+          </CardGrid.Col>
+          <CardGrid.Col xs={6} sm={3}>
+            <AggregateCards.FinishedTransformationPlans
+              finishedPlans={finishedTransformationPlans}
+              loading={isFetchingAllRequestsWithTasks && !requestsWithTasksPreviouslyFetched}
+            />
+          </CardGrid.Col>
+          <CardGrid.Col xs={6} sm={3}>
+            <AggregateCards.ArchivedTransformationPlans
+              archivedPlans={archivedTransformationPlans}
+              loading={isFetchingAllRequestsWithTasks && !requestsWithTasksPreviouslyFetched}
+            />
+          </CardGrid.Col>
+        </Card.HeightMatching>
+      </div>
+    );
+  };
+
   redirectTo = path => this.props.redirectTo(path);
 
   render() {
@@ -214,42 +260,9 @@ class Overview extends React.Component {
       openMappingWizardOnTransitionAction
     } = this.props;
 
-    const aggregateDataCards = (
-      <div className="row-cards-pf">
-        <Card.HeightMatching selector={['.card-pf-match-height']}>
-          <CardGrid.Col xs={6} sm={3}>
-            <AggregateCards.NotStartedTransformationPlans
-              notStartedPlans={notStartedTransformationPlans}
-              loading={isFetchingAllRequestsWithTasks && !requestsWithTasksPreviouslyFetched}
-            />
-          </CardGrid.Col>
-          <CardGrid.Col xs={6} sm={3}>
-            <AggregateCards.ActiveTransformationPlans
-              activePlans={activeTransformationPlans}
-              allRequestsWithTasks={allRequestsWithTasks}
-              reloadCard={reloadCard}
-              loading={isFetchingAllRequestsWithTasks && !requestsWithTasksPreviouslyFetched}
-            />
-          </CardGrid.Col>
-          <CardGrid.Col xs={6} sm={3}>
-            <AggregateCards.FinishedTransformationPlans
-              finishedPlans={finishedTransformationPlans}
-              loading={isFetchingAllRequestsWithTasks && !requestsWithTasksPreviouslyFetched}
-            />
-          </CardGrid.Col>
-          <CardGrid.Col xs={6} sm={3}>
-            <AggregateCards.InfrastructureMappings
-              mappings={transformationMappings}
-              loading={isFetchingTransformationMappings}
-            />
-          </CardGrid.Col>
-        </Card.HeightMatching>
-      </div>
-    );
-
     const overviewContent = (
       <div className="row cards-pf" style={{ overflow: 'auto', paddingBottom: 1, height: '100%' }}>
-        {aggregateDataCards}
+        {this.renderAggregateDataCards()}
         <Spinner
           loading={
             isFetchingProviders ||

--- a/app/javascript/react/screens/App/Overview/Overview.js
+++ b/app/javascript/react/screens/App/Overview/Overview.js
@@ -275,7 +275,6 @@ class Overview extends React.Component {
             !!transformationMappings.length || !!transformationPlans.length || !!archivedTransformationPlans.length ? (
               <Migrations
                 activeFilter={migrationsFilter}
-                setActiveFilter={setMigrationsFilterAction}
                 transformationPlans={transformationPlans}
                 allRequestsWithTasks={allRequestsWithTasks}
                 archivedTransformationPlans={archivedTransformationPlans}

--- a/app/javascript/react/screens/App/Overview/components/AggregateCards/ActiveTransformationPlans/ActiveTransformationPlans.js
+++ b/app/javascript/react/screens/App/Overview/components/AggregateCards/ActiveTransformationPlans/ActiveTransformationPlans.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-
 import {
   Icon,
   Card,
@@ -10,13 +9,22 @@ import {
   AggregateStatusNotification,
   Spinner
 } from 'patternfly-react';
+
 import getMostRecentRequest from '../../../../common/getMostRecentRequest';
 import { PLAN_JOB_STATUS } from '../../../../../../../data/models/plans';
+import { MIGRATIONS_FILTERS } from '../../../OverviewConstants';
 
-const ActiveTransformationPlans = ({ activePlans, allRequestsWithTasks, reloadCard, loading }) => {
+const ActiveTransformationPlans = ({
+  activePlans,
+  allRequestsWithTasks,
+  reloadCard,
+  loading,
+  migrationsFilter,
+  setMigrationsFilterAction
+}) => {
   const countDescription =
     activePlans.length === 1 ? __('Migration Plan In Progress') : __('Migration Plans In Progress');
-
+  const active = migrationsFilter === MIGRATIONS_FILTERS.inProgress;
   const erroredPlans = activePlans.filter(plan => {
     if (allRequestsWithTasks && allRequestsWithTasks.length > 0) {
       const requestsOfAssociatedPlan = allRequestsWithTasks.filter(request => request.source_id === plan.id);
@@ -45,10 +53,16 @@ const ActiveTransformationPlans = ({ activePlans, allRequestsWithTasks, reloadCa
     erroredPlansLen -= 1;
   }
 
-  const classes = cx('overview-aggregate-card', { 'is-loading': loading });
+  const classes = cx('overview-aggregate-card', { 'is-loading': loading, active });
 
   return (
-    <Card className={classes} accented aggregated matchHeight>
+    <Card
+      className={classes}
+      accented
+      aggregated
+      matchHeight
+      onClick={() => setMigrationsFilterAction(MIGRATIONS_FILTERS.inProgress)}
+    >
       <Spinner loading={loading}>
         <Card.Title>
           <AggregateStatusCount>{activePlans.length}</AggregateStatusCount> {countDescription}
@@ -72,7 +86,9 @@ ActiveTransformationPlans.propTypes = {
   activePlans: PropTypes.array,
   allRequestsWithTasks: PropTypes.array,
   reloadCard: PropTypes.bool,
-  loading: PropTypes.bool
+  loading: PropTypes.bool,
+  migrationsFilter: PropTypes.string,
+  setMigrationsFilterAction: PropTypes.func
 };
 
 export default ActiveTransformationPlans;

--- a/app/javascript/react/screens/App/Overview/components/AggregateCards/AggregateCards.scss
+++ b/app/javascript/react/screens/App/Overview/components/AggregateCards/AggregateCards.scss
@@ -1,7 +1,11 @@
 .overview-aggregate-card {
   min-height: 90px;
+  cursor: pointer;
   &.is-loading {
     display: flex;
     align-items: center;
+  }
+  &.active {
+    background: $color-pf-blue-50;
   }
 }

--- a/app/javascript/react/screens/App/Overview/components/AggregateCards/ArchivedTransformationPlans/ArchivedTransformationPlans.js
+++ b/app/javascript/react/screens/App/Overview/components/AggregateCards/ArchivedTransformationPlans/ArchivedTransformationPlans.js
@@ -10,13 +10,21 @@ import {
   Spinner
 } from 'patternfly-react';
 
-const ArchivedTransformationPlans = ({ archivedPlans, loading }) => {
-  const countDescription = archivedPlans.length === 1 ? __('Migration Plan Archived') : __('Migration Plans Archived');
+import { MIGRATIONS_FILTERS } from '../../../OverviewConstants';
 
-  const classes = cx('overview-aggregate-card', { 'is-loading': loading });
+const ArchivedTransformationPlans = ({ archivedPlans, loading, migrationsFilter, setMigrationsFilterAction }) => {
+  const countDescription = archivedPlans.length === 1 ? __('Migration Plan Archived') : __('Migration Plans Archived');
+  const active = migrationsFilter === MIGRATIONS_FILTERS.archived;
+  const classes = cx('overview-aggregate-card', { 'is-loading': loading, active });
 
   return (
-    <Card className={classes} accented aggregated matchHeight>
+    <Card
+      className={classes}
+      accented
+      aggregated
+      matchHeight
+      onClick={() => setMigrationsFilterAction(MIGRATIONS_FILTERS.archived)}
+    >
       <Spinner loading={loading}>
         <Card.Title>
           <AggregateStatusCount>{archivedPlans.length}</AggregateStatusCount> {countDescription}
@@ -37,7 +45,9 @@ const ArchivedTransformationPlans = ({ archivedPlans, loading }) => {
 
 ArchivedTransformationPlans.propTypes = {
   archivedPlans: PropTypes.array,
-  loading: PropTypes.bool
+  loading: PropTypes.bool,
+  migrationsFilter: PropTypes.string,
+  setMigrationsFilterAction: PropTypes.func
 };
 
 export default ArchivedTransformationPlans;

--- a/app/javascript/react/screens/App/Overview/components/AggregateCards/ArchivedTransformationPlans/ArchivedTransformationPlans.js
+++ b/app/javascript/react/screens/App/Overview/components/AggregateCards/ArchivedTransformationPlans/ArchivedTransformationPlans.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-
 import {
   Icon,
   Card,
@@ -11,8 +10,8 @@ import {
   Spinner
 } from 'patternfly-react';
 
-const InfrastructureMappings = ({ mappings, loading }) => {
-  const countDescription = mappings.length === 1 ? __('Infrastructure Mapping') : __('Infrastructure Mappings');
+const ArchivedTransformationPlans = ({ archivedPlans, loading }) => {
+  const countDescription = archivedPlans.length === 1 ? __('Migration Plan Archived') : __('Migration Plans Archived');
 
   const classes = cx('overview-aggregate-card', { 'is-loading': loading });
 
@@ -20,9 +19,9 @@ const InfrastructureMappings = ({ mappings, loading }) => {
     <Card className={classes} accented aggregated matchHeight>
       <Spinner loading={loading}>
         <Card.Title>
-          <AggregateStatusCount>{mappings.length}</AggregateStatusCount> {countDescription}
+          <AggregateStatusCount>{archivedPlans.length}</AggregateStatusCount> {countDescription}
         </Card.Title>
-        {mappings.length > 0 && (
+        {archivedPlans.length > 0 && (
           <Card.Body className="overview-aggregate-card--body">
             <AggregateStatusNotifications>
               <AggregateStatusNotification>
@@ -36,9 +35,9 @@ const InfrastructureMappings = ({ mappings, loading }) => {
   );
 };
 
-InfrastructureMappings.propTypes = {
-  mappings: PropTypes.array,
+ArchivedTransformationPlans.propTypes = {
+  archivedPlans: PropTypes.array,
   loading: PropTypes.bool
 };
 
-export default InfrastructureMappings;
+export default ArchivedTransformationPlans;

--- a/app/javascript/react/screens/App/Overview/components/AggregateCards/FinishedTransformationPlans/FinishedTransformationPlans.js
+++ b/app/javascript/react/screens/App/Overview/components/AggregateCards/FinishedTransformationPlans/FinishedTransformationPlans.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-
 import {
   Icon,
   Card,
@@ -10,20 +9,28 @@ import {
   AggregateStatusNotification,
   Spinner
 } from 'patternfly-react';
+
 import getMostRecentRequest from '../../../../common/getMostRecentRequest';
+import { MIGRATIONS_FILTERS } from '../../../OverviewConstants';
 
-const FinishedTransformationPlans = ({ finishedPlans, loading }) => {
+const FinishedTransformationPlans = ({ finishedPlans, loading, migrationsFilter, setMigrationsFilterAction }) => {
   const countDescription = finishedPlans.length === 1 ? __('Migration Plan Complete') : __('Migration Plans Complete');
-
+  const active = migrationsFilter === MIGRATIONS_FILTERS.completed;
   const failedPlans = finishedPlans.filter(plan => {
     const mostRecentRequest = plan.miq_requests.length > 0 && getMostRecentRequest(plan.miq_requests);
     return mostRecentRequest.status === 'Error';
   });
 
-  const classes = cx('overview-aggregate-card', { 'is-loading': loading });
+  const classes = cx('overview-aggregate-card', { 'is-loading': loading, active });
 
   return (
-    <Card className={classes} accented aggregated matchHeight>
+    <Card
+      className={classes}
+      accented
+      aggregated
+      matchHeight
+      onClick={() => setMigrationsFilterAction(MIGRATIONS_FILTERS.completed)}
+    >
       <Spinner loading={loading}>
         <Card.Title>
           <AggregateStatusCount>{finishedPlans.length}</AggregateStatusCount> {countDescription}
@@ -45,7 +52,9 @@ const FinishedTransformationPlans = ({ finishedPlans, loading }) => {
 
 FinishedTransformationPlans.propTypes = {
   finishedPlans: PropTypes.array,
-  loading: PropTypes.bool
+  loading: PropTypes.bool,
+  migrationsFilter: PropTypes.string,
+  setMigrationsFilterAction: PropTypes.func
 };
 
 export default FinishedTransformationPlans;

--- a/app/javascript/react/screens/App/Overview/components/AggregateCards/NotStartedTransformationPlans/NotStartedTransformationPlans.js
+++ b/app/javascript/react/screens/App/Overview/components/AggregateCards/NotStartedTransformationPlans/NotStartedTransformationPlans.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-
 import {
   Icon,
   Card,
@@ -11,14 +10,22 @@ import {
   Spinner
 } from 'patternfly-react';
 
-const NotStartedTransformationPlans = ({ notStartedPlans, loading }) => {
+import { MIGRATIONS_FILTERS } from '../../../OverviewConstants';
+
+const NotStartedTransformationPlans = ({ notStartedPlans, loading, migrationsFilter, setMigrationsFilterAction }) => {
   const countDescription =
     notStartedPlans.length === 1 ? __('Migration Plan Not Started') : __('Migration Plans Not Started');
-
-  const classes = cx('overview-aggregate-card', { 'is-loading': loading });
+  const active = migrationsFilter === MIGRATIONS_FILTERS.notStarted;
+  const classes = cx('overview-aggregate-card', { 'is-loading': loading, active });
 
   return (
-    <Card className={classes} accented aggregated matchHeight>
+    <Card
+      className={classes}
+      accented
+      aggregated
+      matchHeight
+      onClick={() => setMigrationsFilterAction(MIGRATIONS_FILTERS.notStarted)}
+    >
       <Spinner loading={loading}>
         <Card.Title>
           <AggregateStatusCount>{notStartedPlans.length}</AggregateStatusCount> {countDescription}
@@ -39,7 +46,9 @@ const NotStartedTransformationPlans = ({ notStartedPlans, loading }) => {
 
 NotStartedTransformationPlans.propTypes = {
   notStartedPlans: PropTypes.array,
-  loading: PropTypes.bool
+  loading: PropTypes.bool,
+  migrationsFilter: PropTypes.string,
+  setMigrationsFilterAction: PropTypes.func
 };
 
 export default NotStartedTransformationPlans;

--- a/app/javascript/react/screens/App/Overview/components/AggregateCards/index.js
+++ b/app/javascript/react/screens/App/Overview/components/AggregateCards/index.js
@@ -1,11 +1,11 @@
 import NotStartedTransformationPlans from './NotStartedTransformationPlans/NotStartedTransformationPlans';
 import ActiveTransformationPlans from './ActiveTransformationPlans/ActiveTransformationPlans';
 import FinishedTransformationPlans from './FinishedTransformationPlans/FinishedTransformationPlans';
-import InfrastructureMappings from './InfrastructureMappings/InfrastructureMappings';
+import ArchivedTransformationPlans from './ArchivedTransformationPlans/ArchivedTransformationPlans';
 
 export {
   NotStartedTransformationPlans,
   ActiveTransformationPlans,
   FinishedTransformationPlans,
-  InfrastructureMappings
+  ArchivedTransformationPlans
 };

--- a/app/javascript/react/screens/App/Overview/components/Migrations/Migrations.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/Migrations.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Immutable from 'seamless-immutable';
-import { noop, DropdownButton, Grid, Icon, MenuItem } from 'patternfly-react';
+import { noop, Grid, Icon } from 'patternfly-react';
 import MigrationsInProgressCards from './MigrationsInProgressCards';
 import MigrationsNotStartedList from './MigrationsNotStartedList';
 import MigrationsCompletedList from './MigrationsCompletedList';
@@ -10,7 +10,6 @@ import { MIGRATIONS_FILTERS } from '../../OverviewConstants';
 
 const Migrations = ({
   activeFilter,
-  setActiveFilter,
   transformationPlans,
   allRequestsWithTasks,
   reloadCard,
@@ -44,23 +43,7 @@ const Migrations = ({
   fetchTransformationMappingsAction,
   showEditPlanNameModalAction
 }) => {
-  const filterOptions = [
-    MIGRATIONS_FILTERS.notStarted,
-    MIGRATIONS_FILTERS.inProgress,
-    MIGRATIONS_FILTERS.completed,
-    MIGRATIONS_FILTERS.archived
-  ];
-
   const plansExist = transformationPlans.length > 0 || archivedTransformationPlans.length > 0;
-  const onSelect = eventKey => {
-    if (eventKey === MIGRATIONS_FILTERS.archived) {
-      fetchTransformationPlansAction({
-        url: fetchArchivedTransformationPlansUrl,
-        archived: true
-      });
-    }
-    setActiveFilter(eventKey);
-  };
 
   return (
     <React.Fragment>
@@ -85,22 +68,7 @@ const Migrations = ({
           </div>
         </div>
         <hr style={{ borderTopColor: '#d1d1d1' }} />
-        {plansExist ? (
-          <div style={{ marginBottom: 15 }}>
-            <DropdownButton
-              bsStyle="default"
-              title={sprintf(__('%s'), activeFilter)}
-              id="dropdown-filter"
-              onSelect={eventKey => onSelect(eventKey)}
-            >
-              {filterOptions.map((filter, i) => (
-                <MenuItem eventKey={filter} active={filter === activeFilter} key={i}>
-                  {sprintf(__('%s'), filter)}
-                </MenuItem>
-              ))}
-            </DropdownButton>
-          </div>
-        ) : (
+        {!plansExist && (
           <ShowWizardEmptyState
             showWizardAction={() => createMigrationPlanClick()}
             description={__('Create a migration plan to select VMs for migration.')}
@@ -196,7 +164,6 @@ const Migrations = ({
 
 Migrations.propTypes = {
   activeFilter: PropTypes.string,
-  setActiveFilter: PropTypes.func,
   transformationPlans: PropTypes.array,
   allRequestsWithTasks: PropTypes.array,
   reloadCard: PropTypes.bool,

--- a/app/javascript/react/screens/App/Overview/components/Migrations/Migrations.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/Migrations.js
@@ -50,7 +50,7 @@ const Migrations = ({
       <Grid.Col xs={12}>
         <div className="heading-with-link-container">
           <div className="pull-left">
-            <h3>{__('Migration Plans')}</h3>
+            <h3>{activeFilter}</h3>
           </div>
           <div className="pull-right">
             {/** todo: create IconLink in patternfly-react * */}

--- a/app/javascript/react/screens/App/Overview/components/Migrations/__test__/Migrations.test.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/__test__/Migrations.test.js
@@ -1,10 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import { transformationPlans } from '../../../overview.transformationPlans.fixtures';
 import Migrations from '../Migrations';
-
-const { resources: plans } = transformationPlans;
 
 let createMigrationPlanClick;
 beforeEach(() => {
@@ -22,25 +19,4 @@ test('shows the empty state when there are no transformation plans', () => {
   );
 
   expect(wrapper.find('ShowWizardEmptyState').exists()).toBe(true);
-});
-
-test('selecting Archived Plans triggers an API call to fetch all archived plans', () => {
-  const fetchTransformationPlansAction = jest.fn();
-  const setActiveFilter = jest.fn();
-  const url = '/api/dummy';
-  const wrapper = shallow(
-    <Migrations
-      setActiveFilter={setActiveFilter}
-      transformationPlans={plans}
-      fetchTransformationPlansAction={fetchTransformationPlansAction}
-      fetchArchivedTransformationPlansUrl={url}
-    />
-  );
-
-  wrapper.find('DropdownButton').prop('onSelect')('Archived Plans');
-
-  expect(fetchTransformationPlansAction).toHaveBeenLastCalledWith({
-    archived: true,
-    url
-  });
 });


### PR DESCRIPTION
Fixes #563 
https://bugzilla.redhat.com/show_bug.cgi?id=1640594

# Notes
- Replaces infra mappings aggregate card with archived plans card
- Removes migration select
- Clicking on a aggregate card will show the corresponding listview in the migration plans section
- The active card gets a full border

# Screens
<img width="1920" alt="fullscreen_10_19_18__2_51_pm" src="https://user-images.githubusercontent.com/15141412/47237961-92796680-d3ae-11e8-9d34-5f11f396e450.png">

