### PR TITLE
Make sure all VMs have ids before formatting

### DIFF
--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/helpers.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/helpers.js
@@ -20,14 +20,11 @@ const manageBlankReason = vm => {
   }
 };
 
-const manageNoIdVMRows = (vm, vmIndex) => {
-  if (!vm.id) {
-    vm.id = `no-id-${vmIndex}`;
-  }
-};
+const manageNoIdVMRows = (vm, vmIndex) => (!vm.id ? { ...vm, id: `no-id-${vmIndex}` } : vm);
+
+const fillMissingIds = vms => vms && vms.map((vm, vmIndex) => (vm.id ? vm : manageNoIdVMRows(vm, vmIndex)));
 
 const manageOddCSVImportErrors = (vm, vmIndex, uniqueIds) => {
-  manageNoIdVMRows(vm, vmIndex);
   manageDuplicateVMRows(vm, vmIndex, uniqueIds);
   manageBlankReason(vm);
 };
@@ -47,10 +44,11 @@ export const _formatValidVms = vms => {
 };
 
 export const _formatInvalidVms = vms => {
-  const uniqueIds = vms && [...new Set(vms.map(value => value.id))];
+  const backfilledVms = fillMissingIds(vms);
+  const uniqueIds = backfilledVms && [...new Set(backfilledVms.map(vm => vm.id))];
   return (
-    vms &&
-    vms.map((v, vIndex) => {
+    backfilledVms &&
+    backfilledVms.map((v, vIndex) => {
       v.allocated_size = numeral(v.allocated_size).format('0.00b');
       v.reason = V2V_VM_POST_VALIDATION_REASONS[v.reason];
       if (
@@ -71,10 +69,11 @@ export const _formatConflictVms = vms => {
   const inactiveVMCount = (vms && vms.filter(vm => vm.cluster === '' || vm.path === '').length) || 0;
   const allVMCount = (vms && vms.length) || 0;
   const vmCount = inactiveVMCount > 0 ? allVMCount - inactiveVMCount : allVMCount;
-  const uniqueIds = vms && [...new Set(vms.map(value => value.id))];
+  const backfilledVms = fillMissingIds(vms);
+  const uniqueIds = backfilledVms && [...new Set(backfilledVms.map(value => value.id))];
   return (
-    vms &&
-    vms.map((v, vIndex) => {
+    backfilledVms &&
+    backfilledVms.map((v, vIndex) => {
       v.allocated_size = numeral(v.allocated_size).format('0.00b');
       v.reason = V2V_VM_POST_VALIDATION_REASONS[v.reason];
 


### PR DESCRIPTION
Fixes #714 

When using a CSV, the VM validation service will return certain types of
invalid VMs without an ID. In order to prevent the UI from marking all
of these as Duplicate VMs, we need to backfill these IDs sooner in the
VM formatting process