### PR TITLE
Replace broken axios API mock adapter, fix broken tests

### DIFF
--- a/.jest-setup.js
+++ b/.jest-setup.js
@@ -1,5 +1,7 @@
 import { configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
+import { APImock } from './app/javascript/common/mockRequests';
+
 configure({ adapter: new Adapter() });
 
 // Mocking translation function
@@ -7,5 +9,10 @@ global.__ = str => str;
 global.n__ = str => str;
 global.sprintf = str => str;
 global.Jed = { sprintf: str => str };
-global.API.get = jest.fn(() => Promise.resolve());
-global.API.post = jest.fn(() => Promise.resolve());
+
+APImock.reset();
+
+global.API.get = jest.fn(url => APImock.respond('GET', url));
+global.API.put = jest.fn(url => APImock.respond('PUT', url));
+global.API.post = jest.fn(url => APImock.respond('POST', url));
+global.API.delete = jest.fn(url => APImock.respond('DELETE', url));

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardClustersStep/__tests__/MappingWizardClusterStepActions.test.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardClustersStep/__tests__/MappingWizardClusterStepActions.test.js
@@ -22,7 +22,7 @@ describe('mappingWizard actions', () => {
   it('should fetch source clusters and return PENDING and FULFILLED action', () => {
     const { fetchSourceClustersUrl } = requestSourceClustersData;
     mockRequest({
-      fetchSourceClustersUrl,
+      url: fetchSourceClustersUrl,
       status: 200
     });
     return store.dispatch(actions.fetchSourceClustersAction(fetchSourceClustersUrl)).then(() => {
@@ -32,7 +32,7 @@ describe('mappingWizard actions', () => {
   it('should fetch source clusters and return PENDING and REJECTED action', () => {
     const { fetchSourceClustersUrl } = requestSourceClustersData;
     mockRequest({
-      fetchSourceClustersUrl,
+      url: fetchSourceClustersUrl,
       status: 404
     });
     return store.dispatch(actions.fetchSourceClustersAction(fetchSourceClustersUrl)).catch(() => {
@@ -43,7 +43,7 @@ describe('mappingWizard actions', () => {
   it('should fetch target clusters and return PENDING and FULFILLED action', () => {
     const { fetchTargetClustersUrl } = requestTargetClustersData;
     mockRequest({
-      fetchTargetClustersUrl,
+      url: fetchTargetClustersUrl,
       status: 200
     });
     return store.dispatch(actions.fetchTargetClustersAction(fetchTargetClustersUrl)).then(() => {
@@ -53,7 +53,7 @@ describe('mappingWizard actions', () => {
   it('should fetch target clusters and return PENDING and REJECTED action', () => {
     const { fetchTargetClustersUrl } = requestTargetClustersData;
     mockRequest({
-      fetchTargetClustersUrl,
+      url: fetchTargetClustersUrl,
       status: 404
     });
     return store.dispatch(actions.fetchTargetClustersAction(fetchTargetClustersUrl)).catch(() => {

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardClustersStep/__tests__/__snapshots__/MappingWizardClusterStepActions.test.js.snap
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardClustersStep/__tests__/__snapshots__/MappingWizardClusterStepActions.test.js.snap
@@ -11,6 +11,19 @@ Array [
 ]
 `;
 
+exports[`mappingWizard actions should fetch source clusters and return PENDING and REJECTED action 1`] = `
+Array [
+  Object {
+    "type": "FETCH_V2V_SOURCE_CLUSTERS_PENDING",
+  },
+  Object {
+    "error": true,
+    "payload": [Error: <mocked error>],
+    "type": "FETCH_V2V_SOURCE_CLUSTERS_REJECTED",
+  },
+]
+`;
+
 exports[`mappingWizard actions should fetch target clusters and return PENDING and FULFILLED action 1`] = `
 Array [
   Object {
@@ -18,6 +31,19 @@ Array [
   },
   Object {
     "type": "FETCH_V2V_TARGET_CLUSTERS_FULFILLED",
+  },
+]
+`;
+
+exports[`mappingWizard actions should fetch target clusters and return PENDING and REJECTED action 1`] = `
+Array [
+  Object {
+    "type": "FETCH_V2V_TARGET_CLUSTERS_PENDING",
+  },
+  Object {
+    "error": true,
+    "payload": [Error: <mocked error>],
+    "type": "FETCH_V2V_TARGET_CLUSTERS_REJECTED",
   },
 ]
 `;

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardGeneralStep/__tests__/MappingWizardGeneralStepActions.test.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardGeneralStep/__tests__/MappingWizardGeneralStepActions.test.js
@@ -24,7 +24,7 @@ describe('mappingWizard general step actions', () => {
   it('should fetch conversion hosts and return PENDING and FULFILLED action', () => {
     const { fetchConversionHostsUrl } = requestConversionHostsData;
     mockRequest({
-      fetchConversionHostsUrl,
+      url: fetchConversionHostsUrl,
       status: 200
     });
     return store.dispatch(actions.fetchConversionHostsAction(fetchConversionHostsUrl)).then(() => {

--- a/app/javascript/react/screens/App/Overview/__test__/OverviewActions.test.js
+++ b/app/javascript/react/screens/App/Overview/__test__/OverviewActions.test.js
@@ -24,9 +24,8 @@ describe('fetchTransformationPlansAction', () => {
     mockRequest({
       method: 'GET',
       url: fetchTransformationPlansUrl,
-      params: null,
       status: 200,
-      ...response
+      response
     });
 
     return store
@@ -37,7 +36,12 @@ describe('fetchTransformationPlansAction', () => {
         })
       )
       .then(() => {
-        expect(store.getActions()).toMatchSnapshot();
+        const actions = store.getActions();
+        expect(actions).toHaveLength(3);
+        expect(actions[0].type).toBe('FETCH_V2V_TRANSFORMATION_PLANS_PENDING');
+        expect(actions[1].type).toBe('FETCH_V2V_ALL_REQUESTS_WITH_TASKS_PENDING');
+        expect(actions[2].type).toBe('FETCH_V2V_TRANSFORMATION_PLANS_FULFILLED');
+        expect(actions[2].payload.data.resources).toHaveLength(7);
       });
   });
 
@@ -45,9 +49,8 @@ describe('fetchTransformationPlansAction', () => {
     mockRequest({
       method: 'GET',
       url: fetchTransformationPlansUrl,
-      params: null,
       status: 404,
-      ...response
+      response
     });
 
     return store
@@ -84,6 +87,7 @@ describe('setMigrationsFilterAction', () => {
 describe('cancelPlanRequestAction', () => {
   const request = {
     method: 'POST',
+    url: TRANSFORMATION_PLAN_REQUESTS_URL,
     data: { action: 'cancel' }
   };
 

--- a/app/javascript/react/screens/App/Overview/__test__/__snapshots__/OverviewActions.test.js.snap
+++ b/app/javascript/react/screens/App/Overview/__test__/__snapshots__/OverviewActions.test.js.snap
@@ -1,5 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`cancelPlanRequestAction dispatched PENDING and REJECTED actions 1`] = `
+Array [
+  Object {
+    "payload": "/api/requests/1",
+    "type": "V2V_CANCEL_PLAN_REQUEST_PENDING",
+  },
+  Object {
+    "error": true,
+    "payload": [Error: <mocked error>],
+    "type": "V2V_CANCEL_PLAN_REQUEST_REJECTED",
+  },
+]
+`;
+
 exports[`cancelPlanRequestAction dispatches PENDING and FULFILLED actions 1`] = `
 Array [
   Object {
@@ -7,18 +21,27 @@ Array [
     "type": "V2V_CANCEL_PLAN_REQUEST_PENDING",
   },
   Object {
+    "payload": Object {
+      "data": Object {
+        "href": "http://0.0.0.0:8080/api/requests/28",
+        "message": "MiqRequest 28 canceled",
+        "success": true,
+      },
+    },
     "type": "V2V_CANCEL_PLAN_REQUEST_FULFILLED",
   },
 ]
 `;
 
-exports[`fetchTransformationPlansAction dispatches PENDING and FULFILLED actions 1`] = `
+exports[`fetchTransformationPlansAction dispatches PENDING and REJECTED actions 1`] = `
 Array [
   Object {
     "type": "FETCH_V2V_TRANSFORMATION_PLANS_PENDING",
   },
   Object {
-    "type": "FETCH_V2V_TRANSFORMATION_PLANS_FULFILLED",
+    "error": true,
+    "payload": [Error: <mocked error>],
+    "type": "FETCH_V2V_TRANSFORMATION_PLANS_REJECTED",
   },
 ]
 `;

--- a/app/javascript/react/screens/App/Plan/__test__/PlanActions.test.js
+++ b/app/javascript/react/screens/App/Plan/__test__/PlanActions.test.js
@@ -20,7 +20,7 @@ describe('FETCH_V2V_PLAN', () => {
   const id = '1';
   const { fetchPlanUrl } = requestPlanData(id);
   const request = {
-    fetchPlanUrl,
+    url: fetchPlanUrl,
     status: 200
   };
 

--- a/app/javascript/react/screens/App/Plan/__test__/__snapshots__/PlanActions.test.js.snap
+++ b/app/javascript/react/screens/App/Plan/__test__/__snapshots__/PlanActions.test.js.snap
@@ -10,3 +10,16 @@ Array [
   },
 ]
 `;
+
+exports[`FETCH_V2V_PLAN fetchPlanAction dispatches the PENDING and REJECTED actions 1`] = `
+Array [
+  Object {
+    "type": "FETCH_V2V_PLAN_PENDING",
+  },
+  Object {
+    "error": true,
+    "payload": [Error: <mocked error>],
+    "type": "FETCH_V2V_PLAN_REJECTED",
+  },
+]
+`;


### PR DESCRIPTION
I was about to write a test for `POST /api/settings`, when @michaelkro pointed out a problem...

Ever since our move from `axios` to manageiq's global `API` in https://github.com/ManageIQ/manageiq-v2v/pull/303, the `mockRequest()` calls in our tests have been doing nothing, and some of our tests were using `.catch(() => expect(...))` on promises that would never be rejected, asserting nothing.

This PR replaces the `global.API.get = jest.fn(() => Promise.resolve());` with a simple implementation of an API mock adapter, that simply allows us to specify `method, url, status, response` when mocking and then either resolves or rejects the promise when API calls happen. Old tests are new again! And now I can write new API-mocked tests that are meaningful.

In the `distant future`, I agree with @priley86 in his comments in #303 that we could be doing something better:

> in a future architecture in a galaxy far far away... i would love to be able to document such APIs / request headers via something like an api-docgen

but for now, this gives us something a little more useful to test with.