### PR TITLE
Fix vertical navigation menu for v2v

### DIFF
--- a/app/controllers/migration_controller.rb
+++ b/app/controllers/migration_controller.rb
@@ -5,8 +5,12 @@ class MigrationController < ApplicationController
   after_action :cleanup_action
 
   def index
-    # this sets the active menu item, must match the item name in lib/manageiq-v2v/engine.rb
-    @layout = 'migration'
+    @layout = case request.path
+              when '/migration/overview'
+                'overview'
+              when '/migration/mappings'
+                'mappings'
+              end
     @page_title = _('Migration')
   end
 

--- a/app/controllers/migration_controller.rb
+++ b/app/controllers/migration_controller.rb
@@ -6,7 +6,7 @@ class MigrationController < ApplicationController
 
   def index
     @layout = case request.path
-              when '/migration/overview'
+              when '/migration/overview', /^\/migration\/plan\/.*/
                 'overview'
               when '/migration/mappings'
                 'mappings'

--- a/app/controllers/migration_controller.rb
+++ b/app/controllers/migration_controller.rb
@@ -10,6 +10,8 @@ class MigrationController < ApplicationController
                 'overview'
               when '/migration/mappings'
                 'mappings'
+              when '/migration/settings'
+                'settings'
               end
     @page_title = _('Migration')
   end

--- a/app/javascript/react/config/Routes.js
+++ b/app/javascript/react/config/Routes.js
@@ -14,7 +14,7 @@ const Routes = ({ store }) =>
         <Route
           exact
           key={path}
-          path={`/${path}`}
+          path={path}
           render={props => {
             if (props.match.isExact) {
               return (
@@ -28,7 +28,7 @@ const Routes = ({ store }) =>
         />
       );
     }
-    return <Route exact key={path} path={`/${path}`} />;
+    return <Route exact key={path} path={path} />;
   });
 
 Routes.propTypes = {

--- a/app/javascript/react/config/config.js
+++ b/app/javascript/react/config/config.js
@@ -5,19 +5,19 @@ import MappingsContainer from '../screens/App/Mappings';
 
 export const links = [
   {
-    path: '',
+    path: '/migration/overview',
     component: OverviewContainer
   },
   {
-    path: 'settings',
+    path: '/migration/settings',
     component: Settings
   },
   {
-    path: 'plan/:id',
+    path: '/migration/plan/:id',
     component: PlanContainer
   },
   {
-    path: 'mappings',
+    path: '/migration/mappings',
     component: MappingsContainer
   }
 ];

--- a/app/javascript/react/index.js
+++ b/app/javascript/react/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ConnectedRouter } from 'connected-react-router';
+import { BrowserRouter } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { Spinner } from 'patternfly-react';
 import PropTypes from 'prop-types';
@@ -21,12 +21,12 @@ class App extends React.Component {
         </div>
       );
     return (
-      <ConnectedRouter history={ManageIQ.redux.history}>
+      <BrowserRouter>
         <React.Fragment>
           <NotificationList />
           <Routes store={ManageIQ.redux.store} />
         </React.Fragment>
-      </ConnectedRouter>
+      </BrowserRouter>
     );
   }
 }

