### PR TITLE
[#749] Disable edit button for broken mappings

### DIFF
--- a/app/javascript/react/screens/App/Mappings/components/InfrastructureMappingsList/InfrastructureMappingsList.js
+++ b/app/javascript/react/screens/App/Mappings/components/InfrastructureMappingsList/InfrastructureMappingsList.js
@@ -337,7 +337,9 @@ class InfrastructureMappingsList extends React.Component {
                             <div>
                               <Button
                                 bsStyle="link"
-                                disabled={!!associatedPlansCount}
+                                disabled={
+                                  !!associatedPlansCount || !targetClusters || !targetDatastores || !targetNetworks
+                                }
                                 onClick={e => {
                                   e.stopPropagation();
                                   showMappingWizardEditModeAction(mapping);


### PR DESCRIPTION
Fixes #749

If any clusters/datastores/networks that make up an infra mapping are
missing from the database, disable the edit button.

https://bugzilla.redhat.com/show_bug.cgi?id=1644399