### PR TITLE
Fix/remove links

### DIFF
--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardResultsStep/MappingWizardResultsStep.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardResultsStep/MappingWizardResultsStep.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { noop, Button, Spinner } from 'patternfly-react';
+import { noop, Spinner } from 'patternfly-react';
 
 import { transformationHasBeenEdited } from './helpers';
 import { FETCH_TRANSFORMATION_MAPPINGS_URL } from '../../../../../Mappings/MappingsConstants';
@@ -88,12 +88,6 @@ class MappingWizardResultsStep extends React.Component {
           <h3 className="blank-slate-pf-main-action">
             {sprintf(__('All mappings in %s have been mapped.'), transformationsBody.name)}
           </h3>
-          <p className="blank-slate-pf-secondary-action">
-            <Button bsStyle="link" onClick={() => this.onContinueToPlanWizard(transformationMappingsResult.id)}>
-              {__('Continue to the plan wizard')}
-            </Button>
-            {__('to create a migration plan using the infrastructure mapping.')}
-          </p>
         </div>
       );
     }

--- a/app/javascript/react/screens/App/Overview/Overview.js
+++ b/app/javascript/react/screens/App/Overview/Overview.js
@@ -121,7 +121,7 @@ class Overview extends React.Component {
           <h3 style={{ marginTop: 0 }}>{__('No infrastructure mapping exists')}</h3>
           <p>
             {__('A migration plan must include an infrastructure mapping.')}{' '}
-            <a href="/migration#/mappings">{__('Go to the Infrastructure Mappings page to create one.')}</a>
+            <a href="/migration/mappings#">{__('Go to the Infrastructure Mappings page to create one.')}</a>
           </p>
         </React.Fragment>
       ),


### PR DESCRIPTION
* Followup to https://github.com/ManageIQ/manageiq-v2v/pull/769
* Update link to Mappings page to conform to router changes made in
  aforementioned PR
* Remove "Continue to plan" option from the Mapping Wizard. The routing
  changes made in the aforementioned PR causes a full page refresh
  whenever changing routes. This prevents us from being able to
  implement this particular feature, so we will remove it for now.
* Adding this to the BZ associated with aforementioned PR

https://bugzilla.redhat.com/show_bug.cgi?id=1642104