--- a/app/javascript/react/screens/App/Mappings/Mappings.js
+++ b/app/javascript/react/screens/App/Mappings/Mappings.js
@@ -165,7 +165,7 @@ class Mappings extends Component {
       <React.Fragment>
         <Toolbar>
           <Breadcrumb.Item href="/dashboard/maintab?tab=compute">{__('Compute')}</Breadcrumb.Item>
-          <Breadcrumb.Item href="/migration">{__('Migration')}</Breadcrumb.Item>
+          <Breadcrumb.Item href="/migration/overview">{__('Migration')}</Breadcrumb.Item>
           <Breadcrumb.Item active>{__('Infrastructure Mappings')}</Breadcrumb.Item>
         </Toolbar>
         <Spinner

--- a/app/javascript/react/screens/App/Mappings/Mappings.js
+++ b/app/javascript/react/screens/App/Mappings/Mappings.js
@@ -293,16 +293,16 @@ Mappings.propTypes = {
 };
 
 Mappings.defaultProps = {
-  fetchCloudNetworksUrl: 'api/cloud_networks?expand=resources',
+  fetchCloudNetworksUrl: '/api/cloud_networks?expand=resources',
   fetchCloudTenantsUrl:
-    'api/cloud_tenants?expand=resources&attributes=ext_management_system.name,cloud_networks,cloud_volume_types',
-  fetchCloudVolumeTypesUrl: 'api/cloud_volume_types?expand=resources',
+    '/api/cloud_tenants?expand=resources&attributes=ext_management_system.name,cloud_networks,cloud_volume_types',
+  fetchCloudVolumeTypesUrl: '/api/cloud_volume_types?expand=resources',
   fetchClustersUrl:
-    'api/clusters/' +
+    '/api/clusters/' +
     '?attributes=ext_management_system.emstype,v_parent_datacenter,ext_management_system.name,lans,storages' +
     '&expand=resources',
-  fetchDatastoresUrl: 'api/data_stores?expand=resources',
-  fetchNetworksUrl: 'api/lans/?expand=resources',
+  fetchDatastoresUrl: '/api/data_stores?expand=resources',
+  fetchNetworksUrl: '/api/lans/?expand=resources',
   fetchTransformationMappingsUrl: FETCH_TRANSFORMATION_MAPPINGS_URL,
   fetchArchivedTransformationPlansUrl: FETCH_ARCHIVED_TRANSFORMATION_PLANS_URL,
   fetchTransformationPlansUrl: FETCH_TRANSFORMATION_PLANS_URL

--- a/app/javascript/react/screens/App/Mappings/MappingsConstants.js
+++ b/app/javascript/react/screens/App/Mappings/MappingsConstants.js
@@ -13,7 +13,7 @@ export const SHOW_V2V_DELETE_CONFIRMATION_MODAL = 'SHOW_V2V_DELETE_CONFIRMATION_
 export const YES_TO_DELETE_AND_HIDE_DELETE_CONFIRMATION_MODAL = 'YES_TO_DELETE_AND_HIDE_DELETE_CONFIRMATION_MODAL';
 
 export const FETCH_TRANSFORMATION_MAPPINGS_URL =
-  'api/transformation_mappings?expand=resources' +
+  '/api/transformation_mappings?expand=resources' +
   '&attributes=transformation_mapping_items,service_templates' +
   '&sort_by=updated_at' +
   '&sort_order=desc';

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStepConstants.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStepConstants.js
@@ -8,9 +8,9 @@ export const QUERY_ATTRIBUTES = {
 };
 
 export const FETCH_STORAGE_URLS = {
-  source: 'api/clusters',
-  rhevm: 'api/clusters',
-  openstack: 'api/cloud_tenants'
+  source: '/api/clusters',
+  rhevm: '/api/clusters',
+  openstack: '/api/cloud_tenants'
 };
 
 export const STORAGE_ATTRIBUTES = {

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardNetworksStep/MappingWizardNetworksStepConstants.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardNetworksStep/MappingWizardNetworksStepConstants.js
@@ -9,9 +9,9 @@ export const QUERY_ATTRIBUTES = {
 };
 
 export const FETCH_NETWORK_URLS = {
-  source: 'api/clusters',
-  rhevm: 'api/clusters',
-  openstack: 'api/cloud_tenants',
+  source: '/api/clusters',
+  rhevm: '/api/clusters',
+  openstack: '/api/cloud_tenants',
   public: '/api/providers'
 };
 

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardResultsStep/MappingWizardResultsStep.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardResultsStep/MappingWizardResultsStep.js
@@ -118,7 +118,7 @@ MappingWizardResultsStep.propTypes = {
   redirectTo: PropTypes.func
 };
 MappingWizardResultsStep.defaultProps = {
-  postMappingsUrl: 'api/transformation_mappings',
+  postMappingsUrl: '/api/transformation_mappings',
   postTransformMappingsAction: noop,
   transformationsBody: {},
   isPostingMappings: true,

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardResultsStep/MappingWizardResultsStep.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardResultsStep/MappingWizardResultsStep.js
@@ -51,7 +51,7 @@ class MappingWizardResultsStep extends React.Component {
 
   onContinueToPlanWizard = id => {
     this.props.continueToPlanAction(id);
-    this.props.redirectTo('/');
+    this.props.redirectTo('/migration/overview');
   };
 
   render() {

--- a/app/javascript/react/screens/App/Overview/Overview.js
+++ b/app/javascript/react/screens/App/Overview/Overview.js
@@ -328,7 +328,7 @@ class Overview extends React.Component {
                 description={__('Create an infrastructure mapping to later be used by a migration plan')}
                 buttonText={__('Create Infrastructure Mapping')}
                 showWizardAction={() => {
-                  this.redirectTo('/mappings');
+                  this.redirectTo('/migration/mappings');
                   openMappingWizardOnTransitionAction();
                 }}
                 className="full-page-empty"

--- a/app/javascript/react/screens/App/Overview/components/Migrations/InProgressWithDetailCard.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/InProgressWithDetailCard.js
@@ -7,7 +7,7 @@ const InProgressWithDetailCard = ({ plan, failedOverlay, handleClick, children }
   <InProgressCard
     onClick={e => {
       if (!e.target.classList.contains('pficon-error-circle-o')) {
-        handleClick(`/plan/${plan.id}`);
+        handleClick(`/migration/plan/${plan.id}`);
       }
     }}
     className="in-progress"

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
@@ -191,7 +191,7 @@ const MigrationsCompletedList = ({
                         onClick={e => {
                           e.stopPropagation();
 
-                          redirectTo(`/plan/${plan.id}`);
+                          redirectTo(`/migration/plan/${plan.id}`);
                         }}
                         key={plan.id}
                         leftContent={

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
@@ -87,7 +87,7 @@ const MigrationsNotStartedList = ({
                         stacked
                         className="plans-not-started-list__list-item"
                         onClick={() => {
-                          redirectTo(`/plan/${plan.id}`);
+                          redirectTo(`/migration/plan/${plan.id}`);
                         }}
                         actions={
                           <div>

--- a/app/javascript/react/screens/App/Overview/components/Migrations/__test__/MigrationsNotStartedList.test.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/__test__/MigrationsNotStartedList.test.js
@@ -29,7 +29,7 @@ test('clicking on a plan fires redirectTo with the path to its details page', ()
     .at(0)
     .simulate('click');
 
-  expect(redirectTo).toHaveBeenLastCalledWith(`/plan/${notStartedPlan.id}`);
+  expect(redirectTo).toHaveBeenLastCalledWith(`/migration/plan/${notStartedPlan.id}`);
 });
 
 test.skip('clicking on the Migrate button fires migrateClick with the correct API endpoint', () => {

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardInstancePropertiesStep/PlanWizardInstancePropertiesStep.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardInstancePropertiesStep/PlanWizardInstancePropertiesStep.js
@@ -119,7 +119,7 @@ PlanWizardInstancePropertiesStep.propTypes = {
 
 PlanWizardInstancePropertiesStep.defaultProps = {
   fetchOpenstackTenantUrl: '/api/cloud_tenants',
-  bestFitFlavorUrl: 'api/transformation_mappings',
+  bestFitFlavorUrl: '/api/transformation_mappings',
   queryOpenstackTenantAttributes: ['flavors', 'security_groups', 'default_security_group']
 };
 

--- a/app/javascript/react/screens/App/Plan/Plan.js
+++ b/app/javascript/react/screens/App/Plan/Plan.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Immutable from 'seamless-immutable';
-import { Link } from 'react-router-dom';
 import { Breadcrumb, Spinner, Icon } from 'patternfly-react';
 import Toolbar from '../../../config/Toolbar';
 import PlanRequestDetailList from './components/PlanRequestDetailList/PlanRequestDetailList';
@@ -165,7 +164,7 @@ class Plan extends React.Component {
         <Toolbar>
           <Breadcrumb.Item href="/dashboard/maintab?tab=compute">{__('Compute')}</Breadcrumb.Item>
           <li>
-            <Link to="/">{__('Migration')}</Link>
+            <a href="/migration/overview">{__('Migration')}</a>
           </li>
           {!isRejectedPlan &&
             planName && (

--- a/app/javascript/react/screens/App/common/NotificationList/NotificationList.js
+++ b/app/javascript/react/screens/App/common/NotificationList/NotificationList.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { TimedToastNotification, ToastNotificationList } from 'patternfly-react';
-import { Link } from 'react-router-dom';
 
 class NotificationList extends React.Component {
   render() {
@@ -25,7 +24,7 @@ class NotificationList extends React.Component {
               </span>
               {notification.actionEnabled && (
                 <div className="pull-right toast-pf-action">
-                  <Link to={`/plan/${notification.data.id}`}>{__('View Details')}</Link>
+                  <a href={`/migration/plan/${notification.data.id}`}>{__('View Details')}</a>
                 </div>
               )}
             </TimedToastNotification>

--- a/app/javascript/redux/actions/routerActions.js
+++ b/app/javascript/redux/actions/routerActions.js
@@ -1,8 +1,3 @@
-import { push } from 'connected-react-router';
-
-export const redirectTo = path => (dispatch, getState) => {
-  // NOTE: to avoid pushing the same path to history and throwing error
-  if (getState().router.location.pathname !== path) {
-    dispatch(push(path));
-  }
+export const redirectTo = path => () => {
+  window.DoNav(path);
 };

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 # ManageIQ::V2V::Engine.routes.draw do
 Rails.application.routes.draw do
+  match '/migration' => redirect('/migration/overview'), :via => [:get]
   match '/migration/overview' => 'migration#index', :via => [:get]
   match '/migration/mappings' => 'migration#index', :via => [:get]
   match '/migration/plan/:id' => 'migration#index', :via => [:get]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@
 Rails.application.routes.draw do
   match '/migration/overview' => 'migration#index', :via => [:get]
   match '/migration/mappings' => 'migration#index', :via => [:get]
+  match '/migration/plan/:id' => 'migration#index', :via => [:get]
   match 'migration/*page' => 'migration#index', :via => [:get]
 
   get "migration_log/download_migration_log(/:id)",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 # ManageIQ::V2V::Engine.routes.draw do
 Rails.application.routes.draw do
-  match '/migration' => 'migration#index', :via => [:get]
+  match '/migration/overview' => 'migration#index', :via => [:get]
+  match '/migration/mappings' => 'migration#index', :via => [:get]
   match 'migration/*page' => 'migration#index', :via => [:get]
 
   get "migration_log/download_migration_log(/:id)",

--- a/lib/manageiq/v2v/engine.rb
+++ b/lib/manageiq/v2v/engine.rb
@@ -14,7 +14,7 @@ module ManageIQ::V2V
       Menu::CustomLoader.register(
         Menu::Section.new(:migration, N_("Migration"), 'fa fa-plus', [
           Menu::Item.new('overview', N_("Overview"), 'migration', {:feature => 'migration', :any => true}, '/migration/overview'),
-          Menu::Item.new('mappings', N_("Infrastructure Mappings"), 'mappings', {:feature => 'mappings', :any => true}, '/migration/mappings#/mappings'),
+          Menu::Item.new('mappings', N_("Infrastructure Mappings"), 'mappings', {:feature => 'mappings', :any => true}, '/migration/mappings'),
           Menu::Item.new('settings', N_("Migration Settings"), 'migration_settings', {:feature => 'migration_settings', :any => true}, '/migration/settings')
         ], nil, nil, nil, nil, :compute)
       )

--- a/lib/manageiq/v2v/engine.rb
+++ b/lib/manageiq/v2v/engine.rb
@@ -13,9 +13,9 @@ module ManageIQ::V2V
     initializer 'plugin' do
       Menu::CustomLoader.register(
         Menu::Section.new(:migration, N_("Migration"), 'fa fa-plus', [
-          Menu::Item.new('migration', N_("Overview"), 'migration', {:feature => 'migration', :any => true}, '/migration'),
-          Menu::Item.new('mappings', N_("Infrastructure Mappings"), 'mappings', {:feature => 'mappings', :any => true}, '/migration#/mappings'),
-          Menu::Item.new('settings', N_("Migration Settings"), 'migration_settings', {:feature => 'migration_settings', :any => true}, '/migration#/settings')
+          Menu::Item.new('overview', N_("Overview"), 'migration', {:feature => 'migration', :any => true}, '/migration/overview'),
+          Menu::Item.new('mappings', N_("Infrastructure Mappings"), 'mappings', {:feature => 'mappings', :any => true}, '/migration/mappings#/mappings'),
+          Menu::Item.new('settings', N_("Migration Settings"), 'migration_settings', {:feature => 'migration_settings', :any => true}, '/migration/settings')
         ], nil, nil, nil, nil, :compute)
       )
     end


### PR DESCRIPTION
This PR fixes vertical nagivation menu for v2v to work consistently with the rest of the ManageIQ application. Before these fixes, migration vertical menu items wouldn't be propery highlighted during navigation, nor would the last visited item be remembered when navigating back to the migration menu.

More specifically, this PR:
1. introduces proper RoR routes for migration overview, infra mappings and particular migration plain
2. contains controller & navigation menu changes for the above item
3. fixes API URL strings: some of the did not contain `/` at the beginning, which would lead to incorrect urls being constructed with my changes in place (such as `/migration/api/...`)
4. Replace `ConnectedRouter` with `BrowserRouter`
5. contains fixes for v2v navigation links
6. contains fixes for a js warning which would show when navigating to some v2v pages (overview, plan id, ...): ```Warning: Can't call setState (or forceUpdate) on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in the componentWillUnmount method. in Plan (created by Connect(Plan)) in Connect(Plan) (created by I18nProviderWrapper(Connect(Plan))) in IntlProvider (created by I18nProviderWrapper(Connect(Plan))) in I18nProviderWrapper(Connect(Plan)) (created by Route)``` 

@himdel 

Fixes https://github.com/ManageIQ/manageiq-v2v/issues/717 and https://github.com/ManageIQ/manageiq-v2v/issues/768

https://bugzilla.redhat.com/show_bug.cgi?id=1642104