### PR TITLE
Enable editing orphaned plans and handle undefined mapping when editing

### DIFF
--- a/app/javascript/react/screens/App/Overview/Overview.js
+++ b/app/javascript/react/screens/App/Overview/Overview.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Card, Breadcrumb, CardGrid, Spinner } from 'patternfly-react';
+import { Card, Breadcrumb, CardGrid, Spinner, Icon } from 'patternfly-react';
 
 import Toolbar from '../../../config/Toolbar';
 import * as AggregateCards from './components/AggregateCards';
@@ -66,13 +66,12 @@ class Overview extends React.Component {
       isContinuingToPlan,
       fetchTransformationPlansUrl,
       fetchTransformationPlansAction,
-      planWizardId,
-      showPlanWizardAction
+      planWizardId
     } = this.props;
     const { hasMadeInitialPlansFetch } = this.state;
 
     if (isContinuingToPlan !== nextProps.isContinuingToPlan && !nextProps.isContinuingToPlan) {
-      showPlanWizardAction(planWizardId);
+      this.showPlanWizardOrError(planWizardId);
     }
 
     // kill interval if a wizard becomes visble
@@ -90,6 +89,44 @@ class Overview extends React.Component {
   componentWillUnmount() {
     this.stopPolling();
   }
+
+  showPlanWizardOrError = planWizardId => {
+    const { transformationMappings, showPlanWizardAction } = this.props;
+    if (transformationMappings.length > 0) {
+      showPlanWizardAction(planWizardId);
+    } else {
+      this.showNoMappingsError();
+    }
+  };
+
+  showPlanWizardEditModeOrError = editingPlanId => {
+    const { transformationMappings, showPlanWizardEditModeAction } = this.props;
+    if (transformationMappings.length > 0) {
+      showPlanWizardEditModeAction(editingPlanId);
+    } else {
+      this.showNoMappingsError();
+    }
+  };
+
+  showNoMappingsError = () => {
+    const { showConfirmModalAction, hideConfirmModalAction } = this.props;
+    showConfirmModalAction({
+      title: __('Migration plan error'),
+      icon: <Icon className="confirm-warning-icon" type="pf" name="error-circle-o" />,
+      body: (
+        <React.Fragment>
+          <h3 style={{ marginTop: 0 }}>{__('No infrastructure mapping exists')}</h3>
+          <p>
+            {__('A migration plan must include an infrastructure mapping.')}{' '}
+            <a href="/migration#/mappings">{__('Go to the Infrastructure Mappings page to create one.')}</a>
+          </p>
+        </React.Fragment>
+      ),
+      cancelButtonLabel: null,
+      confirmButtonLabel: __('Close'),
+      onConfirm: hideConfirmModalAction
+    });
+  };
 
   startPolling = () => {
     const { fetchTransformationPlansAction, fetchTransformationPlansUrl } = this.props;
@@ -188,7 +225,6 @@ class Overview extends React.Component {
     const {
       isFetchingProviders,
       hasSufficientProviders,
-      showPlanWizardAction,
       mappingWizardVisible,
       planWizardVisible,
       editPlanNameModalVisible,
@@ -227,7 +263,6 @@ class Overview extends React.Component {
       scheduleMigrationModal,
       scheduleMigrationPlan,
       scheduleMigration,
-      showPlanWizardEditModeAction,
       fetchTransformationMappingsUrl,
       fetchTransformationMappingsAction,
       openMappingWizardOnTransitionAction,
@@ -263,7 +298,7 @@ class Overview extends React.Component {
                 activeTransformationPlans={activeTransformationPlans}
                 serviceTemplatePlaybooks={serviceTemplatePlaybooks}
                 finishedTransformationPlans={finishedTransformationPlans}
-                createMigrationPlanClick={showPlanWizardAction}
+                createMigrationPlanClick={this.showPlanWizardOrError}
                 createTransformationPlanRequestClick={this.createTransformationPlanRequest}
                 isCreatingTransformationPlanRequest={isCreatingTransformationPlanRequest}
                 redirectTo={this.redirectTo}
@@ -282,7 +317,7 @@ class Overview extends React.Component {
                 scheduleMigrationModal={scheduleMigrationModal}
                 scheduleMigrationPlan={scheduleMigrationPlan}
                 scheduleMigration={scheduleMigration}
-                showPlanWizardEditModeAction={showPlanWizardEditModeAction}
+                showPlanWizardEditModeAction={this.showPlanWizardEditModeOrError}
                 fetchTransformationMappingsUrl={fetchTransformationMappingsUrl}
                 fetchTransformationMappingsAction={fetchTransformationMappingsAction}
                 showEditPlanNameModalAction={showEditPlanNameModalAction}

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
@@ -80,7 +80,7 @@ const MigrationsNotStartedList = ({
                       />
                     );
 
-                    const editPlanDisabled = isMissingMapping || loading === plan.href;
+                    const editPlanDisabled = loading === plan.href;
 
                     return (
                       <ListView.Item

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardAdvancedOptionsStep/index.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardAdvancedOptionsStep/index.js
@@ -26,7 +26,10 @@ const mapStateToProps = (
   ownProps
 ) => {
   const editingPlan = findEditingPlan(transformationPlans, editingPlanId);
-  const shouldPrefillForEditing = editingPlan && editingPlan.transformation_mapping.id === infrastructure_mapping;
+  const shouldPrefillForEditing =
+    editingPlan &&
+    editingPlan.transformation_mapping &&
+    editingPlan.transformation_mapping.id === infrastructure_mapping;
   const validVmsDeduped = !shouldPrefillForEditing
     ? planWizardVMStep.valid_vms
     : planWizardVMStep.valid_vms.filter(

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardGeneralStep/PlanWizardGeneralStep.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardGeneralStep/PlanWizardGeneralStep.js
@@ -8,7 +8,13 @@ import { BootstrapSelect } from '../../../../../common/forms/BootstrapSelect';
 import { validation } from '../../../../../../../../common/constants';
 import { asyncValidate, onChange } from './helpers';
 
-const PlanWizardGeneralStep = ({ transformationMappings, editingPlan, showAlertAction, hideAlertAction }) => (
+const PlanWizardGeneralStep = ({
+  transformationMappings,
+  editingPlan,
+  editingOrphanedPlan,
+  showAlertAction,
+  hideAlertAction
+}) => (
   <Form className="form-horizontal">
     <Field
       name="infrastructure_mapping"
@@ -25,7 +31,7 @@ const PlanWizardGeneralStep = ({ transformationMappings, editingPlan, showAlertA
       labelWidth={2}
       controlWidth={9}
       onChange={event => {
-        if (editingPlan && event.target.value !== editingPlan.transformation_mapping.id) {
+        if (editingPlan && (editingOrphanedPlan || event.target.value !== editingPlan.transformation_mapping.id)) {
           showAlertAction(
             __('Selecting a different infrastructure mapping will cause all VM and option selections to be cleared.'),
             'warning'
@@ -81,6 +87,7 @@ const PlanWizardGeneralStep = ({ transformationMappings, editingPlan, showAlertA
 PlanWizardGeneralStep.propTypes = {
   transformationMappings: PropTypes.array,
   editingPlan: PropTypes.object,
+  editingOrphanedPlan: PropTypes.bool,
   showAlertAction: PropTypes.func,
   hideAlertAction: PropTypes.func
 };

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardGeneralStep/index.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardGeneralStep/index.js
@@ -10,12 +10,14 @@ const mapStateToProps = ({ overview, planWizard }) => {
     editingPlan.options &&
     editingPlan.options.config_info &&
     editingPlan.options.config_info.transformation_mapping_id;
+  const prefilledMappingExists =
+    prefilledMappingId && overview.transformationMappings.some(mapping => mapping.id === prefilledMappingId);
   return {
     transformationMappings: overview.transformationMappings,
     transformationPlans: overview.transformationPlans,
     archivedTransformationPlans: overview.archivedTransformationPlans,
     initialValues: {
-      infrastructure_mapping: prefilledMappingId || overview.planWizardId,
+      infrastructure_mapping: (prefilledMappingExists && prefilledMappingId) || overview.planWizardId,
       vm_choice_radio: 'vms_via_discovery',
       name: editingPlan ? editingPlan.name : '',
       description: editingPlan ? editingPlan.description : ''
@@ -23,6 +25,7 @@ const mapStateToProps = ({ overview, planWizard }) => {
     enableReinitialize: true, // Tells redux-form to use new initialValues when they change
     keepDirtyOnReinitialize: true,
     editingPlan,
+    editingOrphanedPlan: prefilledMappingId && !prefilledMappingExists,
     alertType: planWizard && planWizard.alertType
   };
 };

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardInstancePropertiesStep/index.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardInstancePropertiesStep/index.js
@@ -45,7 +45,10 @@ const mapStateToProps = (
     })),
     selectedMapping,
     editingPlan,
-    shouldPrefillForEditing: editingPlan && editingPlan.transformation_mapping.id === infrastructure_mapping
+    shouldPrefillForEditing:
+      editingPlan &&
+      editingPlan.transformation_mapping &&
+      editingPlan.transformation_mapping.id === infrastructure_mapping
   };
 };
 

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/index.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/index.js
@@ -16,7 +16,10 @@ const mapStateToProps = ({ planWizardVMStep, form, overview }, ownProps) => {
     vm_choice_radio: form.planWizardGeneralStep.values.vm_choice_radio,
     infrastructure_mapping_id,
     editingPlan,
-    shouldPrefillForEditing: editingPlan && editingPlan.transformation_mapping.id === infrastructure_mapping_id,
+    shouldPrefillForEditing:
+      editingPlan &&
+      editingPlan.transformation_mapping &&
+      editingPlan.transformation_mapping.id === infrastructure_mapping_id,
     formSelectedVms: form.planWizardVMStep && form.planWizardVMStep.values && form.planWizardVMStep.values.selectedVms
   };
 };

--- a/app/javascript/react/screens/App/common/ConfirmModal.js
+++ b/app/javascript/react/screens/App/common/ConfirmModal.js
@@ -39,9 +39,11 @@ const ConfirmModal = props => {
         )}
       </Modal.Body>
       <Modal.Footer>
-        <Button bsStyle="default" className="btn-cancel" onClick={onCancel} disabled={disableCancelButton}>
-          {cancelButtonLabel}
-        </Button>
+        {cancelButtonLabel && (
+          <Button bsStyle="default" className="btn-cancel" onClick={onCancel} disabled={disableCancelButton}>
+            {cancelButtonLabel}
+          </Button>
+        )}
         <Button bsStyle="primary" onClick={onConfirm} disabled={disableConfirmButton}>
           {confirmButtonLabel}
         </Button>


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1599868

In https://github.com/ManageIQ/manageiq-v2v/pull/757, I made it possible to change the associated mapping for a plan, but I did not enable editing of a plan with a missing mapping, which is the original reason we wanted that functionality. This PR enables that edit button for orphaned plans, and handles some errors that were caused by proceeding through the wizard with an orphaned plan.

We also introduce an error message here when the user attempts to create a new plan, or edit an existing plan, while there are no mappings:
![screenshot 2018-11-14 10 56 43](https://user-images.githubusercontent.com/811963/48495297-ad989400-e7fd-11e8-810e-969d3a09fbe1.png)
