### PR TITLE
[#761] [Code Cleanup] Incorporate <ListViewToolbar /> with PlanRequestDetailList

### DIFF
--- a/app/javascript/react/screens/App/Plan/Plan.js
+++ b/app/javascript/react/screens/App/Plan/Plan.js
@@ -182,6 +182,7 @@ class Plan extends React.Component {
                 filterTypes={planFinished ? FINISHED_PLAN_FILTER_TYPES : ACTIVE_PLAN_FILTER_TYPES}
                 sortFields={planFinished ? FINISHED_PLAN_SORT_FIELDS : ACTIVE_PLAN_SORT_FIELDS}
                 listItems={planRequestTasksMutable}
+                defaultSortTypeIndex={1}
               >
                 {({
                   filteredListItems,

--- a/app/javascript/react/screens/App/Plan/Plan.js
+++ b/app/javascript/react/screens/App/Plan/Plan.js
@@ -8,6 +8,13 @@ import PlanRequestDetailList from './components/PlanRequestDetailList/PlanReques
 import PlanVmsList from './components/PlanVmsList';
 import PlanEmptyState from './components/PlanEmptyState';
 import getMostRecentRequest from '../common/getMostRecentRequest';
+import ListViewToolbar from '../common/ListViewToolbar/ListViewToolbar';
+import {
+  ACTIVE_PLAN_FILTER_TYPES,
+  FINISHED_PLAN_FILTER_TYPES,
+  ACTIVE_PLAN_SORT_FIELDS,
+  FINISHED_PLAN_SORT_FIELDS
+} from './components/PlanRequestDetailList/PlanRequestDetailListConstants';
 
 class Plan extends React.Component {
   static getDerivedStateFromProps(nextProps, prevState) {
@@ -171,29 +178,50 @@ class Plan extends React.Component {
             planRequestPreviouslyFetched &&
             !isRejectedPlanRequest &&
             planRequestTasksMutable.length > 0 && (
-              <PlanRequestDetailList
-                plan={plan}
-                planFinished={planFinished}
-                planRequestTasks={planRequestTasksMutable}
-                downloadLogAction={downloadLogAction}
-                downloadLogInProgressTaskIds={downloadLogInProgressTaskIds}
-                fetchAnsiblePlaybookTemplateAction={fetchAnsiblePlaybookTemplateAction}
-                fetchAnsiblePlaybookTemplateUrl={fetchPlanUrl}
-                ansiblePlaybookTemplate={ansiblePlaybookTemplate}
-                fetchOrchestrationStackUrl={fetchOrchestrationStackUrl}
-                fetchOrchestrationStackAction={fetchOrchestrationStackAction}
-                orchestrationStack={orchestrationStack}
-                cancelPlanRequestTasksUrl={cancelPlanRequestTasksUrl}
-                cancelPlanRequestTasksAction={cancelPlanRequestTasksAction}
-                selectedTasksForCancel={selectedTasksForCancel}
-                updateSelectedTasksForCancelAction={updateSelectedTasksForCancelAction}
-                deleteAllSelectedTasksForCancelAction={deleteAllSelectedTasksForCancelAction}
-                markedForCancellation={markedForCancellation}
-                failedMigrations={failedMigrations}
-                successfulMigrations={successfulMigrations}
-                notificationsSentList={notificationsSentList}
-                dispatchVMTasksCompletionNotificationAction={dispatchVMTasksCompletionNotificationAction}
-              />
+              <ListViewToolbar
+                filterTypes={planFinished ? FINISHED_PLAN_FILTER_TYPES : ACTIVE_PLAN_FILTER_TYPES}
+                sortFields={planFinished ? FINISHED_PLAN_SORT_FIELDS : ACTIVE_PLAN_SORT_FIELDS}
+                listItems={planRequestTasksMutable}
+              >
+                {({
+                  filteredListItems,
+                  filteredSortedPaginatedListItems,
+                  renderFilterControls,
+                  renderSortControls,
+                  renderActiveFilters,
+                  renderPaginationRow
+                }) => (
+                  <PlanRequestDetailList
+                    plan={plan}
+                    planFinished={planFinished}
+                    planRequestTasks={planRequestTasksMutable}
+                    downloadLogAction={downloadLogAction}
+                    downloadLogInProgressTaskIds={downloadLogInProgressTaskIds}
+                    fetchAnsiblePlaybookTemplateAction={fetchAnsiblePlaybookTemplateAction}
+                    fetchAnsiblePlaybookTemplateUrl={fetchPlanUrl}
+                    ansiblePlaybookTemplate={ansiblePlaybookTemplate}
+                    fetchOrchestrationStackUrl={fetchOrchestrationStackUrl}
+                    fetchOrchestrationStackAction={fetchOrchestrationStackAction}
+                    orchestrationStack={orchestrationStack}
+                    cancelPlanRequestTasksUrl={cancelPlanRequestTasksUrl}
+                    cancelPlanRequestTasksAction={cancelPlanRequestTasksAction}
+                    selectedTasksForCancel={selectedTasksForCancel}
+                    updateSelectedTasksForCancelAction={updateSelectedTasksForCancelAction}
+                    deleteAllSelectedTasksForCancelAction={deleteAllSelectedTasksForCancelAction}
+                    markedForCancellation={markedForCancellation}
+                    failedMigrations={failedMigrations}
+                    successfulMigrations={successfulMigrations}
+                    notificationsSentList={notificationsSentList}
+                    dispatchVMTasksCompletionNotificationAction={dispatchVMTasksCompletionNotificationAction}
+                    filteredListItems={filteredListItems}
+                    filteredSortedPaginatedListItems={filteredSortedPaginatedListItems}
+                    renderFilterControls={renderFilterControls}
+                    renderSortControls={renderSortControls}
+                    renderActiveFilters={renderActiveFilters}
+                    renderPaginationRow={renderPaginationRow}
+                  />
+                )}
+              </ListViewToolbar>
             )}
           {!planNotStarted &&
             planRequestPreviouslyFetched &&

--- a/app/javascript/react/screens/App/common/ListViewToolbar/ListViewToolbar.js
+++ b/app/javascript/react/screens/App/common/ListViewToolbar/ListViewToolbar.js
@@ -8,11 +8,9 @@ import paginate from './paginate';
 
 class ListViewToolbar extends Component {
   state = {
-    filterTypes: this.props.filterTypes,
     currentFilterType: this.props.filterTypes[this.props.defaultFilterTypeIndex],
     currentValue: '',
     activeFilters: [],
-    sortFields: this.props.sortFields,
     currentSortType: this.props.sortFields[this.props.defaultSortTypeIndex],
     isSortNumeric: this.props.sortFields[this.props.defaultSortTypeIndex].isNumeric,
     isSortAscending: true,
@@ -23,6 +21,18 @@ class ListViewToolbar extends Component {
     },
     pageChangeValue: 1
   };
+
+  componentDidUpdate(prevProps) {
+    const { filterTypes, sortFields, defaultFilterTypeIndex, defaultSortTypeIndex } = this.props;
+    if (filterTypes !== prevProps.filterTypes) {
+      const newDefaultFilterType = filterTypes[defaultFilterTypeIndex];
+      this.selectFilterType(newDefaultFilterType);
+    }
+    if (sortFields !== prevProps.sortFields) {
+      const newDefaultSortType = sortFields[defaultSortTypeIndex];
+      this.updateCurrentSortType(newDefaultSortType);
+    }
+  }
 
   onValueKeyPress = keyEvent => {
     const { currentValue, currentFilterType } = this.state;
@@ -202,7 +212,8 @@ class ListViewToolbar extends Component {
   };
 
   renderFilterControls = () => {
-    const { filterTypes, currentFilterType } = this.state;
+    const { filterTypes } = this.props;
+    const { currentFilterType } = this.state;
     return (
       <Filter style={{ paddingLeft: 0 }}>
         <Filter.TypeSelector
@@ -216,7 +227,8 @@ class ListViewToolbar extends Component {
   };
 
   renderSortControls = () => {
-    const { sortFields, currentSortType, isSortNumeric, isSortAscending } = this.state;
+    const { sortFields } = this.props;
+    const { currentSortType, isSortNumeric, isSortAscending } = this.state;
     return (
       <Sort>
         <Sort.TypeSelector

--- a/app/javascript/react/screens/App/common/ListViewToolbar/ListViewToolbar.js
+++ b/app/javascript/react/screens/App/common/ListViewToolbar/ListViewToolbar.js
@@ -300,6 +300,7 @@ class ListViewToolbar extends Component {
   };
 
   render() {
+    const filteredListItems = this.filterListItems();
     return this.props.children(
       {
         onFirstPage: this.onFirstPage,
@@ -312,7 +313,8 @@ class ListViewToolbar extends Component {
         clearFilters: this.clearFilters,
         removeFilter: this.removeFilter,
         selectFilterType: this.selectFilterType,
-        filteredSortedPaginatedListItems: this.filterSortPaginateListItems(),
+        filteredListItems,
+        filteredSortedPaginatedListItems: this.filterSortPaginateListItems(filteredListItems),
         toggleCurrentSortDirection: this.toggleCurrentSortDirection,
         updateCurrentSortType: this.updateCurrentSortType,
         renderInput: this.renderInput,

--- a/app/javascript/react/screens/App/common/ListViewToolbar/ListViewToolbar.js
+++ b/app/javascript/react/screens/App/common/ListViewToolbar/ListViewToolbar.js
@@ -211,11 +211,11 @@ class ListViewToolbar extends Component {
     );
   };
 
-  renderFilterControls = () => {
+  renderFilterControls = filterProps => {
     const { filterTypes } = this.props;
     const { currentFilterType } = this.state;
     return (
-      <Filter style={{ paddingLeft: 0 }}>
+      <Filter style={{ paddingLeft: 0 }} {...filterProps}>
         <Filter.TypeSelector
           filterTypes={filterTypes}
           currentFilterType={currentFilterType}

--- a/app/javascript/react/screens/App/common/ListViewToolbar/ListViewToolbar.js
+++ b/app/javascript/react/screens/App/common/ListViewToolbar/ListViewToolbar.js
@@ -135,7 +135,7 @@ class ListViewToolbar extends Component {
     return listFilter(activeFilters, listItems);
   };
 
-  filterSortPaginateListItems = (filteredItems = this.filterListItems()) => {
+  filterSortPaginateListItems = filteredItems => {
     const { currentSortType, isSortNumeric, isSortAscending, pagination } = this.state;
     return paginate(
       sortFilter(currentSortType, isSortNumeric, isSortAscending, filteredItems),


### PR DESCRIPTION
Closes #761.
Closes #767.

https://bugzilla.redhat.com/show_bug.cgi?id=1645714

# Notes

* The `PlanRequestDetailList` has an interesting property that required a change to `ListViewToolbar`: when a plan finishes, its available filter types and sort fields change. There is actually a bug currently in `PlanRequestDetailList` where the currently selected filter will not properly update after this change, so I introduced the `componentDidUpdate` lifecycle method in `ListViewToolbar` to reset the current filter and sort selections to their defaults when this change occurs (I wrote this up in #767, but fixed it here as part of the abstraction). We were also unnecessarily mirroring `filterTypes` and `sortFields` in state, when they fit better as props.

* Because `PlanRequestDetailList` requires access to the filtered items in the scope of its class methods for the purposes of "select all" behavior, I was unable to use `ListViewToolbar` as a child in the render method. (I thought this made the abstraction incompatible, which is why this was closed). But instead I wrapped the whole `PlanRequestDetailList` in a `ListViewToolbar` and passed the filtered items down as a prop, making it a perfect fit (which is why this was reopened!)