### PR TITLE
[#376] Add Edit schedule feature, move Unschedule button to Delete schedule menu item

### DIFF
--- a/app/javascript/react/screens/App/Overview/components/Migrations/DeleteMigrationMenuItem.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/DeleteMigrationMenuItem.js
@@ -61,7 +61,7 @@ const DeleteMigrationMenuItem = ({
         });
       }}
     >
-      {__('Delete')}
+      {__('Delete plan')}
     </MenuItem>
   );
 };

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
@@ -211,6 +211,9 @@ class MigrationsCompletedList extends React.Component {
                         fetchTransformationPlansUrl={fetchTransformationPlansUrl}
                         plan={plan}
                         isMissingMapping={isMissingMapping}
+                        migrationScheduled={migrationScheduled}
+                        migrationStarting={migrationStarting}
+                        showInitialScheduleButton={showInitialScheduleButton}
                       />
                     );
 

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
@@ -7,7 +7,7 @@ import getMostRecentRequest from '../../../common/getMostRecentRequest';
 import getMostRecentVMTasksFromRequests from './helpers/getMostRecentVMTasksFromRequests';
 import sortFilter from '../../../common/ListViewToolbar/sortFilter';
 import { MIGRATIONS_COMPLETED_SORT_FIELDS } from './MigrationsConstants';
-import ScheduleMigrationButton from './ScheduleMigrationButton';
+import ScheduleMigrationButtons from './ScheduleMigrationButtons';
 import ScheduleMigrationModal from '../ScheduleMigrationModal/ScheduleMigrationModal';
 import { formatDateTime } from '../../../../../../components/dates/MomentDate';
 import DeleteMigrationMenuItem from './DeleteMigrationMenuItem';
