### PR TITLE
V2V Overview menu item: fix menu item highlighting

### DIFF
--- a/lib/manageiq/v2v/engine.rb
+++ b/lib/manageiq/v2v/engine.rb
@@ -13,7 +13,7 @@ module ManageIQ::V2V
     initializer 'plugin' do
       Menu::CustomLoader.register(
         Menu::Section.new(:migration, N_("Migration"), 'fa fa-plus', [
-          Menu::Item.new('overview', N_("Overview"), 'miq_report', {:feature => 'miq_report', :any => true}, '/migration'),
+          Menu::Item.new('migration', N_("Overview"), 'miq_report', {:feature => 'miq_report', :any => true}, '/migration'),
           Menu::Item.new('mappings', N_("Infrastructure Mappings"), 'miq_report', {:feature => 'miq_report', :any => true}, '/migration#/mappings')
         ], nil, nil, nil, nil, :compute)
       )


### PR DESCRIPTION
Before:
![v2v-menu-before](https://user-images.githubusercontent.com/6648365/47356374-28213880-d6c4-11e8-8c81-94c682af55e5.jpg)

After:
![v2v-menu-after](https://user-images.githubusercontent.com/6648365/47356378-2bb4bf80-d6c4-11e8-916c-52f80ddb5013.jpg)

The menu item `id` needs to match `@layout` for the menu item to be properly highlighted. See https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/helpers/application_helper/navbar.rb#L12 

Fixes https://github.com/ManageIQ/manageiq-v2v/issues/726