### PR TITLE
convert `scheduleTime` to a Date object before passing to backend

### DIFF
--- a/app/javascript/react/screens/App/Overview/OverviewActions.js
+++ b/app/javascript/react/screens/App/Overview/OverviewActions.js
@@ -203,7 +203,7 @@ export const scheduleMigration = payload => dispatch =>
       let body = {
         action: 'order',
         resource: {
-          schedule_time: scheduleTime
+          schedule_time: new Date(scheduleTime)
         }
       };
       if (scheduleId) {


### PR DESCRIPTION
Converts `scheduleTime` to a Date object before passing to backend.

This seems to be kicking off scheduled migrations without any other timezone related settings applied to the appliance.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1630446

@mturley Can you confirm if this indeed fixes the issue?
Thanks.