@@ -272,7 +272,7 @@ class MigrationsCompletedList extends React.Component {
                             {!archived &&
                               failed && (
                                 <React.Fragment>
-                                  <ScheduleMigrationButton
+                                  <ScheduleMigrationButtons
                                     showConfirmModalAction={showConfirmModalAction}
                                     hideConfirmModalAction={hideConfirmModalAction}
                                     loading={loading}

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
@@ -103,7 +103,12 @@ class MigrationsCompletedList extends React.Component {
                 )}
                 <ListView className="plans-complete-list" style={{ marginTop: 0 }}>
                   {sortedMigrations.map(plan => {
-                    const { migrationScheduled, staleMigrationSchedule, migrationStarting } = getPlanScheduleInfo(plan);
+                    const {
+                      migrationScheduled,
+                      staleMigrationSchedule,
+                      migrationStarting,
+                      showInitialScheduleButton
+                    } = getPlanScheduleInfo(plan);
 
                     const requestsOfAssociatedPlan = allRequestsWithTasks.filter(
                       request => request.source_id === plan.id
@@ -195,6 +200,20 @@ class MigrationsCompletedList extends React.Component {
 
                     const isMissingMapping = !plan.infraMappingName;
 
+                    const scheduleButtons = (
+                      <ScheduleMigrationButtons
+                        showConfirmModalAction={showConfirmModalAction}
+                        hideConfirmModalAction={hideConfirmModalAction}
+                        loading={loading}
+                        toggleScheduleMigrationModal={toggleScheduleMigrationModal}
+                        scheduleMigration={scheduleMigration}
+                        fetchTransformationPlansAction={fetchTransformationPlansAction}
+                        fetchTransformationPlansUrl={fetchTransformationPlansUrl}
+                        plan={plan}
+                        isMissingMapping={isMissingMapping}
+                      />
+                    );
+
                     return (
                       <ListView.Item
                         stacked
@@ -272,17 +291,7 @@ class MigrationsCompletedList extends React.Component {
                             {!archived &&
                               failed && (
                                 <React.Fragment>
-                                  <ScheduleMigrationButtons
-                                    showConfirmModalAction={showConfirmModalAction}
-                                    hideConfirmModalAction={hideConfirmModalAction}
-                                    loading={loading}
-                                    toggleScheduleMigrationModal={toggleScheduleMigrationModal}
-                                    scheduleMigration={scheduleMigration}
-                                    fetchTransformationPlansAction={fetchTransformationPlansAction}
-                                    fetchTransformationPlansUrl={fetchTransformationPlansUrl}
-                                    plan={plan}
-                                    isMissingMapping={isMissingMapping}
-                                  />
+                                  {showInitialScheduleButton && scheduleButtons}
                                   <Button
                                     onClick={e => {
                                       e.stopPropagation();
@@ -303,7 +312,7 @@ class MigrationsCompletedList extends React.Component {
                                       showConfirmModalAction(confirmModalOptions);
                                     }}
                                   >
-                                    {__('Archive')}
+                                    {__('Archive plan')}
                                   </MenuItem>
                                 )}
                                 <MenuItem
@@ -312,7 +321,7 @@ class MigrationsCompletedList extends React.Component {
                                     showEditPlanNameModalAction(plan.id);
                                   }}
                                 >
-                                  {__('Edit')}
+                                  {__('Edit plan')}
                                 </MenuItem>
                                 <DeleteMigrationMenuItem
                                   showConfirmModalAction={showConfirmModalAction}
@@ -329,6 +338,7 @@ class MigrationsCompletedList extends React.Component {
                                   fetchTransformationMappingsAction={fetchTransformationMappingsAction}
                                   fetchTransformationMappingsUrl={fetchTransformationMappingsUrl}
                                 />
+                                {!showInitialScheduleButton && scheduleButtons}
                               </DropdownKebab>
                             </StopPropagationOnClick>
                           </div>

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
@@ -92,10 +92,26 @@ class MigrationsNotStartedList extends React.Component {
                 </Grid.Row>
                 <ListView className="plans-not-started-list" style={{ marginTop: 0 }}>
                   {sortedMigrations.map(plan => {
-                    const { migrationScheduled, migrationStarting } = getPlanScheduleInfo(plan);
+                    const { migrationScheduled, migrationStarting, showInitialScheduleButton } = getPlanScheduleInfo(
+                      plan
+                    );
                     const isMissingMapping = !plan.infraMappingName;
 
                     const editPlanDisabled = isMissingMapping || loading === plan.href;
+
+                    const scheduleButtons = (
+                      <ScheduleMigrationButtons
+                        showConfirmModalAction={showConfirmModalAction}
+                        hideConfirmModalAction={hideConfirmModalAction}
+                        loading={loading}
+                        toggleScheduleMigrationModal={toggleScheduleMigrationModal}
+                        scheduleMigration={scheduleMigration}
+                        fetchTransformationPlansAction={fetchTransformationPlansAction}
+                        fetchTransformationPlansUrl={fetchTransformationPlansUrl}
+                        plan={plan}
+                        isMissingMapping={isMissingMapping}
+                      />
+                    );
 
                     return (
                       <ListView.Item
@@ -106,17 +122,7 @@ class MigrationsNotStartedList extends React.Component {
                         }}
                         actions={
                           <div>
-                            <ScheduleMigrationButtons
-                              showConfirmModalAction={showConfirmModalAction}
-                              hideConfirmModalAction={hideConfirmModalAction}
-                              loading={loading}
-                              toggleScheduleMigrationModal={toggleScheduleMigrationModal}
-                              scheduleMigration={scheduleMigration}
-                              fetchTransformationPlansAction={fetchTransformationPlansAction}
-                              fetchTransformationPlansUrl={fetchTransformationPlansUrl}
-                              plan={plan}
-                              isMissingMapping={isMissingMapping}
-                            />
+                            {showInitialScheduleButton && scheduleButtons}
                             <Button
                               id={`migrate_${plan.id}`}
                               onClick={e => {
@@ -138,7 +144,7 @@ class MigrationsNotStartedList extends React.Component {
                                   }}
                                   disabled={editPlanDisabled}
                                 >
-                                  {__('Edit')}
+                                  {__('Edit plan')}
                                 </MenuItem>
                                 <DeleteMigrationMenuItem
                                   showConfirmModalAction={showConfirmModalAction}
@@ -153,6 +159,7 @@ class MigrationsNotStartedList extends React.Component {
                                   fetchTransformationMappingsAction={fetchTransformationMappingsAction}
                                   fetchTransformationMappingsUrl={fetchTransformationMappingsUrl}
                                 />
+                                {!showInitialScheduleButton && scheduleButtons}
                               </DropdownKebab>
                             </StopPropagationOnClick>
                           </div>

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
@@ -7,7 +7,7 @@ import ScheduleMigrationModal from '../ScheduleMigrationModal/ScheduleMigrationM
 import { formatDateTime } from '../../../../../../components/dates/MomentDate';
 import { MIGRATIONS_NOT_STARTED_SORT_FIELDS } from './MigrationsConstants';
 import sortFilter from '../../../common/ListViewToolbar/sortFilter';
-import ScheduleMigrationButton from './ScheduleMigrationButton';
+import ScheduleMigrationButtons from './ScheduleMigrationButtons';
 import StopPropagationOnClick from '../../../common/StopPropagationOnClick';
 import DeleteMigrationMenuItem from './DeleteMigrationMenuItem';
 import getPlanScheduleInfo from './helpers/getPlanScheduleInfo';
@@ -106,7 +106,7 @@ class MigrationsNotStartedList extends React.Component {
                         }}
                         actions={
                           <div>
-                            <ScheduleMigrationButton
+                            <ScheduleMigrationButtons
                               showConfirmModalAction={showConfirmModalAction}
                               hideConfirmModalAction={hideConfirmModalAction}
                               loading={loading}

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
@@ -110,6 +110,9 @@ class MigrationsNotStartedList extends React.Component {
                         fetchTransformationPlansUrl={fetchTransformationPlansUrl}
                         plan={plan}
                         isMissingMapping={isMissingMapping}
+                        migrationScheduled={migrationScheduled}
+                        migrationStarting={migrationStarting}
+                        showInitialScheduleButton={showInitialScheduleButton}
                       />
                     );
 

--- a/app/javascript/react/screens/App/Overview/components/Migrations/ScheduleMigrationButton.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/ScheduleMigrationButton.js
@@ -64,20 +64,32 @@ const ScheduleMigrationButton = ({
         </Button>
       )}
       {!showScheduleButton && (
-        <Button
-          id={`unschedule_${plan.id}`}
-          onClick={e => {
-            e.stopPropagation();
+        <React.Fragment>
+          <Button
+            id={`edit_schedule_${plan.id}`}
+            onClick={e => {
+              e.stopPropagation();
+              toggleScheduleMigrationModal({ plan });
+            }}
+            disabled={isMissingMapping || loading === plan.href}
+          >
+            {__('Edit Schedule')}
+          </Button>
+          <Button
+            id={`unschedule_${plan.id}`}
+            onClick={e => {
+              e.stopPropagation();
 
-            showConfirmModalAction({
-              ...confirmModalProps,
-              onConfirm
-            });
-          }}
-          disabled={isMissingMapping || loading === plan.href || migrationStarting}
-        >
-          {__('Unschedule')}
-        </Button>
+              showConfirmModalAction({
+                ...confirmModalProps,
+                onConfirm
+              });
+            }}
+            disabled={isMissingMapping || loading === plan.href || migrationStarting}
+          >
+            {__('Delete Schedule')}
+          </Button>
+        </React.Fragment>
       )}
     </React.Fragment>
   );

--- a/app/javascript/react/screens/App/Overview/components/Migrations/ScheduleMigrationButtons.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/ScheduleMigrationButtons.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Button, MenuItem, Icon } from 'patternfly-react';
 import { formatDateTime } from '../../../../../../components/dates/MomentDate';
-import getPlanScheduleInfo from './helpers/getPlanScheduleInfo';
 
 const ScheduleMigrationButtons = ({
   showConfirmModalAction,
@@ -13,10 +12,11 @@ const ScheduleMigrationButtons = ({
   fetchTransformationPlansAction,
   fetchTransformationPlansUrl,
   plan,
-  isMissingMapping
+  isMissingMapping,
+  migrationScheduled,
+  migrationStarting,
+  showInitialScheduleButton
 }) => {
-  const { migrationScheduled, migrationStarting, showInitialScheduleButton } = getPlanScheduleInfo(plan);
-
   const confirmationWarningText = (
     <React.Fragment>
       <p>
@@ -108,7 +108,10 @@ ScheduleMigrationButtons.propTypes = {
   fetchTransformationPlansAction: PropTypes.func,
   fetchTransformationPlansUrl: PropTypes.string,
   plan: PropTypes.object,
-  isMissingMapping: PropTypes.bool
+  isMissingMapping: PropTypes.bool,
+  migrationScheduled: PropTypes.oneOfType(PropTypes.string, PropTypes.number),
+  migrationStarting: PropTypes.bool,
+  showInitialScheduleButton: PropTypes.bool
 };
 
 export default ScheduleMigrationButtons;

--- a/app/javascript/react/screens/App/Overview/components/Migrations/ScheduleMigrationButtons.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/ScheduleMigrationButtons.js
@@ -4,7 +4,7 @@ import { Button, Icon } from 'patternfly-react';
 import { formatDateTime } from '../../../../../../components/dates/MomentDate';
 import getPlanScheduleInfo from './helpers/getPlanScheduleInfo';
 
-const ScheduleMigrationButton = ({
+const ScheduleMigrationButtons = ({
   showConfirmModalAction,
   hideConfirmModalAction,
   loading,
@@ -95,7 +95,7 @@ const ScheduleMigrationButton = ({
   );
 };
 
-ScheduleMigrationButton.propTypes = {
+ScheduleMigrationButtons.propTypes = {
   showConfirmModalAction: PropTypes.func,
   hideConfirmModalAction: PropTypes.func,
   loading: PropTypes.string,
@@ -107,4 +107,4 @@ ScheduleMigrationButton.propTypes = {
   isMissingMapping: PropTypes.bool
 };
 
-export default ScheduleMigrationButton;
+export default ScheduleMigrationButtons;

--- a/app/javascript/react/screens/App/Overview/components/Migrations/ScheduleMigrationButtons.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/ScheduleMigrationButtons.js
@@ -109,7 +109,7 @@ ScheduleMigrationButtons.propTypes = {
   fetchTransformationPlansUrl: PropTypes.string,
   plan: PropTypes.object,
   isMissingMapping: PropTypes.bool,
-  migrationScheduled: PropTypes.oneOfType(PropTypes.string, PropTypes.number),
+  migrationScheduled: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   migrationStarting: PropTypes.bool,
   showInitialScheduleButton: PropTypes.bool
 };

--- a/app/javascript/react/screens/App/Overview/components/Migrations/ScheduleMigrationButtons.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/ScheduleMigrationButtons.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button, Icon } from 'patternfly-react';
+import { Button, MenuItem, Icon } from 'patternfly-react';
 import { formatDateTime } from '../../../../../../components/dates/MomentDate';
 import getPlanScheduleInfo from './helpers/getPlanScheduleInfo';
 
@@ -15,8 +15,7 @@ const ScheduleMigrationButtons = ({
   plan,
   isMissingMapping
 }) => {
-  const { migrationScheduled, staleMigrationSchedule, migrationStarting } = getPlanScheduleInfo(plan);
-  const showScheduleButton = staleMigrationSchedule && !migrationStarting;
+  const { migrationScheduled, migrationStarting, showInitialScheduleButton } = getPlanScheduleInfo(plan);
 
   const confirmationWarningText = (
     <React.Fragment>
@@ -49,9 +48,11 @@ const ScheduleMigrationButtons = ({
     hideConfirmModalAction();
   };
 
+  const editScheduleDisabled = isMissingMapping || loading === plan.href || migrationStarting;
+
   return (
     <React.Fragment>
-      {showScheduleButton && (
+      {showInitialScheduleButton && (
         <Button
           id={`schedule_${plan.id}`}
           onClick={e => {
@@ -63,32 +64,35 @@ const ScheduleMigrationButtons = ({
           {__('Schedule')}
         </Button>
       )}
-      {!showScheduleButton && (
+      {!showInitialScheduleButton && (
         <React.Fragment>
-          <Button
+          <MenuItem
             id={`edit_schedule_${plan.id}`}
             onClick={e => {
               e.stopPropagation();
-              toggleScheduleMigrationModal({ plan });
+              if (!editScheduleDisabled) {
+                toggleScheduleMigrationModal({ plan });
+              }
             }}
-            disabled={isMissingMapping || loading === plan.href}
+            disabled={editScheduleDisabled}
           >
-            {__('Edit Schedule')}
-          </Button>
-          <Button
+            {__('Edit schedule')}
+          </MenuItem>
+          <MenuItem
             id={`unschedule_${plan.id}`}
             onClick={e => {
               e.stopPropagation();
-
-              showConfirmModalAction({
-                ...confirmModalProps,
-                onConfirm
-              });
+              if (!editScheduleDisabled) {
+                showConfirmModalAction({
+                  ...confirmModalProps,
+                  onConfirm
+                });
+              }
             }}
-            disabled={isMissingMapping || loading === plan.href || migrationStarting}
+            disabled={editScheduleDisabled}
           >
-            {__('Delete Schedule')}
-          </Button>
+            {__('Delete schedule')}
+          </MenuItem>
         </React.Fragment>
       )}
     </React.Fragment>

--- a/app/javascript/react/screens/App/Overview/components/Migrations/__test__/MigrationsCompletedList.test.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/__test__/MigrationsCompletedList.test.js
@@ -42,7 +42,7 @@ describe('when displaying archived migration plans', () => {
     );
 
     wrapper.find('ListViewItem').forEach(item => {
-      const archiveButton = item.find('a').filterWhere(link => link.text() === 'Archive');
+      const archiveButton = item.find('a').filterWhere(link => link.text() === 'Archive plan');
       expect(archiveButton).toHaveLength(0);
     });
   });
@@ -79,7 +79,7 @@ describe('when displaying active (not archived) migration plans', () => {
 
   test('clicking the archive button launches the confirmation modal', () => {
     wrapper.find('ListViewItem').forEach(item => {
-      const archiveButton = item.find('a').filterWhere(link => link.text() === 'Archive');
+      const archiveButton = item.find('a').filterWhere(link => link.text() === 'Archive plan');
 
       archiveButton.simulate('click');
 

--- a/app/javascript/react/screens/App/Overview/components/Migrations/helpers/getPlanScheduleInfo.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/helpers/getPlanScheduleInfo.js
@@ -1,11 +1,13 @@
 const getPlanScheduleInfo = plan => {
-  const migrationScheduled = (plan.schedules && plan.schedules[0].run_at.start_time) || 0;
+  const migrationScheduled = (plan && plan.schedules && plan.schedules[0].run_at.start_time) || 0;
   const staleMigrationSchedule = new Date(migrationScheduled).getTime() < Date.now();
   const migrationStarting = staleMigrationSchedule && new Date(migrationScheduled).getTime() > Date.now() - 120000;
+  const showInitialScheduleButton = staleMigrationSchedule && !migrationStarting;
   return {
     migrationScheduled,
     staleMigrationSchedule,
-    migrationStarting
+    migrationStarting,
+    showInitialScheduleButton
   };
 };
 

--- a/app/javascript/react/screens/App/Overview/components/ScheduleMigrationModal/ScheduleMigrationModal.js
+++ b/app/javascript/react/screens/App/Overview/components/ScheduleMigrationModal/ScheduleMigrationModal.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Button, Modal } from 'patternfly-react';
 import ScheduleMigrationModalBody from './ScheduleMigrationModalBody';
+import getPlanScheduleInfo from '../Migrations/helpers/getPlanScheduleInfo';
 
 class ScheduleMigrationModal extends React.Component {
   state = { dateTimeInput: '' };
@@ -15,6 +16,8 @@ class ScheduleMigrationModal extends React.Component {
       fetchTransformationPlansAction,
       fetchTransformationPlansUrl
     } = this.props;
+
+    const { migrationScheduled } = getPlanScheduleInfo(scheduleMigrationPlan);
 
     const handleChange = event => {
       this.setState({ dateTimeInput: event });
@@ -32,7 +35,7 @@ class ScheduleMigrationModal extends React.Component {
           <Modal.Title>{__('Schedule Migration Plan')}</Modal.Title>
         </Modal.Header>
         <Modal.Body>
-          <ScheduleMigrationModalBody handleChange={handleChange} />
+          <ScheduleMigrationModalBody handleChange={handleChange} defaultDate={migrationScheduled} />
         </Modal.Body>
         <Modal.Footer>
           <Button bsStyle="default" className="btn-cancel" onClick={modalClose}>

--- a/app/javascript/react/screens/App/Overview/components/ScheduleMigrationModal/ScheduleMigrationModal.js
+++ b/app/javascript/react/screens/App/Overview/components/ScheduleMigrationModal/ScheduleMigrationModal.js
@@ -35,7 +35,7 @@ class ScheduleMigrationModal extends React.Component {
           <Modal.Title>{__('Schedule Migration Plan')}</Modal.Title>
         </Modal.Header>
         <Modal.Body>
-          <ScheduleMigrationModalBody handleChange={handleChange} defaultDate={migrationScheduled} />
+          <ScheduleMigrationModalBody handleChange={handleChange} defaultDate={migrationScheduled || ''} />
         </Modal.Body>
         <Modal.Footer>
           <Button bsStyle="default" className="btn-cancel" onClick={modalClose}>

--- a/app/javascript/react/screens/App/Overview/components/ScheduleMigrationModal/ScheduleMigrationModalBody.js
+++ b/app/javascript/react/screens/App/Overview/components/ScheduleMigrationModal/ScheduleMigrationModalBody.js
@@ -47,7 +47,8 @@ class ScheduleMigrationModalBody extends React.Component {
 }
 
 ScheduleMigrationModalBody.propTypes = {
-  handleChange: PropTypes.func
+  handleChange: PropTypes.func,
+  defaultDate: PropTypes.string
 };
 
 export default ScheduleMigrationModalBody;

--- a/app/javascript/react/screens/App/Overview/components/ScheduleMigrationModal/ScheduleMigrationModalBody.js
+++ b/app/javascript/react/screens/App/Overview/components/ScheduleMigrationModal/ScheduleMigrationModalBody.js
@@ -8,6 +8,8 @@ class ScheduleMigrationModalBody extends React.Component {
     const datetimeSelector = $('#dateTimePicker');
 
     datetimeSelector.datetimepicker({
+      defaultDate: defaultDate ? new Date(defaultDate) : false,
+      useCurrent: !defaultDate,
       allowInputToggle: true,
       showTodayButton: true,
       minDate: new Date(Date.now() + 120000),
@@ -23,9 +25,6 @@ class ScheduleMigrationModalBody extends React.Component {
     });
 
     const picker = datetimeSelector.data('DateTimePicker');
-    if (defaultDate) {
-      picker.date(new Date(defaultDate));
-    }
     handleChange(picker.date().toDate());
   }
   render() {

--- a/app/javascript/react/screens/App/Overview/components/ScheduleMigrationModal/ScheduleMigrationModalBody.js
+++ b/app/javascript/react/screens/App/Overview/components/ScheduleMigrationModal/ScheduleMigrationModalBody.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 
 class ScheduleMigrationModalBody extends React.Component {
   componentDidMount() {
-    const { handleChange } = this.props;
+    const { handleChange, defaultDate } = this.props;
     const datetimeSelector = $('#dateTimePicker');
 
     datetimeSelector.datetimepicker({
@@ -23,6 +23,9 @@ class ScheduleMigrationModalBody extends React.Component {
     });
 
     const picker = datetimeSelector.data('DateTimePicker');
+    if (defaultDate) {
+      picker.date(new Date(defaultDate));
+    }
     handleChange(picker.date().toDate());
   }
   render() {


### PR DESCRIPTION
Closes #376.
https://bugzilla.redhat.com/show_bug.cgi?id=1640779

For Not Started and Failed plans, if the plan is not scheduled, the existing Schedule button remains in place. If the plan is scheduled, "Edit schedule" and "Delete schedule" now appear in the kebab menu. "Edit" and "Delete" have been renamed to "Edit plan" and "Delete plan" for consistency and disambiguation.

When clicking the "Edit schedule" button, the schedule modal is pre-filled with the existing scheduled time.

![screenshot 2018-10-18 14 11 38](https://user-images.githubusercontent.com/811963/47174973-1e708d00-d2e0-11e8-97f8-85ca4f84d2eb.png)

![screenshot 2018-10-18 14 11 29](https://user-images.githubusercontent.com/811963/47174990-27f9f500-d2e0-11e8-816b-76ea0441dbc6.png)


(Replaces #707)