### PR TITLE
[#785] Add defensive coding to helpers

### DIFF
--- a/app/javascript/react/screens/App/Overview/components/Migrations/helpers/getMostRecentVMTasksFromRequests.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/helpers/getMostRecentVMTasksFromRequests.js
@@ -12,7 +12,13 @@ const getMostRecentVMTasksFromRequests = (requests, actions) => {
 
   const vmTasksForRequestOfPlan = [];
   vmTasksForRequestOfPlan.push(
-    vm_ids.map(vmId => commonUtilitiesHelper.getMostRecentEntityByCreationDate(groupedByVMId[vmId]))
+    vm_ids.reduce((tasks, id) => {
+      const task = commonUtilitiesHelper.getMostRecentEntityByCreationDate(groupedByVMId[id]);
+      if (task) {
+        return [...tasks, task];
+      }
+      return tasks;
+    }, [])
   );
 
   const flattenVMTasksForRequestOfPlan = [];

--- a/app/javascript/react/screens/App/common/commonUtilitiesHelper.js
+++ b/app/javascript/react/screens/App/common/commonUtilitiesHelper.js
@@ -1,8 +1,9 @@
 const commonUtilitiesHelper = {
   getMostRecentEntityByCreationDate: entities =>
-    entities.reduce((prev, current) => (prev.created_on > current.created_on ? prev : current)),
+    entities && entities.reduce((prev, current) => (prev.created_on > current.created_on ? prev : current)),
 
   groupBy: (items, key) =>
+    items &&
     items.reduce(
       (result, item) => ({
         ...result,
@@ -12,7 +13,7 @@ const commonUtilitiesHelper = {
     ),
 
   flatten: (arrayItems, flattenedArray) =>
-    arrayItems.map(task => task.map(arrayElement => flattenedArray.push(arrayElement)))
+    arrayItems && arrayItems.map(task => task.map(arrayElement => flattenedArray.push(arrayElement)))
 };
 
 export default commonUtilitiesHelper;


### PR DESCRIPTION
Fixes #785 
https://bugzilla.redhat.com/show_bug.cgi?id=1648460

In the edge case where a request that we expect to have tasks has none,
using map on vm_ids will result with [undefined] being pushed into
vmTasksForRequestOfPlan instead of an empty array.

# Notes
* To reproduce the bug as described in the BZ, delete all `ServiceTemplateTransformationPlanTask` in the rails console, but leave all existing plans and requests
* Viewing plans on Overview and in the Plan details pages should work as expected