### PR TITLE
[#715] Link directly from the Overview page to the Infra Mappings page without filter

### DIFF
--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
@@ -235,7 +235,7 @@ const MigrationsCompletedList = ({
                           ),
                           !isMissingMapping && (
                             <ListView.InfoItem key={`${plan.id}-infraMappingName`}>
-                              {plan.infraMappingName}
+                              <a href="/migration/mappings#">{plan.infraMappingName}</a>
                             </ListView.InfoItem>
                           ),
                           <ListView.InfoItem key={`${plan.id}-elapsed`}>

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
@@ -152,7 +152,7 @@ const MigrationsNotStartedList = ({
                           ),
                           !isMissingMapping && (
                             <ListView.InfoItem key={`${plan.id}-infraMappingName`}>
-                              {plan.infraMappingName}
+                              <a href="/migration/mappings#">{plan.infraMappingName}</a>
                             </ListView.InfoItem>
                           ),
                           migrationScheduled && !migrationStarting ? (


### PR DESCRIPTION
Closes #715.
https://bugzilla.redhat.com/show_bug.cgi?id=1643610

This is an alternative to #742 which does not filter the mappings list upon arrival.


On the Overview list views, the name of the associated infra mapping is now a link:

<img width="893" alt="screenshot 2018-10-26 13 22 45" src="https://user-images.githubusercontent.com/811963/47582466-69af1f00-d922-11e8-9690-024a02d88076.png">