### PR TITLE
[#724] Add sorting, filtering and pagination to Migration Plan list views

### DIFF
--- a/app/javascript/react/screens/App/Mappings/components/InfrastructureMappingsList/InfrastructureMappingsList.js
+++ b/app/javascript/react/screens/App/Mappings/components/InfrastructureMappingsList/InfrastructureMappingsList.js
@@ -117,7 +117,9 @@ class InfrastructureMappingsList extends React.Component {
       <React.Fragment>
         <ListViewToolbar
           filterTypes={INFRA_MAPPINGS_FILTER_TYPES}
+          defaultFilterTypeIndex={0}
           sortFields={INFRA_MAPPINGS_SORT_FIELDS}
+          defaultSortTypeIndex={1}
           listItems={transformationMappingsMutable}
           render={(
             {

--- a/app/javascript/react/screens/App/Mappings/components/InfrastructureMappingsList/InfrastructureMappingsList.js
+++ b/app/javascript/react/screens/App/Mappings/components/InfrastructureMappingsList/InfrastructureMappingsList.js
@@ -117,9 +117,7 @@ class InfrastructureMappingsList extends React.Component {
       <React.Fragment>
         <ListViewToolbar
           filterTypes={INFRA_MAPPINGS_FILTER_TYPES}
-          defaultFilterTypeIndex={0}
           sortFields={INFRA_MAPPINGS_SORT_FIELDS}
-          defaultSortTypeIndex={1}
           listItems={transformationMappingsMutable}
         >
           {(

--- a/app/javascript/react/screens/App/Mappings/components/InfrastructureMappingsList/InfrastructureMappingsList.js
+++ b/app/javascript/react/screens/App/Mappings/components/InfrastructureMappingsList/InfrastructureMappingsList.js
@@ -121,7 +121,8 @@ class InfrastructureMappingsList extends React.Component {
           sortFields={INFRA_MAPPINGS_SORT_FIELDS}
           defaultSortTypeIndex={1}
           listItems={transformationMappingsMutable}
-          render={(
+        >
+          {(
             {
               filterTypes,
               currentFilterType,
@@ -134,7 +135,7 @@ class InfrastructureMappingsList extends React.Component {
               pageChangeValue
             },
             {
-              filterSortPaginateListItems,
+              filteredSortedPaginatedListItems,
               selectFilterType,
               renderInput,
               updateCurrentSortType,
@@ -149,9 +150,8 @@ class InfrastructureMappingsList extends React.Component {
               onLastPage,
               onSubmit
             }
-          ) => {
-            const paginatedSortedFiltersMappings = filterSortPaginateListItems();
-            return error ? (
+          ) =>
+            error ? (
               <ShowWizardEmptyState
                 title={__('Error loading mappings.')}
                 iconType="pf"
@@ -208,8 +208,8 @@ class InfrastructureMappingsList extends React.Component {
                       activeFilters.length > 0 && (
                         <Toolbar.Results>
                           <h5>
-                            {paginatedSortedFiltersMappings.itemCount}{' '}
-                            {paginatedSortedFiltersMappings.itemCount === 1 ? __('Result') : __('Results')}
+                            {filteredSortedPaginatedListItems.itemCount}{' '}
+                            {filteredSortedPaginatedListItems.itemCount === 1 ? __('Result') : __('Results')}
                           </h5>
                           <Filter.ActiveLabel>{__('Active Filters')}:</Filter.ActiveLabel>
                           <Filter.List>
@@ -234,7 +234,7 @@ class InfrastructureMappingsList extends React.Component {
                 </Grid.Row>
                 <div style={{ overflow: 'auto', paddingBottom: 300, height: '100%' }}>
                   <ListView style={{ marginTop: 10 }} className="infra-mappings-list-view" id="infrastructure_mappings">
-                    {paginatedSortedFiltersMappings.tasks.map(mapping => {
+                    {filteredSortedPaginatedListItems.tasks.map(mapping => {
                       const associatedPlansCount = mapping.service_templates && mapping.service_templates.length;
 
                       const { targetClusters, targetDatastores, targetNetworks } = mapInfrastructureMappings(
@@ -579,10 +579,10 @@ class InfrastructureMappingsList extends React.Component {
                     viewType={PAGINATION_VIEW.LIST}
                     pagination={pagination}
                     pageInputValue={pageChangeValue}
-                    amountOfPages={paginatedSortedFiltersMappings.amountOfPages}
-                    itemCount={paginatedSortedFiltersMappings.itemCount}
-                    itemsStart={paginatedSortedFiltersMappings.itemsStart}
-                    itemsEnd={paginatedSortedFiltersMappings.itemsEnd}
+                    amountOfPages={filteredSortedPaginatedListItems.amountOfPages}
+                    itemCount={filteredSortedPaginatedListItems.itemCount}
+                    itemsStart={filteredSortedPaginatedListItems.itemsStart}
+                    itemsEnd={filteredSortedPaginatedListItems.itemsEnd}
                     onPerPageSelect={onPerPageSelect}
                     onFirstPage={onFirstPage}
                     onPreviousPage={onPreviousPage}
@@ -595,9 +595,9 @@ class InfrastructureMappingsList extends React.Component {
               </React.Fragment>
             ) : (
               this.renderEmptyState()
-            );
-          }}
-        />
+            )
+          }
+        </ListViewToolbar>
         <DeleteInfrastructureMappingConfirmationModal
           showDeleteConfirmationModal={showDeleteConfirmationModal}
           hideDeleteConfirmationModalAction={hideDeleteConfirmationModalAction}

--- a/app/javascript/react/screens/App/Overview/Overview.js
+++ b/app/javascript/react/screens/App/Overview/Overview.js
@@ -269,9 +269,8 @@ class Overview extends React.Component {
       openMappingWizardOnTransitionAction
     } = this.props;
 
-    const overviewContent = (
-      <div className="row cards-pf" style={{ overflow: 'auto', paddingBottom: 1, height: '100%' }}>
-        {this.renderAggregateDataCards()}
+    const mainContent = (
+      <React.Fragment>
         <Spinner
           loading={
             isFetchingProviders ||
@@ -349,8 +348,24 @@ class Overview extends React.Component {
           fetchTransformationPlansUrl={fetchTransformationPlansUrl}
           fetchArchivedTransformationPlansUrl={fetchArchivedTransformationPlansUrl}
         />
-      </div>
+      </React.Fragment>
     );
+
+    // Full-height grey background (.cards-pf) for in-progress cards, otherwise only grey behind aggregate cards
+    const overviewContent =
+      migrationsFilter === MIGRATIONS_FILTERS.inProgress ? (
+        <div className="row cards-pf" style={{ overflow: 'auto', paddingBottom: 1, height: '100%' }}>
+          {this.renderAggregateDataCards()}
+          {mainContent}
+        </div>
+      ) : (
+        <React.Fragment>
+          <div className="row cards-pf" style={{ overflow: 'auto', paddingBottom: 1 }}>
+            {this.renderAggregateDataCards()}
+          </div>
+          <div className="row">{mainContent}</div>
+        </React.Fragment>
+      );
 
     const toolbarContent = (
       <Toolbar>

--- a/app/javascript/react/screens/App/Overview/Overview.js
+++ b/app/javascript/react/screens/App/Overview/Overview.js
@@ -351,9 +351,18 @@ class Overview extends React.Component {
       </React.Fragment>
     );
 
-    // Full-height grey background (.cards-pf) for in-progress cards, otherwise only grey behind aggregate cards
+    const inProgressCardsVisible =
+      migrationsFilter === MIGRATIONS_FILTERS.inProgress && activeTransformationPlans.length > 0;
+
+    const emptyStateVisible =
+      (migrationsFilter === MIGRATIONS_FILTERS.notStarted && notStartedTransformationPlans.length === 0) ||
+      (migrationsFilter === MIGRATIONS_FILTERS.inProgress && activeTransformationPlans.length === 0) ||
+      (migrationsFilter === MIGRATIONS_FILTERS.completed && finishedTransformationPlans.length === 0) ||
+      (migrationsFilter === MIGRATIONS_FILTERS.archived && archivedTransformationPlans.length === 0);
+
+    // Full-height grey background (.cards-pf) for in-progress cards and empty states, otherwise only grey behind aggregate cards
     const overviewContent =
-      migrationsFilter === MIGRATIONS_FILTERS.inProgress ? (
+      inProgressCardsVisible || emptyStateVisible ? (
         <div className="row cards-pf" style={{ overflow: 'auto', paddingBottom: 1, height: '100%' }}>
           {this.renderAggregateDataCards()}
           {mainContent}

--- a/app/javascript/react/screens/App/Overview/components/Migrations/Migrations.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/Migrations.js
@@ -67,15 +67,18 @@ const Migrations = ({
             </a>
           </div>
         </div>
-        <hr style={{ borderTopColor: '#d1d1d1' }} />
+        <hr style={{ borderTopColor: '#d1d1d1', marginBottom: 0, marginLeft: '-20px', marginRight: '-20px' }} />
         {!plansExist && (
-          <ShowWizardEmptyState
-            showWizardAction={() => createMigrationPlanClick()}
-            description={__('Create a migration plan to select VMs for migration.')}
-            buttonText={__('Create Migration Plan')}
-          />
+          <div style={{ marginLeft: '-20px', marginRight: '-20px', marginBottom: '-20px' }}>
+            <ShowWizardEmptyState
+              showWizardAction={() => createMigrationPlanClick()}
+              description={__('Create a migration plan to select VMs for migration.')}
+              buttonText={__('Create Migration Plan')}
+            />
+          </div>
         )}
       </Grid.Col>
+
       {plansExist && (
         <div className="migrations">
           {activeFilter === MIGRATIONS_FILTERS.notStarted && (

--- a/app/javascript/react/screens/App/Overview/components/Migrations/Migrations.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/Migrations.js
@@ -47,7 +47,7 @@ const Migrations = ({
 
   return (
     <React.Fragment>
-      <Grid.Col xs={12}>
+      <Grid.Col xs={12} style={{ backgroundColor: '#fff' }}>
         <div className="heading-with-link-container">
           <div className="pull-left">
             <h3>{activeFilter}</h3>

--- a/app/javascript/react/screens/App/Overview/components/Migrations/Migrations.scss
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/Migrations.scss
@@ -26,15 +26,3 @@
     margin-right: 5px;
   }
 }
-
-.migrations {
-  .toolbar-pf {
-    background: none;
-    border-bottom: none;
-    box-shadow: none;
-
-    .form-group {
-      padding-left: 0;
-    }
-  }
-}

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
@@ -63,7 +63,6 @@ const MigrationsCompletedList = ({
         {finishedTransformationPlans.length > 0 ? (
           <ListViewToolbar
             filterTypes={MIGRATIONS_FILTER_TYPES}
-            defaultFilterTypeIndex={0}
             sortFields={!archived ? MIGRATIONS_COMPLETED_SORT_FIELDS : MIGRATIONS_ARCHIVED_SORT_FIELDS}
             defaultSortTypeIndex={!archived ? 1 : 0}
             listItems={finishedTransformationPlans}

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
@@ -20,7 +20,11 @@ import ShowWizardEmptyState from '../../../common/ShowWizardEmptyState/ShowWizar
 import getMostRecentRequest from '../../../common/getMostRecentRequest';
 import getMostRecentVMTasksFromRequests from './helpers/getMostRecentVMTasksFromRequests';
 import ListViewToolbar from '../../../common/ListViewToolbar/ListViewToolbar';
-import { MIGRATIONS_COMPLETED_SORT_FIELDS, MIGRATIONS_FILTER_TYPES } from './MigrationsConstants';
+import {
+  MIGRATIONS_COMPLETED_SORT_FIELDS,
+  MIGRATIONS_FILTER_TYPES,
+  MIGRATIONS_ARCHIVED_SORT_FIELDS
+} from './MigrationsConstants';
 import ScheduleMigrationButtons from './ScheduleMigrationButtons';
 import ScheduleMigrationModal from '../ScheduleMigrationModal/ScheduleMigrationModal';
 import { formatDateTime } from '../../../../../../components/dates/MomentDate';
@@ -59,7 +63,9 @@ const MigrationsCompletedList = ({
         {finishedTransformationPlans.length > 0 ? (
           <ListViewToolbar
             filterTypes={MIGRATIONS_FILTER_TYPES}
-            sortFields={MIGRATIONS_COMPLETED_SORT_FIELDS}
+            defaultFilterTypeIndex={0}
+            sortFields={!archived ? MIGRATIONS_COMPLETED_SORT_FIELDS : MIGRATIONS_ARCHIVED_SORT_FIELDS}
+            defaultSortTypeIndex={!archived ? 1 : 0}
             listItems={finishedTransformationPlans}
             render={(
               {

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
@@ -147,7 +147,7 @@ const MigrationsCompletedList = ({
                       )}
                   </Toolbar>
                 </Grid.Row>
-                <ListView className="plans-complete-list" style={{ marginTop: 0 }}>
+                <ListView className="plans-complete-list" style={{ marginTop: 10 }}>
                   {filteredSortedPaginatedListItems.tasks.map(plan => {
                     const {
                       migrationScheduled,

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsConstants.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsConstants.js
@@ -17,3 +17,24 @@ export const MIGRATIONS_COMPLETED_SORT_FIELDS = [
   { id: 'name', title: __('Name'), isNumeric: false },
   { id: 'status', title: __('Status'), isNumeric: false }
 ];
+
+export const MIGRATIONS_FILTER_TYPES = [
+  {
+    id: 'name',
+    title: __('Name'),
+    placeholder: __('Filter by Name'),
+    filterType: 'text'
+  },
+  {
+    id: 'description',
+    title: __('Description'),
+    placeholder: __('Filter by Description'),
+    filterType: 'text'
+  },
+  {
+    id: 'infraMappingName',
+    title: __('Infrastructure Mapping'),
+    placeholder: __('Filter by Mapping'),
+    filterType: 'text'
+  }
+];

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsConstants.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsConstants.js
@@ -18,6 +18,8 @@ export const MIGRATIONS_COMPLETED_SORT_FIELDS = [
   { id: 'status', title: __('Status'), isNumeric: false }
 ];
 
+export const MIGRATIONS_ARCHIVED_SORT_FIELDS = [{ id: 'name', title: __('Name'), isNumeric: false }];
+
 export const MIGRATIONS_FILTER_TYPES = [
   {
     id: 'name',

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsInProgressCards.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsInProgressCards.js
@@ -14,7 +14,10 @@ const MigrationsInProgressCards = ({
 }) => (
   <div className="row-cards-pf">
     <Grid.Row>
-      <Grid.Col xs={12} style={{ marginTop: '20px' }}>
+      <Grid.Col
+        xs={12}
+        style={activeTransformationPlans.length > 0 && allRequestsWithTasks.length > 0 ? { marginTop: '20px' } : {}}
+      >
         <Card.HeightMatching selector={['.card-pf-match-height']}>
           <Spinner loading={loading}>
             {activeTransformationPlans.length > 0 && allRequestsWithTasks.length > 0 ? (

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsInProgressCards.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsInProgressCards.js
@@ -14,7 +14,7 @@ const MigrationsInProgressCards = ({
 }) => (
   <div className="row-cards-pf">
     <Grid.Row>
-      <Grid.Col xs={12}>
+      <Grid.Col xs={12} style={{ marginTop: '20px' }}>
         <Card.HeightMatching selector={['.card-pf-match-height']}>
           <Spinner loading={loading}>
             {activeTransformationPlans.length > 0 && allRequestsWithTasks.length > 0 ? (

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
@@ -52,7 +52,9 @@ const MigrationsNotStartedList = ({
         {notStartedPlans.length > 0 ? (
           <ListViewToolbar
             filterTypes={MIGRATIONS_FILTER_TYPES}
+            defaultFilterTypeIndex={0}
             sortFields={MIGRATIONS_NOT_STARTED_SORT_FIELDS}
+            defaultSortTypeIndex={0}
             listItems={notStartedPlans}
             render={(
               {

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
@@ -52,9 +52,7 @@ const MigrationsNotStartedList = ({
         {notStartedPlans.length > 0 ? (
           <ListViewToolbar
             filterTypes={MIGRATIONS_FILTER_TYPES}
-            defaultFilterTypeIndex={0}
             sortFields={MIGRATIONS_NOT_STARTED_SORT_FIELDS}
-            defaultSortTypeIndex={0}
             listItems={notStartedPlans}
           >
             {(

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
@@ -135,7 +135,7 @@ const MigrationsNotStartedList = ({
                       )}
                   </Toolbar>
                 </Grid.Row>
-                <ListView className="plans-not-started-list" style={{ marginTop: 0 }}>
+                <ListView className="plans-not-started-list" style={{ marginTop: 10 }}>
                   {filteredSortedPaginatedListItems.tasks.map(plan => {
                     const { migrationScheduled, migrationStarting, showInitialScheduleButton } = getPlanScheduleInfo(
                       plan

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
@@ -56,7 +56,8 @@ const MigrationsNotStartedList = ({
             sortFields={MIGRATIONS_NOT_STARTED_SORT_FIELDS}
             defaultSortTypeIndex={0}
             listItems={notStartedPlans}
-            render={(
+          >
+            {(
               {
                 filterTypes,
                 currentFilterType,
@@ -69,7 +70,7 @@ const MigrationsNotStartedList = ({
                 pageChangeValue
               },
               {
-                filterSortPaginateListItems,
+                filteredSortedPaginatedListItems,
                 selectFilterType,
                 renderInput,
                 updateCurrentSortType,
@@ -84,199 +85,195 @@ const MigrationsNotStartedList = ({
                 onLastPage,
                 onSubmit
               }
-            ) => {
-              const paginatedSortedFilteredPlans = filterSortPaginateListItems();
-              return (
-                <React.Fragment>
-                  <Grid.Row>
-                    <Toolbar>
-                      <Filter style={{ paddingLeft: 0 }}>
-                        <Filter.TypeSelector
-                          filterTypes={filterTypes}
-                          currentFilterType={currentFilterType}
-                          onFilterTypeSelected={selectFilterType}
-                        />
-                        {renderInput()}
-                      </Filter>
-                      <Sort>
-                        <Sort.TypeSelector
-                          sortTypes={sortFields}
-                          currentSortType={currentSortType}
-                          onSortTypeSelected={updateCurrentSortType}
-                        />
-                        <Sort.DirectionSelector
-                          isNumeric={isSortNumeric}
-                          isAscending={isSortAscending}
-                          onClick={toggleCurrentSortDirection}
-                        />
-                      </Sort>
-                      {activeFilters &&
-                        activeFilters.length > 0 && (
-                          <Toolbar.Results>
-                            <h5>
-                              {paginatedSortedFilteredPlans.itemCount}{' '}
-                              {paginatedSortedFilteredPlans.itemCount === 1 ? __('Result') : __('Results')}
-                            </h5>
-                            <Filter.ActiveLabel>{__('Active Filters')}:</Filter.ActiveLabel>
-                            <Filter.List>
-                              {activeFilters.map((item, index) => (
-                                <Filter.Item key={index} onRemove={removeFilter} filterData={item}>
-                                  {item.label}
-                                </Filter.Item>
-                              ))}
-                            </Filter.List>
-                            <a
-                              href="#"
+            ) => (
+              <React.Fragment>
+                <Grid.Row>
+                  <Toolbar>
+                    <Filter style={{ paddingLeft: 0 }}>
+                      <Filter.TypeSelector
+                        filterTypes={filterTypes}
+                        currentFilterType={currentFilterType}
+                        onFilterTypeSelected={selectFilterType}
+                      />
+                      {renderInput()}
+                    </Filter>
+                    <Sort>
+                      <Sort.TypeSelector
+                        sortTypes={sortFields}
+                        currentSortType={currentSortType}
+                        onSortTypeSelected={updateCurrentSortType}
+                      />
+                      <Sort.DirectionSelector
+                        isNumeric={isSortNumeric}
+                        isAscending={isSortAscending}
+                        onClick={toggleCurrentSortDirection}
+                      />
+                    </Sort>
+                    {activeFilters &&
+                      activeFilters.length > 0 && (
+                        <Toolbar.Results>
+                          <h5>
+                            {filteredSortedPaginatedListItems.itemCount}{' '}
+                            {filteredSortedPaginatedListItems.itemCount === 1 ? __('Result') : __('Results')}
+                          </h5>
+                          <Filter.ActiveLabel>{__('Active Filters')}:</Filter.ActiveLabel>
+                          <Filter.List>
+                            {activeFilters.map((item, index) => (
+                              <Filter.Item key={index} onRemove={removeFilter} filterData={item}>
+                                {item.label}
+                              </Filter.Item>
+                            ))}
+                          </Filter.List>
+                          <a
+                            href="#"
+                            onClick={e => {
+                              e.preventDefault();
+                              clearFilters();
+                            }}
+                          >
+                            {__('Clear All Filters')}
+                          </a>
+                        </Toolbar.Results>
+                      )}
+                  </Toolbar>
+                </Grid.Row>
+                <ListView className="plans-not-started-list" style={{ marginTop: 0 }}>
+                  {filteredSortedPaginatedListItems.tasks.map(plan => {
+                    const { migrationScheduled, migrationStarting, showInitialScheduleButton } = getPlanScheduleInfo(
+                      plan
+                    );
+                    const isMissingMapping = !plan.infraMappingName;
+
+                    const scheduleButtons = (
+                      <ScheduleMigrationButtons
+                        showConfirmModalAction={showConfirmModalAction}
+                        hideConfirmModalAction={hideConfirmModalAction}
+                        loading={loading}
+                        toggleScheduleMigrationModal={toggleScheduleMigrationModal}
+                        scheduleMigration={scheduleMigration}
+                        fetchTransformationPlansAction={fetchTransformationPlansAction}
+                        fetchTransformationPlansUrl={fetchTransformationPlansUrl}
+                        plan={plan}
+                        isMissingMapping={isMissingMapping}
+                        migrationScheduled={migrationScheduled}
+                        migrationStarting={migrationStarting}
+                        showInitialScheduleButton={showInitialScheduleButton}
+                      />
+                    );
+
+                    const editPlanDisabled = isMissingMapping || loading === plan.href;
+
+                    return (
+                      <ListView.Item
+                        stacked
+                        className="plans-not-started-list__list-item"
+                        onClick={() => {
+                          redirectTo(`/plan/${plan.id}`);
+                        }}
+                        actions={
+                          <div>
+                            {showInitialScheduleButton && scheduleButtons}
+                            <Button
+                              id={`migrate_${plan.id}`}
                               onClick={e => {
-                                e.preventDefault();
-                                clearFilters();
+                                e.stopPropagation();
+                                migrateClick(plan.href);
                               }}
+                              disabled={
+                                isMissingMapping || loading === plan.href || plan.schedule_type || migrationStarting
+                              }
                             >
-                              {__('Clear All Filters')}
-                            </a>
-                          </Toolbar.Results>
-                        )}
-                    </Toolbar>
-                  </Grid.Row>
-                  <ListView className="plans-not-started-list" style={{ marginTop: 0 }}>
-                    {paginatedSortedFilteredPlans.tasks.map(plan => {
-                      const { migrationScheduled, migrationStarting, showInitialScheduleButton } = getPlanScheduleInfo(
-                        plan
-                      );
-                      const isMissingMapping = !plan.infraMappingName;
-
-                      const scheduleButtons = (
-                        <ScheduleMigrationButtons
-                          showConfirmModalAction={showConfirmModalAction}
-                          hideConfirmModalAction={hideConfirmModalAction}
-                          loading={loading}
-                          toggleScheduleMigrationModal={toggleScheduleMigrationModal}
-                          scheduleMigration={scheduleMigration}
-                          fetchTransformationPlansAction={fetchTransformationPlansAction}
-                          fetchTransformationPlansUrl={fetchTransformationPlansUrl}
-                          plan={plan}
-                          isMissingMapping={isMissingMapping}
-                          migrationScheduled={migrationScheduled}
-                          migrationStarting={migrationStarting}
-                          showInitialScheduleButton={showInitialScheduleButton}
-                        />
-                      );
-
-                      const editPlanDisabled = isMissingMapping || loading === plan.href;
-
-                      return (
-                        <ListView.Item
-                          stacked
-                          className="plans-not-started-list__list-item"
-                          onClick={() => {
-                            redirectTo(`/plan/${plan.id}`);
-                          }}
-                          actions={
-                            <div>
-                              {showInitialScheduleButton && scheduleButtons}
-                              <Button
-                                id={`migrate_${plan.id}`}
-                                onClick={e => {
-                                  e.stopPropagation();
-                                  migrateClick(plan.href);
-                                }}
-                                disabled={
-                                  isMissingMapping || loading === plan.href || plan.schedule_type || migrationStarting
-                                }
-                              >
-                                {__('Migrate')}
-                              </Button>
-                              <StopPropagationOnClick>
-                                <DropdownKebab id={`${plan.id}-kebab`} pullRight>
-                                  <MenuItem
-                                    onClick={e => {
-                                      e.stopPropagation();
-                                      if (!editPlanDisabled) showPlanWizardEditModeAction(plan.id);
-                                    }}
-                                    disabled={editPlanDisabled}
-                                  >
-                                    {__('Edit plan')}
-                                  </MenuItem>
-                                  <DeleteMigrationMenuItem
-                                    showConfirmModalAction={showConfirmModalAction}
-                                    hideConfirmModalAction={hideConfirmModalAction}
-                                    deleteTransformationPlanAction={deleteTransformationPlanAction}
-                                    deleteTransformationPlanUrl={deleteTransformationPlanUrl}
-                                    addNotificationAction={addNotificationAction}
-                                    fetchTransformationPlansAction={fetchTransformationPlansAction}
-                                    fetchTransformationPlansUrl={fetchTransformationPlansUrl}
-                                    planId={plan.id}
-                                    planName={plan.name}
-                                    fetchTransformationMappingsAction={fetchTransformationMappingsAction}
-                                    fetchTransformationMappingsUrl={fetchTransformationMappingsUrl}
-                                  />
-                                  {!showInitialScheduleButton && scheduleButtons}
-                                </DropdownKebab>
-                              </StopPropagationOnClick>
-                            </div>
-                          }
-                          leftContent={<div />}
-                          heading={plan.name}
-                          description={
-                            <EllipsisWithTooltip id={plan.description}>
-                              <React.Fragment>{plan.description}</React.Fragment>
-                            </EllipsisWithTooltip>
-                          }
-                          additionalInfo={[
-                            <ListView.InfoItem key={plan.id}>
-                              <Icon type="pf" name="virtual-machine" />
-                              <strong>{plan.options.config_info.actions.length}</strong> {__('VMs')}
-                            </ListView.InfoItem>,
-                            isMissingMapping && (
-                              <ListView.InfoItem key={`${plan.id}-infraMappingWarning`}>
-                                <Icon type="pf" name="warning-triangle-o" />{' '}
-                                {__('Infrastucture mapping does not exist.')}
-                              </ListView.InfoItem>
-                            ),
-                            !isMissingMapping && (
-                              <ListView.InfoItem key={`${plan.id}-infraMappingName`}>
-                                {plan.infraMappingName}
-                              </ListView.InfoItem>
-                            ),
-                            migrationScheduled && !migrationStarting ? (
-                              <ListView.InfoItem key={`${plan.id}-scheduledTime`} style={{ textAlign: 'left' }}>
-                                <Icon type="fa" name="clock-o" />
-                                {__('Migration scheduled')}
-                                <br />
-                                {formatDateTime(migrationScheduled)}
-                              </ListView.InfoItem>
-                            ) : null,
-                            migrationStarting && (
-                              <ListView.InfoItem key={`${plan.id}-starting`} style={{ textAlign: 'left' }}>
-                                {__('Migration in progress')}
-                              </ListView.InfoItem>
-                            )
-                          ]}
-                          key={plan.id}
-                        />
-                      );
-                    })}
-                  </ListView>
-                  <PaginationRow
-                    viewType={PAGINATION_VIEW.LIST}
-                    pagination={pagination}
-                    pageInputValue={pageChangeValue}
-                    amountOfPages={paginatedSortedFilteredPlans.amountOfPages}
-                    itemCount={paginatedSortedFilteredPlans.itemCount}
-                    itemsStart={paginatedSortedFilteredPlans.itemsStart}
-                    itemsEnd={paginatedSortedFilteredPlans.itemsEnd}
-                    onPerPageSelect={onPerPageSelect}
-                    onFirstPage={onFirstPage}
-                    onPreviousPage={onPreviousPage}
-                    onPageInput={onPageInput}
-                    onNextPage={onNextPage}
-                    onLastPage={onLastPage}
-                    onSubmit={onSubmit}
-                  />
-                </React.Fragment>
-              );
-            }}
-          />
+                              {__('Migrate')}
+                            </Button>
+                            <StopPropagationOnClick>
+                              <DropdownKebab id={`${plan.id}-kebab`} pullRight>
+                                <MenuItem
+                                  onClick={e => {
+                                    e.stopPropagation();
+                                    if (!editPlanDisabled) showPlanWizardEditModeAction(plan.id);
+                                  }}
+                                  disabled={editPlanDisabled}
+                                >
+                                  {__('Edit plan')}
+                                </MenuItem>
+                                <DeleteMigrationMenuItem
+                                  showConfirmModalAction={showConfirmModalAction}
+                                  hideConfirmModalAction={hideConfirmModalAction}
+                                  deleteTransformationPlanAction={deleteTransformationPlanAction}
+                                  deleteTransformationPlanUrl={deleteTransformationPlanUrl}
+                                  addNotificationAction={addNotificationAction}
+                                  fetchTransformationPlansAction={fetchTransformationPlansAction}
+                                  fetchTransformationPlansUrl={fetchTransformationPlansUrl}
+                                  planId={plan.id}
+                                  planName={plan.name}
+                                  fetchTransformationMappingsAction={fetchTransformationMappingsAction}
+                                  fetchTransformationMappingsUrl={fetchTransformationMappingsUrl}
+                                />
+                                {!showInitialScheduleButton && scheduleButtons}
+                              </DropdownKebab>
+                            </StopPropagationOnClick>
+                          </div>
+                        }
+                        leftContent={<div />}
+                        heading={plan.name}
+                        description={
+                          <EllipsisWithTooltip id={plan.description}>
+                            <React.Fragment>{plan.description}</React.Fragment>
+                          </EllipsisWithTooltip>
+                        }
+                        additionalInfo={[
+                          <ListView.InfoItem key={plan.id}>
+                            <Icon type="pf" name="virtual-machine" />
+                            <strong>{plan.options.config_info.actions.length}</strong> {__('VMs')}
+                          </ListView.InfoItem>,
+                          isMissingMapping && (
+                            <ListView.InfoItem key={`${plan.id}-infraMappingWarning`}>
+                              <Icon type="pf" name="warning-triangle-o" /> {__('Infrastucture mapping does not exist.')}
+                            </ListView.InfoItem>
+                          ),
+                          !isMissingMapping && (
+                            <ListView.InfoItem key={`${plan.id}-infraMappingName`}>
+                              {plan.infraMappingName}
+                            </ListView.InfoItem>
+                          ),
+                          migrationScheduled && !migrationStarting ? (
+                            <ListView.InfoItem key={`${plan.id}-scheduledTime`} style={{ textAlign: 'left' }}>
+                              <Icon type="fa" name="clock-o" />
+                              {__('Migration scheduled')}
+                              <br />
+                              {formatDateTime(migrationScheduled)}
+                            </ListView.InfoItem>
+                          ) : null,
+                          migrationStarting && (
+                            <ListView.InfoItem key={`${plan.id}-starting`} style={{ textAlign: 'left' }}>
+                              {__('Migration in progress')}
+                            </ListView.InfoItem>
+                          )
+                        ]}
+                        key={plan.id}
+                      />
+                    );
+                  })}
+                </ListView>
+                <PaginationRow
+                  viewType={PAGINATION_VIEW.LIST}
+                  pagination={pagination}
+                  pageInputValue={pageChangeValue}
+                  amountOfPages={filteredSortedPaginatedListItems.amountOfPages}
+                  itemCount={filteredSortedPaginatedListItems.itemCount}
+                  itemsStart={filteredSortedPaginatedListItems.itemsStart}
+                  itemsEnd={filteredSortedPaginatedListItems.itemsEnd}
+                  onPerPageSelect={onPerPageSelect}
+                  onFirstPage={onFirstPage}
+                  onPreviousPage={onPreviousPage}
+                  onPageInput={onPageInput}
+                  onNextPage={onNextPage}
+                  onLastPage={onLastPage}
+                  onSubmit={onSubmit}
+                />
+              </React.Fragment>
+            )}
+          </ListViewToolbar>
         ) : (
           <ShowWizardEmptyState
             title={__('No Migration Plans Not Started')}

--- a/app/javascript/react/screens/App/Overview/components/Migrations/__test__/MigrationsNotStartedList.test.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/__test__/MigrationsNotStartedList.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 
 import MigrationsNotStartedList from '../MigrationsNotStartedList';
 import { transformationPlans } from '../../../overview.transformationPlans.fixtures';
@@ -13,11 +13,11 @@ let wrapper;
 beforeEach(() => {
   migrateClick = jest.fn();
   redirectTo = jest.fn();
-  wrapper = shallow(
+  wrapper = mount(
     <MigrationsNotStartedList
       migrateClick={migrateClick}
       redirectTo={redirectTo}
-      loading="href"
+      loading=""
       notStartedPlans={[notStartedPlan]}
     />
   );

--- a/app/javascript/react/screens/App/common/ListViewToolbar/ListViewToolbar.js
+++ b/app/javascript/react/screens/App/common/ListViewToolbar/ListViewToolbar.js
@@ -202,7 +202,7 @@ class ListViewToolbar extends Component {
   };
 
   render() {
-    return this.props.render(this.state, {
+    return this.props.children(this.state, {
       onFirstPage: this.onFirstPage,
       onLastPage: this.onLastPage,
       onNextPage: this.onNextPage,
@@ -213,7 +213,7 @@ class ListViewToolbar extends Component {
       clearFilters: this.clearFilters,
       removeFilter: this.removeFilter,
       selectFilterType: this.selectFilterType,
-      filterSortPaginateListItems: this.filterSortPaginateListItems,
+      filteredSortedPaginatedListItems: this.filterSortPaginateListItems(),
       toggleCurrentSortDirection: this.toggleCurrentSortDirection,
       updateCurrentSortType: this.updateCurrentSortType,
       renderInput: this.renderInput
@@ -224,7 +224,7 @@ class ListViewToolbar extends Component {
 ListViewToolbar.propTypes = {
   filterTypes: PropTypes.array,
   listItems: PropTypes.array,
-  render: PropTypes.func,
+  children: PropTypes.func,
   sortFields: PropTypes.array,
   defaultSortTypeIndex: PropTypes.number,
   defaultFilterTypeIndex: PropTypes.number

--- a/app/javascript/react/screens/App/common/ListViewToolbar/ListViewToolbar.js
+++ b/app/javascript/react/screens/App/common/ListViewToolbar/ListViewToolbar.js
@@ -9,12 +9,12 @@ import paginate from './paginate';
 class ListViewToolbar extends Component {
   state = {
     filterTypes: this.props.filterTypes,
-    currentFilterType: this.props.filterTypes[0],
+    currentFilterType: this.props.filterTypes[this.props.defaultFilterTypeIndex],
     currentValue: '',
     activeFilters: [],
     sortFields: this.props.sortFields,
-    currentSortType: this.props.sortFields[1],
-    isSortNumeric: this.props.sortFields[1].isNumeric,
+    currentSortType: this.props.sortFields[this.props.defaultSortTypeIndex],
+    isSortNumeric: this.props.sortFields[this.props.defaultSortTypeIndex].isNumeric,
     isSortAscending: true,
     pagination: {
       page: 1,
@@ -225,7 +225,14 @@ ListViewToolbar.propTypes = {
   filterTypes: PropTypes.array,
   listItems: PropTypes.array,
   render: PropTypes.func,
-  sortFields: PropTypes.array
+  sortFields: PropTypes.array,
+  defaultSortTypeIndex: PropTypes.number,
+  defaultFilterTypeIndex: PropTypes.number
+};
+
+ListViewToolbar.defaultProps = {
+  defaultSortTypeIndex: 1,
+  defaultFilterTypeIndex: 0
 };
 
 export default ListViewToolbar;

--- a/app/javascript/react/screens/App/common/ListViewToolbar/ListViewToolbar.js
+++ b/app/javascript/react/screens/App/common/ListViewToolbar/ListViewToolbar.js
@@ -231,7 +231,7 @@ ListViewToolbar.propTypes = {
 };
 
 ListViewToolbar.defaultProps = {
-  defaultSortTypeIndex: 1,
+  defaultSortTypeIndex: 0,
   defaultFilterTypeIndex: 0
 };
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1642175

Fixes #724 
Fixes #733

List views (Plans Not Started, Plans In Progress, Plans Archived) now have a white background, and include sorting, filtering, and pagination controls. They can be filtered by name, description, or infrastructure mapping name.

![screenshot 2018-10-25 11 17 48](https://user-images.githubusercontent.com/811963/47511281-e0c3b500-d847-11e8-8312-b5f547e78e7b.png)

The Migrations In Progress view still has the old grey background behind everything except the header, because of its white cards:

![screenshot 2018-10-25 11 05 51](https://user-images.githubusercontent.com/811963/47511352-06e95500-d848-11e8-8c62-a9fd80472a5d.png)

All the empty states also render with a grey background behind everything except the header:

![screenshot 2018-10-25 11 05 02](https://user-images.githubusercontent.com/811963/47511375-11a3ea00-d848-11e8-9b53-e778cbd2e7ba.png)

