### PR TITLE
[HAMMER] Hide Migration UI by default for CF 4.7 Public Beta

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,11 @@
 # ManageIQ::V2V::Engine.routes.draw do
-Rails.application.routes.draw do
-  match '/migration' => 'migration#index', :via => [:get]
-  match 'migration/*page' => 'migration#index', :via => [:get]
+if ::Settings.product.ims == true
+  Rails.application.routes.draw do
+    match '/migration' => 'migration#index', :via => [:get]
+    match 'migration/*page' => 'migration#index', :via => [:get]
 
-  get "migration_log/download_migration_log(/:id)",
-    :action     => 'download_migration_log',
-    :controller => 'migration_log'
+    get "migration_log/download_migration_log(/:id)",
+      :action     => 'download_migration_log',
+      :controller => 'migration_log'
+  end
 end

--- a/lib/manageiq/v2v/engine.rb
+++ b/lib/manageiq/v2v/engine.rb
@@ -10,7 +10,7 @@ module ManageIQ::V2V
       app.config.assets.paths << root.join('assets', 'images').to_s
     end
 
-    initializer 'plugin' do
+    def render_migration_menu
       Menu::CustomLoader.register(
         Menu::Section.new(:migration, N_("Migration"), 'fa fa-plus', [
           Menu::Item.new('migration', N_("Overview"), 'miq_report', {:feature => 'miq_report', :any => true}, '/migration'),
@@ -18,6 +18,10 @@ module ManageIQ::V2V
           Menu::Item.new('settings', N_("Migration Settings"), 'miq_report', {:feature => 'miq_report', :any => true}, '/migration#/settings')
         ], nil, nil, nil, nil, :compute)
       )
+    end
+
+    initializer 'plugin' do
+      Menu::CustomLoader.register(::Settings.product.ims == true ? render_migration_menu : nil)
     end
 
     def self.plugin_name


### PR DESCRIPTION
The v2v Migration menu would be hidden and inaccessible by default.

To enable it, add `:ims: true` under the `product` settings 

https://bugzilla.redhat.com/show_bug.cgi?id=1649474