### PR TITLE
Rename "Overview" page to "Migration Plans" and change /overview route to /plans

### DIFF
--- a/app/controllers/migration_controller.rb
+++ b/app/controllers/migration_controller.rb
@@ -6,8 +6,8 @@ class MigrationController < ApplicationController
 
   def index
     @layout = case request.path
-              when '/migration/overview', /^\/migration\/plan\/.*/
-                'overview'
+              when '/migration/plans', /^\/migration\/plan\/.*/
+                'plans'
               when '/migration/mappings'
                 'mappings'
               when '/migration/settings'

--- a/app/javascript/react/config/config.js
+++ b/app/javascript/react/config/config.js
@@ -5,7 +5,7 @@ import MappingsContainer from '../screens/App/Mappings';
 
 export const links = [
   {
-    path: '/migration/overview',
+    path: '/migration/plans',
     component: OverviewContainer
   },
   {

--- a/app/javascript/react/screens/App/Mappings/Mappings.js
+++ b/app/javascript/react/screens/App/Mappings/Mappings.js
@@ -171,7 +171,7 @@ class Mappings extends Component {
       <React.Fragment>
         <Toolbar>
           <Breadcrumb.Item href="/dashboard/maintab?tab=compute">{__('Compute')}</Breadcrumb.Item>
-          <Breadcrumb.Item href="/migration/overview">{__('Migration')}</Breadcrumb.Item>
+          <Breadcrumb.Item href="/migration/plans">{__('Migration')}</Breadcrumb.Item>
           <Breadcrumb.Item active>{__('Infrastructure Mappings')}</Breadcrumb.Item>
         </Toolbar>
         <Spinner

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardResultsStep/MappingWizardResultsStep.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardResultsStep/MappingWizardResultsStep.js
@@ -51,7 +51,7 @@ class MappingWizardResultsStep extends React.Component {
 
   onContinueToPlanWizard = id => {
     this.props.continueToPlanAction(id);
-    this.props.redirectTo('/migration/overview');
+    this.props.redirectTo('/migration/plans');
   };
 
   render() {

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardResultsStep/PlanWizardResultsStep.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardResultsStep/PlanWizardResultsStep.js
@@ -94,7 +94,7 @@ class PlanWizardResultsStep extends React.Component {
       return this.renderError(__('Error Saving Migration Plan'), errorMessage, hidePlanWizardAction);
     } else if (planSchedule === 'migration_plan_later' && migrationPlansResult) {
       const migrationPlanSaved = sprintf(__(" Migration Plan: '%s' has been saved"), plansBody.name);
-      const migrationPlanFollowupMessage = __('Select Migrate on the Overview page to begin migration');
+      const migrationPlanFollowupMessage = __('Select Migrate on the Migration Plans page to begin migration');
       const showVmPowerWarning = targetProvider === 'openstack';
       return this.renderResult(
         migrationPlanSaved,

--- a/app/javascript/react/screens/App/Plan/Plan.js
+++ b/app/javascript/react/screens/App/Plan/Plan.js
@@ -167,7 +167,7 @@ class Plan extends React.Component {
         <Toolbar>
           <Breadcrumb.Item href="/dashboard/maintab?tab=compute">{__('Compute')}</Breadcrumb.Item>
           <li>
-            <a href="/migration/overview">{__('Migration')}</a>
+            <a href="/migration/plans">{__('Migration')}</a>
           </li>
           {!isRejectedPlan &&
             planName && (

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 # ManageIQ::V2V::Engine.routes.draw do
 Rails.application.routes.draw do
-  match '/migration' => redirect('/migration/overview'), :via => [:get]
-  match '/migration/overview' => 'migration#index', :via => [:get]
+  match '/migration' => redirect('/migration/plans'), :via => [:get]
+  match '/migration/plans' => 'migration#index', :via => [:get]
   match '/migration/mappings' => 'migration#index', :via => [:get]
   match '/migration/plan/:id' => 'migration#index', :via => [:get]
   match 'migration/*page' => 'migration#index', :via => [:get]

--- a/lib/manageiq/v2v/engine.rb
+++ b/lib/manageiq/v2v/engine.rb
@@ -13,7 +13,7 @@ module ManageIQ::V2V
     initializer 'plugin' do
       Menu::CustomLoader.register(
         Menu::Section.new(:migration, N_("Migration"), 'fa fa-plus', [
-          Menu::Item.new('overview', N_("Overview"), 'migration', {:feature => 'migration', :any => true}, '/migration/overview'),
+          Menu::Item.new('plans', N_("Migration Plans"), 'migration', {:feature => 'migration', :any => true}, '/migration/plans'),
           Menu::Item.new('mappings', N_("Infrastructure Mappings"), 'mappings', {:feature => 'mappings', :any => true}, '/migration/mappings'),
           Menu::Item.new('settings', N_("Migration Settings"), 'migration_settings', {:feature => 'migration_settings', :any => true}, '/migration/settings')
         ], nil, nil, nil, nil, :compute)


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1655174

<img width="693" alt="screenshot 2018-11-30 16 23 02" src="https://user-images.githubusercontent.com/811963/49315675-852abe00-f4bc-11e8-8796-5543b22375aa.png">

We have a ton of references to the word "Overview" throughout our code in filenames, redux store keys, snapshot names, etc etc. I didn't bother changing all of those, especially right before a release, so I only changed the route and the places we make the page name visible to the user.

If we ever do introduce a new Overview page, we might want to consider renaming all these old references. Or we could just call it Dashboard :)