### PR TITLE
[#728] Pass a copy of listItems to be sorted

### DIFF
--- a/app/javascript/react/screens/App/Mappings/components/InfrastructureMappingsList/InfrastructureMappingsList.js
+++ b/app/javascript/react/screens/App/Mappings/components/InfrastructureMappingsList/InfrastructureMappingsList.js
@@ -167,7 +167,7 @@ class InfrastructureMappingsList extends React.Component {
                 </Grid.Row>
                 <div style={{ overflow: 'auto', paddingBottom: 300, height: '100%' }}>
                   <ListView style={{ marginTop: 10 }} className="infra-mappings-list-view" id="infrastructure_mappings">
-                    {filteredSortedPaginatedListItems.tasks.map(mapping => {
+                    {filteredSortedPaginatedListItems.items.map(mapping => {
                       const associatedPlansCount = mapping.service_templates && mapping.service_templates.length;
 
                       const { targetClusters, targetDatastores, targetNetworks } = mapInfrastructureMappings(

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
@@ -69,7 +69,7 @@ const MigrationsCompletedList = ({
                   </Toolbar>
                 </Grid.Row>
                 <ListView className="plans-complete-list" style={{ marginTop: 10 }}>
-                  {filteredSortedPaginatedListItems.tasks.map(plan => {
+                  {filteredSortedPaginatedListItems.items.map(plan => {
                     const {
                       migrationScheduled,
                       staleMigrationSchedule,

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
@@ -57,7 +57,7 @@ const MigrationsNotStartedList = ({
                   </Toolbar>
                 </Grid.Row>
                 <ListView className="plans-not-started-list" style={{ marginTop: 10 }}>
-                  {filteredSortedPaginatedListItems.tasks.map(plan => {
+                  {filteredSortedPaginatedListItems.items.map(plan => {
                     const { migrationScheduled, migrationStarting, showInitialScheduleButton } = getPlanScheduleInfo(
                       plan
                     );

--- a/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
+++ b/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
@@ -471,7 +471,7 @@ class PlanRequestDetailList extends React.Component {
         </Grid.Row>
         <div style={{ overflow: 'auto', paddingBottom: 300, height: '100%' }}>
           <ListView className="plan-request-details-list">
-            {paginatedSortedFiltersTasks.tasks.map((task, n) => {
+            {paginatedSortedFiltersTasks.items.map((task, n) => {
               let taskMessage = task.message;
               let taskCancelled = false;
 

--- a/app/javascript/react/screens/App/Plan/components/PlanVmsList.js
+++ b/app/javascript/react/screens/App/Plan/components/PlanVmsList.js
@@ -256,7 +256,7 @@ class PlanVmsList extends React.Component {
         </Grid.Row>
         <div style={{ overflow: 'auto', paddingBottom: 300, height: '100%' }}>
           <ListView className="plan-request-details-list">
-            {paginatedSortedFiltersVms.tasks.map((task, n) => (
+            {paginatedSortedFiltersVms.items.map((task, n) => (
               <ListView.Item
                 key={task.id}
                 heading={task.name}

--- a/app/javascript/react/screens/App/common/ListViewToolbar/paginate.js
+++ b/app/javascript/react/screens/App/common/ListViewToolbar/paginate.js
@@ -2,17 +2,17 @@
  * Client Side Pagination helper which returns amountOfPages, itemCount,
  * itemsStart, itemsEnd, and paginated tasks
  */
-export default function paginate(tasks, page, perPage) {
+export default function paginate(items, page, perPage) {
   // adapt to zero indexed logic
   const p = page - 1 || 0;
-  const amountOfPages = Math.ceil(tasks.length / perPage);
+  const amountOfPages = Math.ceil(items.length / perPage);
   const startPage = p < amountOfPages ? p : 0;
   const endOfPage = startPage * perPage + perPage;
   return {
     amountOfPages,
-    itemCount: tasks.length,
+    itemCount: items.length,
     itemsStart: startPage * perPage + 1,
-    itemsEnd: endOfPage > tasks.length ? tasks.length : endOfPage,
-    tasks: tasks.slice(startPage * perPage, endOfPage)
+    itemsEnd: endOfPage > items.length ? items.length : endOfPage,
+    items: items.slice(startPage * perPage, endOfPage)
   };
 }

--- a/app/javascript/react/screens/App/common/ListViewToolbar/sortFilter.js
+++ b/app/javascript/react/screens/App/common/ListViewToolbar/sortFilter.js
@@ -10,11 +10,12 @@
  *  ...
  * }]
  */
-export default function sortFilter(currentSortType, isSortNumeric, isSortAscending, tasks) {
-  if (currentSortType && tasks && tasks.length) {
+export default function sortFilter(currentSortType, isSortNumeric, isSortAscending, items = []) {
+  const itemsCopy = [...items];
+  if (currentSortType && itemsCopy && itemsCopy.length) {
     if (isSortNumeric) {
       // handle numbers and dates
-      return tasks.sort((a, b) => {
+      return itemsCopy.sort((a, b) => {
         const x = a[currentSortType.id];
         const y = b[currentSortType.id];
         return isSortAscending ? x - y : y - x;
@@ -31,7 +32,7 @@ export default function sortFilter(currentSortType, isSortNumeric, isSortAscendi
     const rx = /(\d+)|(\D+)/g;
     const rd = /\d+/;
 
-    return tasks.sort((as, bs) => {
+    return itemsCopy.sort((as, bs) => {
       a = String(as[currentSortType.id])
         .toLowerCase()
         .match(rx);
@@ -64,5 +65,5 @@ export default function sortFilter(currentSortType, isSortNumeric, isSortAscendi
       return b.length - a.length;
     });
   }
-  return tasks;
+  return itemsCopy;
 }


### PR DESCRIPTION
Fixes #728 
https://bugzilla.redhat.com/show_bug.cgi?id=1643295

Since [].sort(), directly manipulates the array on which it is called,
we are sometimes inadvertently mutating component state.

# Notes
- [Array.prototype.sort()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort)
- To reproduce the issue, make enough Infra Mappings so that you have 2 pages in the ListView.  Then set the sort criteria to "Number of Associated Plans" and wait for the next polling interval to pass