### PR TITLE
[#783] Hide polling after initial page load

### DIFF
--- a/app/javascript/react/screens/App/Overview/OverviewReducer.js
+++ b/app/javascript/react/screens/App/Overview/OverviewReducer.js
@@ -241,6 +241,7 @@ export default (state = initialState, action) => {
         .set('allArchivedPlanRequestsWithTasks', action.payload.data.results)
         .set('isFetchingAllArchivedPlanRequestsWithTasks', false)
         .set('isRejectedAllArchivedPlanRequestsWithTasks', false)
+        .set('requestsWithTasksPreviouslyFetched', true)
         .set('errorAllArchivedPlanRequestsWithTasks', null);
     case `${FETCH_V2V_ALL_ARCHIVED_PLAN_REQUESTS_WITH_TASKS}_REJECTED`:
       return state


### PR DESCRIPTION
Fixes #783 

In the case where there exist only archived plans, the
requestsWithTasksPreviouslyFetched flag is not being set to true after
the initial page load.

https://bugzilla.redhat.com/show_bug.cgi?id=1648039