### PR TITLE
[#753] Public cloud networks

### DIFF
--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardClustersStep/MappingWizardClustersStep.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardClustersStep/MappingWizardClustersStep.js
@@ -130,7 +130,7 @@ MappingWizardClustersStep.defaultProps = {
       '/api/clusters?expand=resources' +
       '&attributes=ext_management_system.emstype,v_parent_datacenter,ext_management_system.name,hosts' +
       '&filter[]=ext_management_system.emstype=rhevm',
-    openstack: '/api/cloud_tenants?expand=resources&attributes=ext_management_system.name'
+    openstack: '/api/cloud_tenants?expand=resources&attributes=ext_management_system.name,ext_management_system.id'
   }
 };
 

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardNetworksStep/MappingWizardNetworksStep.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardNetworksStep/MappingWizardNetworksStep.js
@@ -7,7 +7,7 @@ import { length } from 'redux-form-validators';
 import NetworksStepForm from './components/NetworksStepForm/NetworksStepForm';
 import { BootstrapSelect } from '../../../../../common/forms/BootstrapSelect';
 import { getClusterOptions, updateMappings } from '../helpers';
-import { FETCH_NETWORK_URLS } from './MappingWizardNetworksStepConstants';
+import { FETCH_NETWORK_URLS, HAS_CLOUD_NETWORKS } from './MappingWizardNetworksStepConstants';
 import { createNetworksMappings } from './components/NetworksStepForm/helpers';
 
 class MappingWizardNetworksStep extends React.Component {
@@ -91,6 +91,7 @@ class MappingWizardNetworksStep extends React.Component {
       fetchNetworksUrls,
       fetchSourceNetworksAction,
       fetchTargetNetworksAction,
+      fetchPublicCloudNetworksAction,
       clusterMappings,
       targetProvider
     } = this.props;
@@ -108,6 +109,10 @@ class MappingWizardNetworksStep extends React.Component {
 
     fetchSourceNetworksAction(fetchNetworksUrls.source, sourceClusterId);
     fetchTargetNetworksAction(fetchNetworksUrls[targetProvider], targetCluster.id, targetProvider);
+
+    if (HAS_CLOUD_NETWORKS[targetProvider]) {
+      fetchPublicCloudNetworksAction(fetchNetworksUrls.public, targetCluster.ext_management_system.id);
+    }
   };
 
   render() {
@@ -166,6 +171,7 @@ MappingWizardNetworksStep.propTypes = {
   clusterMappings: PropTypes.array,
   editingMapping: PropTypes.object,
   fetchNetworksUrls: PropTypes.object,
+  fetchPublicCloudNetworksAction: PropTypes.func,
   fetchSourceNetworksAction: PropTypes.func,
   fetchTargetNetworksAction: PropTypes.func,
   initialize: PropTypes.func,

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardNetworksStep/MappingWizardNetworksStep.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardNetworksStep/MappingWizardNetworksStep.js
@@ -111,7 +111,7 @@ class MappingWizardNetworksStep extends React.Component {
     fetchTargetNetworksAction(fetchNetworksUrls[targetProvider], targetCluster.id, targetProvider);
 
     if (HAS_CLOUD_NETWORKS[targetProvider]) {
-      fetchPublicCloudNetworksAction(fetchNetworksUrls.public, targetCluster.ext_management_system.id);
+      fetchPublicCloudNetworksAction(fetchNetworksUrls.public, targetCluster);
     }
   };
 

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardNetworksStep/MappingWizardNetworksStepActions.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardNetworksStep/MappingWizardNetworksStepActions.js
@@ -3,6 +3,7 @@ import API from '../../../../../../../../common/API';
 import {
   FETCH_V2V_SOURCE_NETWORKS,
   FETCH_V2V_TARGET_NETWORKS,
+  FETCH_V2V_PUBLIC_CLOUD_NETWORKS,
   QUERY_ATTRIBUTES
 } from './MappingWizardNetworksStepConstants';
 import { V2V_TARGET_PROVIDER_NETWORK_KEYS } from '../../MappingWizardConstants';
@@ -84,4 +85,17 @@ export const fetchTargetNetworksAction = (url, id, targetProvider) => {
   uri.addSearch({ attributes: QUERY_ATTRIBUTES[targetProvider] });
 
   return _getTargetNetworksActionCreator(uri.toString(), targetProvider);
+};
+
+const _getPublicCloudNetworksActionCreator = url => dispatch =>
+  dispatch({
+    type: FETCH_V2V_PUBLIC_CLOUD_NETWORKS,
+    payload: API.get(url)
+  });
+
+export const fetchPublicCloudNetworksAction = (url, id) => {
+  const uri = new URI(`${url}/${id}/cloud_networks`);
+  uri.addSearch({ expand: 'resources' });
+
+  return _getPublicCloudNetworksActionCreator(uri.toString());
 };

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardNetworksStep/MappingWizardNetworksStepConstants.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardNetworksStep/MappingWizardNetworksStepConstants.js
@@ -1,5 +1,6 @@
 export const FETCH_V2V_SOURCE_NETWORKS = 'FETCH_V2V_SOURCE_NETWORKS';
 export const FETCH_V2V_TARGET_NETWORKS = 'FETCH_V2V_TARGET_NETWORKS';
+export const FETCH_V2V_PUBLIC_CLOUD_NETWORKS = 'FETCH_V2V_PUBLIC_CLOUD_NETWORKS';
 
 export const QUERY_ATTRIBUTES = {
   source: 'lans,ext_management_system.name,v_parent_datacenter',
@@ -10,7 +11,8 @@ export const QUERY_ATTRIBUTES = {
 export const FETCH_NETWORK_URLS = {
   source: 'api/clusters',
   rhevm: 'api/clusters',
-  openstack: 'api/cloud_tenants'
+  openstack: 'api/cloud_tenants',
+  public: '/api/providers'
 };
 
 export const NETWORK_ATTRIBUTES = {

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardNetworksStep/MappingWizardNetworksStepConstants.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardNetworksStep/MappingWizardNetworksStepConstants.js
@@ -19,3 +19,8 @@ export const NETWORK_ATTRIBUTES = {
   openstack: 'cloud_networks',
   rhevm: 'lans'
 };
+
+export const HAS_CLOUD_NETWORKS = {
+  openstack: true,
+  rhevm: false
+};

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardNetworksStep/MappingWizardNetworksStepReducer.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardNetworksStep/MappingWizardNetworksStepReducer.js
@@ -53,9 +53,7 @@ export default (state = initialState, action) => {
     case `${FETCH_V2V_PUBLIC_CLOUD_NETWORKS}_PENDING`:
       return state.set('isFetchingPublicCloudNetworks', true).set('isRejectedPublicCloudNetworks', false);
     case `${FETCH_V2V_PUBLIC_CLOUD_NETWORKS}_FULFILLED`:
-      return state
-        .set('publicCloudNetworks', action.payload.data.resources)
-        .set('isFetchingPublicCloudNetworks', false);
+      return state.set('publicCloudNetworks', action.payload).set('isFetchingPublicCloudNetworks', false);
     case `${FETCH_V2V_PUBLIC_CLOUD_NETWORKS}_REJECTED`:
       return state
         .set('errorPublicCloudNetworks', action.payload)

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardNetworksStep/MappingWizardNetworksStepReducer.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardNetworksStep/MappingWizardNetworksStepReducer.js
@@ -1,6 +1,10 @@
 import Immutable from 'seamless-immutable';
 
-import { FETCH_V2V_SOURCE_NETWORKS, FETCH_V2V_TARGET_NETWORKS } from './MappingWizardNetworksStepConstants';
+import {
+  FETCH_V2V_SOURCE_NETWORKS,
+  FETCH_V2V_TARGET_NETWORKS,
+  FETCH_V2V_PUBLIC_CLOUD_NETWORKS
+} from './MappingWizardNetworksStepConstants';
 import { V2V_MAPPING_WIZARD_EXITED } from '../../../../screens/MappingWizard/MappingWizardConstants';
 
 const initialState = Immutable({
@@ -11,7 +15,11 @@ const initialState = Immutable({
   isRejectedTargetNetworks: false,
   errorTargetNetworks: null,
   sourceNetworks: [],
-  targetNetworks: []
+  targetNetworks: [],
+  isFetchingPublicCloudNetworks: false,
+  isRejectedPublicCloudNetworks: false,
+  errorPublicCloudNetworks: null,
+  publicCloudNetworks: []
 });
 
 export default (state = initialState, action) => {
@@ -41,6 +49,19 @@ export default (state = initialState, action) => {
         .set('errorTargetNetworks', action.payload)
         .set('isRejectedTargetNetworks', true)
         .set('isFetchingTargetNetworks', false);
+
+    case `${FETCH_V2V_PUBLIC_CLOUD_NETWORKS}_PENDING`:
+      return state.set('isFetchingPublicCloudNetworks', true).set('isRejectedPublicCloudNetworks', false);
+    case `${FETCH_V2V_PUBLIC_CLOUD_NETWORKS}_FULFILLED`:
+      return state
+        .set('publicCloudNetworks', action.payload.data.resources)
+        .set('isFetchingPublicCloudNetworks', false);
+    case `${FETCH_V2V_PUBLIC_CLOUD_NETWORKS}_REJECTED`:
+      return state
+        .set('errorPublicCloudNetworks', action.payload)
+        .set('isRejectedPublicCloudNetworks', true)
+        .set('isFetchingPublicCloudNetworks', false);
+
     case V2V_MAPPING_WIZARD_EXITED:
       return initialState;
 

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardNetworksStep/MappingWizardNetworksStepSelectors.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardNetworksStep/MappingWizardNetworksStepSelectors.js
@@ -1,4 +1,5 @@
 import { networkKey } from '../../../../../common/networkKey';
+import { normalizeCloudNetworkHref } from './helpers';
 
 export const uniqueNetworks = (networks = []) =>
   networks.reduce(
@@ -10,3 +11,17 @@ export const uniqueNetworks = (networks = []) =>
     }),
     {}
   );
+
+export const combineNetworks = (privateNetworks, publicNetworks) => {
+  const normalizedPublicNetworks = publicNetworks.filter(network => network.shared).map(normalizeCloudNetworkHref);
+
+  return [...normalizedPublicNetworks, ...privateNetworks].reduce((networks, network) => {
+    const networkIsDuplicate = networks.some(ntwk => ntwk.id === network.id);
+
+    if (networkIsDuplicate) {
+      return networks;
+    }
+
+    return [...networks, network];
+  }, []);
+};

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardNetworksStep/__tests__/__snapshots__/MappingWizardDatastoresStepReducer.test.js.snap
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardNetworksStep/__tests__/__snapshots__/MappingWizardDatastoresStepReducer.test.js.snap
@@ -118,12 +118,16 @@ Object {
 
 exports[`sets default state 1`] = `
 Object {
+  "errorPublicCloudNetworks": null,
   "errorSourceNetworks": null,
   "errorTargetNetworks": null,
+  "isFetchingPublicCloudNetworks": false,
   "isFetchingSourceNetworks": false,
   "isFetchingTargetNetworks": false,
+  "isRejectedPublicCloudNetworks": false,
   "isRejectedSourceNetworks": false,
   "isRejectedTargetNetworks": false,
+  "publicCloudNetworks": Array [],
   "sourceNetworks": Array [],
   "targetNetworks": Array [],
 }

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardNetworksStep/helpers.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardNetworksStep/helpers.js
@@ -1,0 +1,5 @@
+export const normalizeCloudNetworkHref = network => {
+  const normalizedHref = network.href && network.href.replace(/\/providers\/\d+/, '');
+
+  return { ...network, href: normalizedHref };
+};

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardNetworksStep/index.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardNetworksStep/index.js
@@ -2,7 +2,7 @@ import { connect } from 'react-redux';
 import MappingWizardNetworksStep from './MappingWizardNetworksStep';
 import * as MappingWizardNetworksStepActions from './MappingWizardNetworksStepActions';
 import { showAlertAction } from '../../MappingWizardActions';
-import { uniqueNetworks } from './MappingWizardNetworksStepSelectors';
+import { uniqueNetworks, combineNetworks } from './MappingWizardNetworksStepSelectors';
 
 import reducer from './MappingWizardNetworksStepReducer';
 
@@ -17,7 +17,9 @@ const mapStateToProps = (
   editingMapping,
   clusterMappings: form.mappingWizardClustersStep.values.clusterMappings,
   groupedSourceNetworks: uniqueNetworks(mappingWizardNetworksStep.sourceNetworks),
-  groupedTargetNetworks: uniqueNetworks(mappingWizardNetworksStep.targetNetworks),
+  groupedTargetNetworks: uniqueNetworks(
+    combineNetworks(mappingWizardNetworksStep.targetNetworks, mappingWizardNetworksStep.publicCloudNetworks)
+  ),
   targetProvider: form.mappingWizardGeneralStep.values.targetProvider,
   mappingWizardNetworksStepForm: form.mappingWizardNetworksStep,
   initialValues: {


### PR DESCRIPTION
Fixes #753 
https://bugzilla.redhat.com/show_bug.cgi?id=1644442

# Notes
Even though the public networks are available to all target tenants, they still belong to _some_ `cloud_tenant`.  Therefore, if an OSP mapping maps any network(s) to one of these public networks, the list view visualization will reflect the network's actual associated `cloud_tenant` as opposed to the target tenant for the mapping (***sub-note:*** this always has and will continue to be the case, but up until now, the network's associated tenant/cluster always matched the target tenant/cluster without exception)

![manageiq__migration](https://user-images.githubusercontent.com/15141412/48150812-b503ee80-e28d-11e8-84ef-cae937b5560a.png)

![manageiq__migration](https://user-images.githubusercontent.com/15141412/48150975-1d52d000-e28e-11e8-8ff4-ec0234915f2b.png)
