### PR TITLE
Fix router warnings on component unmount

### DIFF
--- a/app/javascript/react/screens/App/Mappings/Mappings.js
+++ b/app/javascript/react/screens/App/Mappings/Mappings.js
@@ -10,6 +10,11 @@ import { FETCH_TRANSFORMATION_MAPPINGS_URL } from './MappingsConstants';
 import ShowWizardEmptyState from '../common/ShowWizardEmptyState/ShowWizardEmptyState';
 
 class Mappings extends Component {
+  constructor(props) {
+    super(props);
+    this.willUnmount = false;
+  }
+
   mappingWizard = componentRegistry.markup('MappingWizardContainer', this.props.store);
 
   componentDidMount = () => {
@@ -59,7 +64,7 @@ class Mappings extends Component {
         archived: true
       })
     ]).then(() => {
-      if (!this.pollingInterval) {
+      if (!this.pollingInterval && !this.willUnmount) {
         this.startPolling();
       }
     });
@@ -78,7 +83,7 @@ class Mappings extends Component {
     if (prevProps.mappinWizardVisible !== this.props.mappingWizardVisible) {
       if (this.props.mappingWizardVisible) {
         this.stopPolling();
-      } else if (!this.props.mappingWizardVisible && !this.pollingInterval) {
+      } else if (!this.props.mappingWizardVisible && !this.pollingInterval && !this.willUnmount) {
         this.props.fetchTransformationPlansAction({
           url: this.props.fetchTransformationPlansUrl,
           archived: false
@@ -89,6 +94,7 @@ class Mappings extends Component {
   };
 
   componentWillUnmount() {
+    this.willUnmount = true;
     this.stopPolling();
   }
 

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStep.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStep.js
@@ -27,8 +27,8 @@ class MappingWizardDatastoresStep extends React.Component {
       []
     );
 
-    const synchronousSetState = (fn) => {
-      this.state = { ...this.state, ...fn() }
+    const synchronousSetState = fn => {
+      this.state = { ...this.state, ...fn() };
     };
 
     if (sourceClusters.length === 1 || !pristine) {

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStep.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStep.js
@@ -17,7 +17,9 @@ class MappingWizardDatastoresStep extends React.Component {
     preLoadingMappings: false
   };
 
-  componentWillMount() {
+  constructor(props) {
+    super(props);
+
     const { clusterMappings, pristine } = this.props;
 
     const sourceClusters = clusterMappings.reduce(
@@ -25,8 +27,12 @@ class MappingWizardDatastoresStep extends React.Component {
       []
     );
 
+    const synchronousSetState = (fn) => {
+      this.state = { ...this.state, ...fn() }
+    };
+
     if (sourceClusters.length === 1 || !pristine) {
-      this.selectSourceCluster(sourceClusters[0].id);
+      this.selectSourceCluster(sourceClusters[0].id, synchronousSetState);
     }
   }
 
@@ -83,7 +89,7 @@ class MappingWizardDatastoresStep extends React.Component {
     }
   }
 
-  selectSourceCluster = sourceClusterId => {
+  selectSourceCluster = (sourceClusterId, setState = this.setState) => {
     // when dropdown selection occurs for source cluster, we go retrieve the datastores for that
     // cluster
     const {
@@ -100,7 +106,7 @@ class MappingWizardDatastoresStep extends React.Component {
 
     const { nodes: sourceClusters, ...targetCluster } = selectedClusterMapping;
 
-    this.setState(() => ({
+    setState(() => ({
       selectedCluster: sourceClusters.find(sourceCluster => sourceCluster.id === sourceClusterId),
       selectedClusterMapping
     }));

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardNetworksStep/MappingWizardNetworksStep.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardNetworksStep/MappingWizardNetworksStep.js
@@ -17,7 +17,9 @@ class MappingWizardNetworksStep extends React.Component {
     preLoadingMappings: false
   };
 
-  componentWillMount() {
+  constructor(props) {
+    super(props);
+
     const { clusterMappings, pristine } = this.props;
 
     const sourceClusters = clusterMappings.reduce(
@@ -25,8 +27,12 @@ class MappingWizardNetworksStep extends React.Component {
       []
     );
 
+    const synchronousSetState = (fn) => {
+      this.state = { ...this.state, ...fn() }
+    };
+
     if (sourceClusters.length === 1 || !pristine) {
-      this.selectSourceCluster(sourceClusters[0].id);
+      this.selectSourceCluster(sourceClusters[0].id, synchronousSetState);
     }
   }
 
@@ -84,7 +90,7 @@ class MappingWizardNetworksStep extends React.Component {
     }
   }
 
-  selectSourceCluster = sourceClusterId => {
+  selectSourceCluster = (sourceClusterId, setState = this.setState) => {
     // when dropdown selection occurs for source cluster, we go retrieve the
     // newworks for that cluster
     const {
@@ -102,7 +108,7 @@ class MappingWizardNetworksStep extends React.Component {
 
     const { nodes: sourceClusters, ...targetCluster } = selectedClusterMapping;
 
-    this.setState(() => ({
+    setState(() => ({
       selectedCluster: sourceClusters.find(sourceCluster => sourceCluster.id === sourceClusterId),
       selectedClusterMapping
     }));

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardNetworksStep/MappingWizardNetworksStep.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardNetworksStep/MappingWizardNetworksStep.js
@@ -27,8 +27,8 @@ class MappingWizardNetworksStep extends React.Component {
       []
     );
 
-    const synchronousSetState = (fn) => {
-      this.state = { ...this.state, ...fn() }
+    const synchronousSetState = fn => {
+      this.state = { ...this.state, ...fn() };
     };
 
     if (sourceClusters.length === 1 || !pristine) {

--- a/app/javascript/react/screens/App/Overview/Overview.js
+++ b/app/javascript/react/screens/App/Overview/Overview.js
@@ -21,11 +21,10 @@ class Overview extends React.Component {
     super(props);
 
     this.planWizard = componentRegistry.markup('PlanWizardContainer', props.store);
-  }
 
-  state = {
-    hasMadeInitialPlansFetch: false
-  };
+    this.hasMadeInitialPlansFetch = false;
+    this.willUnmount = false;
+  }
 
   componentDidMount() {
     const {
@@ -52,10 +51,9 @@ class Overview extends React.Component {
     const p5 = fetchProvidersAction();
 
     Promise.all([p1, p2, p3, p4, p5]).then(() => {
-      this.setState(() => ({
-        hasMadeInitialPlansFetch: true
-      }));
-      if (!this.pollingInterval) {
+      this.hasMadeInitialPlansFetch = true;
+
+      if (!this.pollingInterval && !this.willUnmount) {
         this.startPolling();
       }
     });
@@ -68,7 +66,6 @@ class Overview extends React.Component {
       fetchTransformationPlansAction,
       planWizardId
     } = this.props;
-    const { hasMadeInitialPlansFetch } = this.state;
 
     if (isContinuingToPlan !== nextProps.isContinuingToPlan && !nextProps.isContinuingToPlan) {
       this.showPlanWizardOrError(planWizardId);
@@ -77,7 +74,7 @@ class Overview extends React.Component {
     // kill interval if a wizard becomes visble
     if (nextProps.planWizardVisible) {
       this.stopPolling();
-    } else if (!nextProps.planWizardVisible && hasMadeInitialPlansFetch && !this.pollingInterval) {
+    } else if (!nextProps.planWizardVisible && this.hasMadeInitialPlansFetch && !this.pollingInterval) {
       fetchTransformationPlansAction({
         url: fetchTransformationPlansUrl,
         archived: false
@@ -87,6 +84,7 @@ class Overview extends React.Component {
   }
 
   componentWillUnmount() {
+    this.willUnmount = true;
     this.stopPolling();
   }
 

--- a/app/javascript/react/screens/App/Overview/Overview.js
+++ b/app/javascript/react/screens/App/Overview/Overview.js
@@ -273,7 +273,7 @@ class Overview extends React.Component {
         <Spinner
           loading={
             !requestsWithTasksPreviouslyFetched &&
-            !this.state.hasMadeInitialPlansFetch &&
+            !this.hasMadeInitialPlansFetch &&
             (isFetchingAllRequestsWithTasks ||
               isFetchingProviders ||
               isFetchingTransformationPlans ||

--- a/app/javascript/react/screens/App/Overview/Overview.js
+++ b/app/javascript/react/screens/App/Overview/Overview.js
@@ -74,7 +74,7 @@ class Overview extends React.Component {
     // kill interval if a wizard becomes visble
     if (nextProps.planWizardVisible) {
       this.stopPolling();
-    } else if (!nextProps.planWizardVisible && this.hasMadeInitialPlansFetch && !this.pollingInterval) {
+    } else if (!nextProps.planWizardVisible && this.hasMadeInitialPlansFetch && !this.pollingInterval && !this.willUnmount) {
       fetchTransformationPlansAction({
         url: fetchTransformationPlansUrl,
         archived: false

--- a/app/javascript/react/screens/App/Overview/Overview.js
+++ b/app/javascript/react/screens/App/Overview/Overview.js
@@ -74,7 +74,12 @@ class Overview extends React.Component {
     // kill interval if a wizard becomes visble
     if (nextProps.planWizardVisible) {
       this.stopPolling();
-    } else if (!nextProps.planWizardVisible && this.hasMadeInitialPlansFetch && !this.pollingInterval && !this.willUnmount) {
+    } else if (
+      !nextProps.planWizardVisible &&
+      this.hasMadeInitialPlansFetch &&
+      !this.pollingInterval &&
+      !this.willUnmount
+    ) {
       fetchTransformationPlansAction({
         url: fetchTransformationPlansUrl,
         archived: false

--- a/app/javascript/react/screens/App/Plan/Plan.js
+++ b/app/javascript/react/screens/App/Plan/Plan.js
@@ -44,6 +44,7 @@ class Plan extends React.Component {
     };
 
     this.props.resetPlanStateAction();
+    this.willUnmount = false;
   }
 
   componentDidMount() {
@@ -72,7 +73,7 @@ class Plan extends React.Component {
       if (miq_requests.length > 0) {
         const mostRecentRequest = getMostRecentRequest(miq_requests);
         fetchTasksForAllRequestsForPlanAction(fetchTasksForAllRequestsForPlanUrl, miq_requests);
-        if (mostRecentRequest.request_state === 'active') {
+        if (mostRecentRequest.request_state === 'active' && !this.pollingInterval && !this.willUnmount) {
           this.startPolling(miq_requests);
         } else {
           this.setState(() => ({
@@ -86,6 +87,7 @@ class Plan extends React.Component {
   }
 
   componentWillUnmount() {
+    this.willUnmount = true;
     const { resetPlanStateAction } = this.props;
     this.stopPolling();
     resetPlanStateAction();


### PR DESCRIPTION
#769 depends on this (depends = no warnings, it would work anyway)

This fixes the warnings exposed by switching to browserrouter.

Essentially, this fixes 2 problems:

* sometimes, polling was started from a http response handler, which could respond *after* the component gets unmounted, leading to setState calls on unmounted components
* `componentWillMount` is deprecated, and should be replaced by constructors, except calling `setState` from a constructor doesn't work, you're supposed to change the state synchronously (hence the `synchronousSetState` method with the same interface).

Cc @mzazrivec 

BZ https://bugzilla.redhat.com/show_bug.cgi?id=1642104 (with #769)