### PR TITLE
[Code Cleanup] Deduplicate filter/sort/pagination elements into ListViewToolbar renderers

### DIFF
--- a/app/javascript/react/screens/App/Mappings/components/InfrastructureMappingsList/InfrastructureMappingsList.js
+++ b/app/javascript/react/screens/App/Mappings/components/InfrastructureMappingsList/InfrastructureMappingsList.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Immutable from 'seamless-immutable';
 import EllipsisWithTooltip from 'react-ellipsis-with-tooltip';
-import { Button, Icon, ListView, Grid, Toolbar, Filter, Sort, PaginationRow, PAGINATION_VIEW } from 'patternfly-react';
+import { Button, Icon, ListView, Grid, Toolbar, Filter, PaginationRow, PAGINATION_VIEW } from 'patternfly-react';
 
 import { formatDateTime } from '../../../../../../components/dates/MomentDate';
 import ShowWizardEmptyState from '../../../common/ShowWizardEmptyState/ShowWizardEmptyState';
@@ -121,12 +121,11 @@ class InfrastructureMappingsList extends React.Component {
           listItems={transformationMappingsMutable}
         >
           {(
-            { sortFields, currentSortType, isSortNumeric, isSortAscending, activeFilters, pagination, pageChangeValue },
+            { activeFilters, pagination, pageChangeValue },
             {
               filteredSortedPaginatedListItems,
               renderFilterControls,
-              updateCurrentSortType,
-              toggleCurrentSortDirection,
+              renderSortControls,
               clearFilters,
               removeFilter,
               onPerPageSelect,
@@ -157,18 +156,7 @@ class InfrastructureMappingsList extends React.Component {
                 <Grid.Row>
                   <Toolbar>
                     {renderFilterControls()}
-                    <Sort>
-                      <Sort.TypeSelector
-                        sortTypes={sortFields}
-                        currentSortType={currentSortType}
-                        onSortTypeSelected={updateCurrentSortType}
-                      />
-                      <Sort.DirectionSelector
-                        isNumeric={isSortNumeric}
-                        isAscending={isSortAscending}
-                        onClick={toggleCurrentSortDirection}
-                      />
-                    </Sort>
+                    {renderSortControls()}
                     {!error && (
                       <Toolbar.RightContent>
                         <a

--- a/app/javascript/react/screens/App/Mappings/components/InfrastructureMappingsList/InfrastructureMappingsList.js
+++ b/app/javascript/react/screens/App/Mappings/components/InfrastructureMappingsList/InfrastructureMappingsList.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Immutable from 'seamless-immutable';
 import EllipsisWithTooltip from 'react-ellipsis-with-tooltip';
-import { Button, Icon, ListView, Grid, Toolbar, Filter, PaginationRow, PAGINATION_VIEW } from 'patternfly-react';
+import { Button, Icon, ListView, Grid, Toolbar, PaginationRow, PAGINATION_VIEW } from 'patternfly-react';
 
 import { formatDateTime } from '../../../../../../components/dates/MomentDate';
 import ShowWizardEmptyState from '../../../common/ShowWizardEmptyState/ShowWizardEmptyState';
@@ -121,13 +121,12 @@ class InfrastructureMappingsList extends React.Component {
           listItems={transformationMappingsMutable}
         >
           {(
-            { activeFilters, pagination, pageChangeValue },
+            { pagination, pageChangeValue },
             {
               filteredSortedPaginatedListItems,
               renderFilterControls,
               renderSortControls,
-              clearFilters,
-              removeFilter,
+              renderActiveFilters,
               onPerPageSelect,
               onFirstPage,
               onPreviousPage,
@@ -172,32 +171,7 @@ class InfrastructureMappingsList extends React.Component {
                         </a>
                       </Toolbar.RightContent>
                     )}
-                    {activeFilters &&
-                      activeFilters.length > 0 && (
-                        <Toolbar.Results>
-                          <h5>
-                            {filteredSortedPaginatedListItems.itemCount}{' '}
-                            {filteredSortedPaginatedListItems.itemCount === 1 ? __('Result') : __('Results')}
-                          </h5>
-                          <Filter.ActiveLabel>{__('Active Filters')}:</Filter.ActiveLabel>
-                          <Filter.List>
-                            {activeFilters.map((item, index) => (
-                              <Filter.Item key={index} onRemove={removeFilter} filterData={item}>
-                                {item.label}
-                              </Filter.Item>
-                            ))}
-                          </Filter.List>
-                          <a
-                            href="#"
-                            onClick={e => {
-                              e.preventDefault();
-                              clearFilters();
-                            }}
-                          >
-                            {__('Clear All Filters')}
-                          </a>
-                        </Toolbar.Results>
-                      )}
+                    {renderActiveFilters(filteredSortedPaginatedListItems)}
                   </Toolbar>
                 </Grid.Row>
                 <div style={{ overflow: 'auto', paddingBottom: 300, height: '100%' }}>

--- a/app/javascript/react/screens/App/Mappings/components/InfrastructureMappingsList/InfrastructureMappingsList.js
+++ b/app/javascript/react/screens/App/Mappings/components/InfrastructureMappingsList/InfrastructureMappingsList.js
@@ -121,21 +121,10 @@ class InfrastructureMappingsList extends React.Component {
           listItems={transformationMappingsMutable}
         >
           {(
-            {
-              filterTypes,
-              currentFilterType,
-              sortFields,
-              currentSortType,
-              isSortNumeric,
-              isSortAscending,
-              activeFilters,
-              pagination,
-              pageChangeValue
-            },
+            { sortFields, currentSortType, isSortNumeric, isSortAscending, activeFilters, pagination, pageChangeValue },
             {
               filteredSortedPaginatedListItems,
-              selectFilterType,
-              renderInput,
+              renderFilterControls,
               updateCurrentSortType,
               toggleCurrentSortDirection,
               clearFilters,
@@ -167,14 +156,7 @@ class InfrastructureMappingsList extends React.Component {
               <React.Fragment>
                 <Grid.Row>
                   <Toolbar>
-                    <Filter style={{ paddingLeft: 0 }}>
-                      <Filter.TypeSelector
-                        filterTypes={filterTypes}
-                        currentFilterType={currentFilterType}
-                        onFilterTypeSelected={selectFilterType}
-                      />
-                      {renderInput()}
-                    </Filter>
+                    {renderFilterControls()}
                     <Sort>
                       <Sort.TypeSelector
                         sortTypes={sortFields}

--- a/app/javascript/react/screens/App/Mappings/components/InfrastructureMappingsList/InfrastructureMappingsList.js
+++ b/app/javascript/react/screens/App/Mappings/components/InfrastructureMappingsList/InfrastructureMappingsList.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Immutable from 'seamless-immutable';
 import EllipsisWithTooltip from 'react-ellipsis-with-tooltip';
-import { Button, Icon, ListView, Grid, Toolbar, PaginationRow, PAGINATION_VIEW } from 'patternfly-react';
+import { Button, Icon, ListView, Grid, Toolbar } from 'patternfly-react';
 
 import { formatDateTime } from '../../../../../../components/dates/MomentDate';
 import ShowWizardEmptyState from '../../../common/ShowWizardEmptyState/ShowWizardEmptyState';
@@ -120,22 +120,13 @@ class InfrastructureMappingsList extends React.Component {
           sortFields={INFRA_MAPPINGS_SORT_FIELDS}
           listItems={transformationMappingsMutable}
         >
-          {(
-            { pagination, pageChangeValue },
-            {
-              filteredSortedPaginatedListItems,
-              renderFilterControls,
-              renderSortControls,
-              renderActiveFilters,
-              onPerPageSelect,
-              onFirstPage,
-              onPreviousPage,
-              onPageInput,
-              onNextPage,
-              onLastPage,
-              onSubmit
-            }
-          ) =>
+          {({
+            filteredSortedPaginatedListItems,
+            renderFilterControls,
+            renderSortControls,
+            renderActiveFilters,
+            renderPaginationRow
+          }) =>
             error ? (
               <ShowWizardEmptyState
                 title={__('Error loading mappings.')}
@@ -517,22 +508,7 @@ class InfrastructureMappingsList extends React.Component {
                       );
                     })}
                   </ListView>
-                  <PaginationRow
-                    viewType={PAGINATION_VIEW.LIST}
-                    pagination={pagination}
-                    pageInputValue={pageChangeValue}
-                    amountOfPages={filteredSortedPaginatedListItems.amountOfPages}
-                    itemCount={filteredSortedPaginatedListItems.itemCount}
-                    itemsStart={filteredSortedPaginatedListItems.itemsStart}
-                    itemsEnd={filteredSortedPaginatedListItems.itemsEnd}
-                    onPerPageSelect={onPerPageSelect}
-                    onFirstPage={onFirstPage}
-                    onPreviousPage={onPreviousPage}
-                    onPageInput={onPageInput}
-                    onNextPage={onNextPage}
-                    onLastPage={onLastPage}
-                    onSubmit={onSubmit}
-                  />
+                  {renderPaginationRow(filteredSortedPaginatedListItems)}
                 </div>
               </React.Fragment>
             ) : (

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
@@ -8,7 +8,6 @@ import {
   Spinner,
   Icon,
   Toolbar,
-  Sort,
   Filter,
   DropdownKebab,
   MenuItem,
@@ -68,20 +67,11 @@ const MigrationsCompletedList = ({
             listItems={finishedTransformationPlans}
           >
             {(
-              {
-                sortFields,
-                currentSortType,
-                isSortNumeric,
-                isSortAscending,
-                activeFilters,
-                pagination,
-                pageChangeValue
-              },
+              { activeFilters, pagination, pageChangeValue },
               {
                 filteredSortedPaginatedListItems,
                 renderFilterControls,
-                updateCurrentSortType,
-                toggleCurrentSortDirection,
+                renderSortControls,
                 clearFilters,
                 removeFilter,
                 onPerPageSelect,
@@ -97,18 +87,7 @@ const MigrationsCompletedList = ({
                 <Grid.Row>
                   <Toolbar>
                     {renderFilterControls()}
-                    <Sort>
-                      <Sort.TypeSelector
-                        sortTypes={sortFields}
-                        currentSortType={currentSortType}
-                        onSortTypeSelected={updateCurrentSortType}
-                      />
-                      <Sort.DirectionSelector
-                        isNumeric={isSortNumeric}
-                        isAscending={isSortAscending}
-                        onClick={toggleCurrentSortDirection}
-                      />
-                    </Sort>
+                    {renderSortControls()}
                     {activeFilters &&
                       activeFilters.length > 0 && (
                         <Toolbar.Results>

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
@@ -69,8 +69,6 @@ const MigrationsCompletedList = ({
           >
             {(
               {
-                filterTypes,
-                currentFilterType,
                 sortFields,
                 currentSortType,
                 isSortNumeric,
@@ -81,8 +79,7 @@ const MigrationsCompletedList = ({
               },
               {
                 filteredSortedPaginatedListItems,
-                selectFilterType,
-                renderInput,
+                renderFilterControls,
                 updateCurrentSortType,
                 toggleCurrentSortDirection,
                 clearFilters,
@@ -99,14 +96,7 @@ const MigrationsCompletedList = ({
               <React.Fragment>
                 <Grid.Row>
                   <Toolbar>
-                    <Filter style={{ paddingLeft: 0 }}>
-                      <Filter.TypeSelector
-                        filterTypes={filterTypes}
-                        currentFilterType={currentFilterType}
-                        onFilterTypeSelected={selectFilterType}
-                      />
-                      {renderInput()}
-                    </Filter>
+                    {renderFilterControls()}
                     <Sort>
                       <Sort.TypeSelector
                         sortTypes={sortFields}

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
@@ -1,18 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {
-  noop,
-  Button,
-  ListView,
-  Grid,
-  Spinner,
-  Icon,
-  Toolbar,
-  DropdownKebab,
-  MenuItem,
-  PaginationRow,
-  PAGINATION_VIEW
-} from 'patternfly-react';
+import { noop, Button, ListView, Grid, Spinner, Icon, Toolbar, DropdownKebab, MenuItem } from 'patternfly-react';
 import { IsoElapsedTime } from '../../../../../../components/dates/IsoElapsedTime';
 import ShowWizardEmptyState from '../../../common/ShowWizardEmptyState/ShowWizardEmptyState';
 import getMostRecentRequest from '../../../common/getMostRecentRequest';
@@ -65,22 +53,13 @@ const MigrationsCompletedList = ({
             defaultSortTypeIndex={!archived ? 1 : 0}
             listItems={finishedTransformationPlans}
           >
-            {(
-              { pagination, pageChangeValue },
-              {
-                filteredSortedPaginatedListItems,
-                renderFilterControls,
-                renderSortControls,
-                renderActiveFilters,
-                onPerPageSelect,
-                onFirstPage,
-                onPreviousPage,
-                onPageInput,
-                onNextPage,
-                onLastPage,
-                onSubmit
-              }
-            ) => (
+            {({
+              filteredSortedPaginatedListItems,
+              renderFilterControls,
+              renderSortControls,
+              renderActiveFilters,
+              renderPaginationRow
+            }) => (
               <React.Fragment>
                 <Grid.Row>
                   <Toolbar>
@@ -338,22 +317,7 @@ const MigrationsCompletedList = ({
                     );
                   })}
                 </ListView>
-                <PaginationRow
-                  viewType={PAGINATION_VIEW.LIST}
-                  pagination={pagination}
-                  pageInputValue={pageChangeValue}
-                  amountOfPages={filteredSortedPaginatedListItems.amountOfPages}
-                  itemCount={filteredSortedPaginatedListItems.itemCount}
-                  itemsStart={filteredSortedPaginatedListItems.itemsStart}
-                  itemsEnd={filteredSortedPaginatedListItems.itemsEnd}
-                  onPerPageSelect={onPerPageSelect}
-                  onFirstPage={onFirstPage}
-                  onPreviousPage={onPreviousPage}
-                  onPageInput={onPageInput}
-                  onNextPage={onNextPage}
-                  onLastPage={onLastPage}
-                  onSubmit={onSubmit}
-                />
+                {renderPaginationRow(filteredSortedPaginatedListItems)}
               </React.Fragment>
             )}
           </ListViewToolbar>

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
@@ -8,7 +8,6 @@ import {
   Spinner,
   Icon,
   Toolbar,
-  Filter,
   DropdownKebab,
   MenuItem,
   PaginationRow,
@@ -67,13 +66,12 @@ const MigrationsCompletedList = ({
             listItems={finishedTransformationPlans}
           >
             {(
-              { activeFilters, pagination, pageChangeValue },
+              { pagination, pageChangeValue },
               {
                 filteredSortedPaginatedListItems,
                 renderFilterControls,
                 renderSortControls,
-                clearFilters,
-                removeFilter,
+                renderActiveFilters,
                 onPerPageSelect,
                 onFirstPage,
                 onPreviousPage,
@@ -88,32 +86,7 @@ const MigrationsCompletedList = ({
                   <Toolbar>
                     {renderFilterControls()}
                     {renderSortControls()}
-                    {activeFilters &&
-                      activeFilters.length > 0 && (
-                        <Toolbar.Results>
-                          <h5>
-                            {filteredSortedPaginatedListItems.itemCount}{' '}
-                            {filteredSortedPaginatedListItems.itemCount === 1 ? __('Result') : __('Results')}
-                          </h5>
-                          <Filter.ActiveLabel>{__('Active Filters')}:</Filter.ActiveLabel>
-                          <Filter.List>
-                            {activeFilters.map((item, index) => (
-                              <Filter.Item key={index} onRemove={removeFilter} filterData={item}>
-                                {item.label}
-                              </Filter.Item>
-                            ))}
-                          </Filter.List>
-                          <a
-                            href="#"
-                            onClick={e => {
-                              e.preventDefault();
-                              clearFilters();
-                            }}
-                          >
-                            {__('Clear All Filters')}
-                          </a>
-                        </Toolbar.Results>
-                      )}
+                    {renderActiveFilters(filteredSortedPaginatedListItems)}
                   </Toolbar>
                 </Grid.Row>
                 <ListView className="plans-complete-list" style={{ marginTop: 10 }}>

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
@@ -9,7 +9,6 @@ import {
   Spinner,
   Toolbar,
   Filter,
-  Sort,
   DropdownKebab,
   MenuItem,
   PaginationRow,
@@ -56,20 +55,11 @@ const MigrationsNotStartedList = ({
             listItems={notStartedPlans}
           >
             {(
-              {
-                sortFields,
-                currentSortType,
-                isSortNumeric,
-                isSortAscending,
-                activeFilters,
-                pagination,
-                pageChangeValue
-              },
+              { activeFilters, pagination, pageChangeValue },
               {
                 filteredSortedPaginatedListItems,
                 renderFilterControls,
-                updateCurrentSortType,
-                toggleCurrentSortDirection,
+                renderSortControls,
                 clearFilters,
                 removeFilter,
                 onPerPageSelect,
@@ -85,18 +75,7 @@ const MigrationsNotStartedList = ({
                 <Grid.Row>
                   <Toolbar>
                     {renderFilterControls()}
-                    <Sort>
-                      <Sort.TypeSelector
-                        sortTypes={sortFields}
-                        currentSortType={currentSortType}
-                        onSortTypeSelected={updateCurrentSortType}
-                      />
-                      <Sort.DirectionSelector
-                        isNumeric={isSortNumeric}
-                        isAscending={isSortAscending}
-                        onClick={toggleCurrentSortDirection}
-                      />
-                    </Sort>
+                    {renderSortControls()}
                     {activeFilters &&
                       activeFilters.length > 0 && (
                         <Toolbar.Results>

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
@@ -1,18 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {
-  noop,
-  Button,
-  ListView,
-  Grid,
-  Icon,
-  Spinner,
-  Toolbar,
-  DropdownKebab,
-  MenuItem,
-  PaginationRow,
-  PAGINATION_VIEW
-} from 'patternfly-react';
+import { noop, Button, ListView, Grid, Icon, Spinner, Toolbar, DropdownKebab, MenuItem } from 'patternfly-react';
 import EllipsisWithTooltip from 'react-ellipsis-with-tooltip';
 import ShowWizardEmptyState from '../../../common/ShowWizardEmptyState/ShowWizardEmptyState';
 import ScheduleMigrationModal from '../ScheduleMigrationModal/ScheduleMigrationModal';
@@ -53,22 +41,13 @@ const MigrationsNotStartedList = ({
             sortFields={MIGRATIONS_NOT_STARTED_SORT_FIELDS}
             listItems={notStartedPlans}
           >
-            {(
-              { pagination, pageChangeValue },
-              {
-                filteredSortedPaginatedListItems,
-                renderFilterControls,
-                renderSortControls,
-                renderActiveFilters,
-                onPerPageSelect,
-                onFirstPage,
-                onPreviousPage,
-                onPageInput,
-                onNextPage,
-                onLastPage,
-                onSubmit
-              }
-            ) => (
+            {({
+              filteredSortedPaginatedListItems,
+              renderFilterControls,
+              renderSortControls,
+              renderActiveFilters,
+              renderPaginationRow
+            }) => (
               <React.Fragment>
                 <Grid.Row>
                   <Toolbar>
@@ -195,22 +174,7 @@ const MigrationsNotStartedList = ({
                     );
                   })}
                 </ListView>
-                <PaginationRow
-                  viewType={PAGINATION_VIEW.LIST}
-                  pagination={pagination}
-                  pageInputValue={pageChangeValue}
-                  amountOfPages={filteredSortedPaginatedListItems.amountOfPages}
-                  itemCount={filteredSortedPaginatedListItems.itemCount}
-                  itemsStart={filteredSortedPaginatedListItems.itemsStart}
-                  itemsEnd={filteredSortedPaginatedListItems.itemsEnd}
-                  onPerPageSelect={onPerPageSelect}
-                  onFirstPage={onFirstPage}
-                  onPreviousPage={onPreviousPage}
-                  onPageInput={onPageInput}
-                  onNextPage={onNextPage}
-                  onLastPage={onLastPage}
-                  onSubmit={onSubmit}
-                />
+                {renderPaginationRow(filteredSortedPaginatedListItems)}
               </React.Fragment>
             )}
           </ListViewToolbar>

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
@@ -8,7 +8,6 @@ import {
   Icon,
   Spinner,
   Toolbar,
-  Filter,
   DropdownKebab,
   MenuItem,
   PaginationRow,
@@ -55,13 +54,12 @@ const MigrationsNotStartedList = ({
             listItems={notStartedPlans}
           >
             {(
-              { activeFilters, pagination, pageChangeValue },
+              { pagination, pageChangeValue },
               {
                 filteredSortedPaginatedListItems,
                 renderFilterControls,
                 renderSortControls,
-                clearFilters,
-                removeFilter,
+                renderActiveFilters,
                 onPerPageSelect,
                 onFirstPage,
                 onPreviousPage,
@@ -76,32 +74,7 @@ const MigrationsNotStartedList = ({
                   <Toolbar>
                     {renderFilterControls()}
                     {renderSortControls()}
-                    {activeFilters &&
-                      activeFilters.length > 0 && (
-                        <Toolbar.Results>
-                          <h5>
-                            {filteredSortedPaginatedListItems.itemCount}{' '}
-                            {filteredSortedPaginatedListItems.itemCount === 1 ? __('Result') : __('Results')}
-                          </h5>
-                          <Filter.ActiveLabel>{__('Active Filters')}:</Filter.ActiveLabel>
-                          <Filter.List>
-                            {activeFilters.map((item, index) => (
-                              <Filter.Item key={index} onRemove={removeFilter} filterData={item}>
-                                {item.label}
-                              </Filter.Item>
-                            ))}
-                          </Filter.List>
-                          <a
-                            href="#"
-                            onClick={e => {
-                              e.preventDefault();
-                              clearFilters();
-                            }}
-                          >
-                            {__('Clear All Filters')}
-                          </a>
-                        </Toolbar.Results>
-                      )}
+                    {renderActiveFilters(filteredSortedPaginatedListItems)}
                   </Toolbar>
                 </Grid.Row>
                 <ListView className="plans-not-started-list" style={{ marginTop: 10 }}>

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
@@ -57,8 +57,6 @@ const MigrationsNotStartedList = ({
           >
             {(
               {
-                filterTypes,
-                currentFilterType,
                 sortFields,
                 currentSortType,
                 isSortNumeric,
@@ -69,8 +67,7 @@ const MigrationsNotStartedList = ({
               },
               {
                 filteredSortedPaginatedListItems,
-                selectFilterType,
-                renderInput,
+                renderFilterControls,
                 updateCurrentSortType,
                 toggleCurrentSortDirection,
                 clearFilters,
@@ -87,14 +84,7 @@ const MigrationsNotStartedList = ({
               <React.Fragment>
                 <Grid.Row>
                   <Toolbar>
-                    <Filter style={{ paddingLeft: 0 }}>
-                      <Filter.TypeSelector
-                        filterTypes={filterTypes}
-                        currentFilterType={currentFilterType}
-                        onFilterTypeSelected={selectFilterType}
-                      />
-                      {renderInput()}
-                    </Filter>
+                    {renderFilterControls()}
                     <Sort>
                       <Sort.TypeSelector
                         sortTypes={sortFields}

--- a/app/javascript/react/screens/App/common/ListViewToolbar/ListViewToolbar.js
+++ b/app/javascript/react/screens/App/common/ListViewToolbar/ListViewToolbar.js
@@ -201,6 +201,20 @@ class ListViewToolbar extends Component {
     );
   };
 
+  renderFilterControls = () => {
+    const { filterTypes, currentFilterType } = this.state;
+    return (
+      <Filter style={{ paddingLeft: 0 }}>
+        <Filter.TypeSelector
+          filterTypes={filterTypes}
+          currentFilterType={currentFilterType}
+          onFilterTypeSelected={this.selectFilterType}
+        />
+        {this.renderInput()}
+      </Filter>
+    );
+  };
+
   render() {
     return this.props.children(this.state, {
       onFirstPage: this.onFirstPage,
@@ -216,7 +230,8 @@ class ListViewToolbar extends Component {
       filteredSortedPaginatedListItems: this.filterSortPaginateListItems(),
       toggleCurrentSortDirection: this.toggleCurrentSortDirection,
       updateCurrentSortType: this.updateCurrentSortType,
-      renderInput: this.renderInput
+      renderInput: this.renderInput,
+      renderFilterControls: this.renderFilterControls
     });
   }
 }

--- a/app/javascript/react/screens/App/common/ListViewToolbar/ListViewToolbar.js
+++ b/app/javascript/react/screens/App/common/ListViewToolbar/ListViewToolbar.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { FormControl, Filter, Sort, Toolbar } from 'patternfly-react';
+import { FormControl, Filter, Sort, Toolbar, PaginationRow, PAGINATION_VIEW } from 'patternfly-react';
 
 import listFilter from './listFilter';
 import sortFilter from './sortFilter';
@@ -265,26 +265,52 @@ class ListViewToolbar extends Component {
     );
   };
 
+  renderPaginationRow = filteredSortedPaginatedListItems => {
+    const { pagination, pageChangeValue } = this.state;
+    return (
+      <PaginationRow
+        viewType={PAGINATION_VIEW.LIST}
+        pagination={pagination}
+        pageInputValue={pageChangeValue}
+        amountOfPages={filteredSortedPaginatedListItems.amountOfPages}
+        itemCount={filteredSortedPaginatedListItems.itemCount}
+        itemsStart={filteredSortedPaginatedListItems.itemsStart}
+        itemsEnd={filteredSortedPaginatedListItems.itemsEnd}
+        onPerPageSelect={this.onPerPageSelect}
+        onFirstPage={this.onFirstPage}
+        onPreviousPage={this.onPreviousPage}
+        onPageInput={this.onPageInput}
+        onNextPage={this.onNextPage}
+        onLastPage={this.onLastPage}
+        onSubmit={this.onSubmit}
+      />
+    );
+  };
+
   render() {
-    return this.props.children(this.state, {
-      onFirstPage: this.onFirstPage,
-      onLastPage: this.onLastPage,
-      onNextPage: this.onNextPage,
-      onPageInput: this.onPageInput,
-      onPerPageSelect: this.onPerPageSelect,
-      onPreviousPage: this.onPreviousPage,
-      onSubmit: this.onSubmit,
-      clearFilters: this.clearFilters,
-      removeFilter: this.removeFilter,
-      selectFilterType: this.selectFilterType,
-      filteredSortedPaginatedListItems: this.filterSortPaginateListItems(),
-      toggleCurrentSortDirection: this.toggleCurrentSortDirection,
-      updateCurrentSortType: this.updateCurrentSortType,
-      renderInput: this.renderInput,
-      renderFilterControls: this.renderFilterControls,
-      renderSortControls: this.renderSortControls,
-      renderActiveFilters: this.renderActiveFilters
-    });
+    return this.props.children(
+      {
+        onFirstPage: this.onFirstPage,
+        onLastPage: this.onLastPage,
+        onNextPage: this.onNextPage,
+        onPageInput: this.onPageInput,
+        onPerPageSelect: this.onPerPageSelect,
+        onPreviousPage: this.onPreviousPage,
+        onSubmit: this.onSubmit,
+        clearFilters: this.clearFilters,
+        removeFilter: this.removeFilter,
+        selectFilterType: this.selectFilterType,
+        filteredSortedPaginatedListItems: this.filterSortPaginateListItems(),
+        toggleCurrentSortDirection: this.toggleCurrentSortDirection,
+        updateCurrentSortType: this.updateCurrentSortType,
+        renderInput: this.renderInput,
+        renderFilterControls: this.renderFilterControls,
+        renderSortControls: this.renderSortControls,
+        renderActiveFilters: this.renderActiveFilters,
+        renderPaginationRow: this.renderPaginationRow
+      },
+      this.state
+    );
   }
 }
 

--- a/app/javascript/react/screens/App/common/ListViewToolbar/ListViewToolbar.js
+++ b/app/javascript/react/screens/App/common/ListViewToolbar/ListViewToolbar.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { FormControl, Filter } from 'patternfly-react';
+import { FormControl, Filter, Sort } from 'patternfly-react';
 
 import listFilter from './listFilter';
 import sortFilter from './sortFilter';
@@ -215,6 +215,24 @@ class ListViewToolbar extends Component {
     );
   };
 
+  renderSortControls = () => {
+    const { sortFields, currentSortType, isSortNumeric, isSortAscending } = this.state;
+    return (
+      <Sort>
+        <Sort.TypeSelector
+          sortTypes={sortFields}
+          currentSortType={currentSortType}
+          onSortTypeSelected={this.updateCurrentSortType}
+        />
+        <Sort.DirectionSelector
+          isNumeric={isSortNumeric}
+          isAscending={isSortAscending}
+          onClick={this.toggleCurrentSortDirection}
+        />
+      </Sort>
+    );
+  };
+
   render() {
     return this.props.children(this.state, {
       onFirstPage: this.onFirstPage,
@@ -231,7 +249,8 @@ class ListViewToolbar extends Component {
       toggleCurrentSortDirection: this.toggleCurrentSortDirection,
       updateCurrentSortType: this.updateCurrentSortType,
       renderInput: this.renderInput,
-      renderFilterControls: this.renderFilterControls
+      renderFilterControls: this.renderFilterControls,
+      renderSortControls: this.renderSortControls
     });
   }
 }

--- a/app/javascript/react/screens/App/common/ListViewToolbar/ListViewToolbar.js
+++ b/app/javascript/react/screens/App/common/ListViewToolbar/ListViewToolbar.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { FormControl, Filter, Sort } from 'patternfly-react';
+import { FormControl, Filter, Sort, Toolbar } from 'patternfly-react';
 
 import listFilter from './listFilter';
 import sortFilter from './sortFilter';
@@ -233,6 +233,38 @@ class ListViewToolbar extends Component {
     );
   };
 
+  renderActiveFilters = filteredSortedPaginatedListItems => {
+    const { activeFilters } = this.state;
+    return (
+      activeFilters &&
+      activeFilters.length > 0 && (
+        <Toolbar.Results>
+          <h5>
+            {filteredSortedPaginatedListItems.itemCount}{' '}
+            {filteredSortedPaginatedListItems.itemCount === 1 ? __('Result') : __('Results')}
+          </h5>
+          <Filter.ActiveLabel>{__('Active Filters')}:</Filter.ActiveLabel>
+          <Filter.List>
+            {activeFilters.map((item, index) => (
+              <Filter.Item key={index} onRemove={this.removeFilter} filterData={item}>
+                {item.label}
+              </Filter.Item>
+            ))}
+          </Filter.List>
+          <a
+            href="#"
+            onClick={e => {
+              e.preventDefault();
+              this.clearFilters();
+            }}
+          >
+            {__('Clear All Filters')}
+          </a>
+        </Toolbar.Results>
+      )
+    );
+  };
+
   render() {
     return this.props.children(this.state, {
       onFirstPage: this.onFirstPage,
@@ -250,7 +282,8 @@ class ListViewToolbar extends Component {
       updateCurrentSortType: this.updateCurrentSortType,
       renderInput: this.renderInput,
       renderFilterControls: this.renderFilterControls,
-      renderSortControls: this.renderSortControls
+      renderSortControls: this.renderSortControls,
+      renderActiveFilters: this.renderActiveFilters
     });
   }
 }


### PR DESCRIPTION
This is a refactor with no changes to actual functionality. To test it, we should simply verify that filtering, sorting and pagination all continues to work on the Migration Plans Not Started, Migration Plans Completed/Archived, and Infrastructure Mappings list views.

https://bugzilla.redhat.com/show_bug.cgi?id=1643290