### PR TITLE
Phase 2 of vertical menu fixes

### DIFF
--- a/app/controllers/migration_controller.rb
+++ b/app/controllers/migration_controller.rb
@@ -1,18 +1,13 @@
 # Migration controller - mostly service to initialize the react top level component
 # and to handle the initial routing endpoint.
 class MigrationController < ApplicationController
+  include Mixins::MenuUpdateMixin
+
   before_action :check_privileges
   after_action :cleanup_action
 
   def index
-    @layout = case request.path
-              when '/migration/plans', /^\/migration\/plan\/.*/
-                'plans'
-              when '/migration/mappings'
-                'mappings'
-              when '/migration/settings'
-                'settings'
-              end
+    @layout = 'migration'
     @page_title = _('Migration')
   end
 

--- a/app/javascript/common/menu.js
+++ b/app/javascript/common/menu.js
@@ -1,0 +1,33 @@
+import http from './http';
+
+const updateUrl = '/migration/menu_section_url?section=migration&url=/migration%23';
+const activeMenuItemSelector = '[data-target="#menu-migration"] > div > ul > li[class="list-group-item active"]';
+const plansMenuItemId = 'menu_item_plans';
+const mappingsMenuItemId = 'menu_item_mappings';
+const settingsMenuItemId = 'menu_item_settings';
+const pathToMenuItem = {
+  plan: plansMenuItemId,
+  plans: plansMenuItemId,
+  mappings: mappingsMenuItemId,
+  settings: settingsMenuItemId
+};
+
+export const updateVerticalMenu = path => {
+  // POST /migration/menu_section_url to update session[:tab_url] on server
+  http.post(updateUrl + path);
+
+  // Remove 'active' class from current active menu item
+  const activeMenuItem = document.querySelector(activeMenuItemSelector);
+  if (activeMenuItem !== null) {
+    activeMenuItem.classList.remove('active');
+  }
+
+  // Based on location.pathname, set menu item id
+  const menu_item_id = pathToMenuItem[path.split('/')[1]];
+
+  // Add 'active' class to menu_item_id
+  const newActiveMenuItem = document.querySelector(`[id="${menu_item_id}"]`);
+  if (newActiveMenuItem !== null) {
+    newActiveMenuItem.classList.add('active');
+  }
+};

--- a/app/javascript/common/menu.js
+++ b/app/javascript/common/menu.js
@@ -15,12 +15,10 @@ export const updateVerticalMenu = path => {
   }
 
   // Based on location.pathname, set menu item id
-  const link_item = links.find(element => {
-    return element['path'].split('/')[0] === path.split('/')[1];
-  });
+  const link_item = links.find(element => element.path.split('/')[0] === path.split('/')[1]);
 
   // Add 'active' class to correct menu item
-  const newActiveMenuItem = document.querySelector(`[id="${link_item['menu_item_id']}"]`);
+  const newActiveMenuItem = document.querySelector(`[id="${link_item.menu_item_id}"]`);
   if (newActiveMenuItem !== null) {
     newActiveMenuItem.classList.add('active');
   }

--- a/app/javascript/common/menu.js
+++ b/app/javascript/common/menu.js
@@ -1,16 +1,8 @@
 import http from './http';
+import { links } from '../react/config/config';
 
 const updateUrl = '/migration/menu_section_url?section=migration&url=/migration%23';
 const activeMenuItemSelector = '[data-target="#menu-migration"] > div > ul > li[class="list-group-item active"]';
-const plansMenuItemId = 'menu_item_plans';
-const mappingsMenuItemId = 'menu_item_mappings';
-const settingsMenuItemId = 'menu_item_settings';
-const pathToMenuItem = {
-  plan: plansMenuItemId,
-  plans: plansMenuItemId,
-  mappings: mappingsMenuItemId,
-  settings: settingsMenuItemId
-};
 
 export const updateVerticalMenu = path => {
   // POST /migration/menu_section_url to update session[:tab_url] on server
@@ -23,10 +15,12 @@ export const updateVerticalMenu = path => {
   }
 
   // Based on location.pathname, set menu item id
-  const menu_item_id = pathToMenuItem[path.split('/')[1]];
+  const link_item = links.find(element => {
+    return element['path'].split('/')[0] === path.split('/')[1];
+  });
 
-  // Add 'active' class to menu_item_id
-  const newActiveMenuItem = document.querySelector(`[id="${menu_item_id}"]`);
+  // Add 'active' class to correct menu item
+  const newActiveMenuItem = document.querySelector(`[id="${link_item['menu_item_id']}"]`);
   if (newActiveMenuItem !== null) {
     newActiveMenuItem.classList.add('active');
   }

--- a/app/javascript/react/config/Routes.js
+++ b/app/javascript/react/config/Routes.js
@@ -1,12 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Route } from 'react-router-dom';
+import { Redirect, Route } from 'react-router-dom';
 import { links } from './config';
 import { componentSettings } from '../../components';
 import componentRegistry from '../../components/componentRegistry';
 
 const Routes = ({ store }) =>
-  links.map(({ path, component }) => {
+  links.map(({ path, component, redirect }) => {
+    if (typeof redirect !== 'undefined') {
+      return <Route exact key={path} path={path} render={() => <Redirect to={redirect} />} />;
+    }
     const coreComponent = componentSettings(component);
     if (coreComponent) {
       const markup = componentRegistry.markup(coreComponent.name, coreComponent.data, store);

--- a/app/javascript/react/config/Routes.js
+++ b/app/javascript/react/config/Routes.js
@@ -14,7 +14,7 @@ const Routes = ({ store }) =>
         <Route
           exact
           key={path}
-          path={path}
+          path={`/${path}`}
           render={props => {
             if (props.match.isExact) {
               return (
@@ -28,7 +28,7 @@ const Routes = ({ store }) =>
         />
       );
     }
-    return <Route exact key={path} path={path} />;
+    return <Route exact key={path} path={`/${path}`} />;
   });
 
 Routes.propTypes = {

--- a/app/javascript/react/config/config.js
+++ b/app/javascript/react/config/config.js
@@ -23,5 +23,9 @@ export const links = [
     path: 'mappings',
     component: MappingsContainer,
     menu_item_id: 'menu_item_mappings'
+  },
+  {
+    path: '',
+    redirect: 'plans'
   }
 ];

--- a/app/javascript/react/config/config.js
+++ b/app/javascript/react/config/config.js
@@ -6,18 +6,22 @@ import MappingsContainer from '../screens/App/Mappings';
 export const links = [
   {
     path: 'plans',
-    component: OverviewContainer
+    component: OverviewContainer,
+    menu_item_id: 'menu_item_plans'
   },
   {
     path: 'settings',
-    component: Settings
+    component: Settings,
+    menu_item_id: 'menu_item_settings'
   },
   {
     path: 'plan/:id',
-    component: PlanContainer
+    component: PlanContainer,
+    menu_item_id: 'menu_item_plans'
   },
   {
     path: 'mappings',
-    component: MappingsContainer
+    component: MappingsContainer,
+    menu_item_id: 'menu_item_mappings'
   }
 ];

--- a/app/javascript/react/config/config.js
+++ b/app/javascript/react/config/config.js
@@ -5,19 +5,19 @@ import MappingsContainer from '../screens/App/Mappings';
 
 export const links = [
   {
-    path: '/migration/plans',
+    path: 'plans',
     component: OverviewContainer
   },
   {
-    path: '/migration/settings',
+    path: 'settings',
     component: Settings
   },
   {
-    path: '/migration/plan/:id',
+    path: 'plan/:id',
     component: PlanContainer
   },
   {
-    path: '/migration/mappings',
+    path: 'mappings',
     component: MappingsContainer
   }
 ];

--- a/app/javascript/react/index.js
+++ b/app/javascript/react/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BrowserRouter } from 'react-router-dom';
+import { ConnectedRouter } from 'connected-react-router';
 import { connect } from 'react-redux';
 import { Spinner } from 'patternfly-react';
 import PropTypes from 'prop-types';
@@ -21,12 +21,12 @@ class App extends React.Component {
         </div>
       );
     return (
-      <BrowserRouter>
+      <ConnectedRouter history={ManageIQ.redux.history}>
         <React.Fragment>
           <NotificationList />
           <Routes store={ManageIQ.redux.store} />
         </React.Fragment>
-      </BrowserRouter>
+      </ConnectedRouter>
     );
   }
 }

--- a/app/javascript/react/index.js
+++ b/app/javascript/react/index.js
@@ -6,11 +6,13 @@ import PropTypes from 'prop-types';
 import Routes from './config/Routes';
 import NotificationList from './screens/App/common/NotificationList';
 import createReducers from '../redux/reducers';
+import { updateVerticalMenu } from '../common/menu';
 
 class App extends React.Component {
   constructor(props) {
     super(props);
     ManageIQ.redux.addReducer(createReducers());
+    updateVerticalMenu(ManageIQ.redux.store.getState().router.location.pathname);
   }
 
   render() {
@@ -28,6 +30,16 @@ class App extends React.Component {
         </React.Fragment>
       </ConnectedRouter>
     );
+  }
+
+  componentDidMount() {
+    this.unlisten = ManageIQ.redux.history.listen(location => {
+      updateVerticalMenu(location.pathname);
+    });
+  }
+
+  componentWillUnmount() {
+    this.unlisten();
   }
 }
 

--- a/app/javascript/react/screens/App/Mappings/Mappings.js
+++ b/app/javascript/react/screens/App/Mappings/Mappings.js
@@ -173,7 +173,7 @@ class Mappings extends Component {
       <React.Fragment>
         <Toolbar>
           <Breadcrumb.Item href="/dashboard/maintab?tab=compute">{__('Compute')}</Breadcrumb.Item>
-          <Breadcrumb.Item href="/migration/plans">{__('Migration')}</Breadcrumb.Item>
+          <Breadcrumb.Item href="#/plans">{__('Migration')}</Breadcrumb.Item>
           <Breadcrumb.Item active>{__('Infrastructure Mappings')}</Breadcrumb.Item>
         </Toolbar>
         <Spinner

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardResultsStep/MappingWizardResultsStep.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardResultsStep/MappingWizardResultsStep.js
@@ -51,7 +51,7 @@ class MappingWizardResultsStep extends React.Component {
 
   onContinueToPlanWizard = id => {
     this.props.continueToPlanAction(id);
-    this.props.redirectTo('/migration/plans');
+    this.props.redirectTo('/plans');
   };
 
   render() {

--- a/app/javascript/react/screens/App/Overview/Overview.js
+++ b/app/javascript/react/screens/App/Overview/Overview.js
@@ -124,7 +124,7 @@ class Overview extends React.Component {
           <h3 style={{ marginTop: 0 }}>{__('No infrastructure mapping exists')}</h3>
           <p>
             {__('A migration plan must include an infrastructure mapping.')}{' '}
-            <a href="/migration/mappings#">{__('Go to the Infrastructure Mappings page to create one.')}</a>
+            <a href="/migration#/mappings">{__('Go to the Infrastructure Mappings page to create one.')}</a>
           </p>
         </React.Fragment>
       ),
@@ -346,7 +346,7 @@ class Overview extends React.Component {
                 description={__('Create an infrastructure mapping to later be used by a migration plan')}
                 buttonText={__('Create Infrastructure Mapping')}
                 showWizardAction={() => {
-                  this.redirectTo('/migration/mappings');
+                  this.redirectTo('/mappings');
                   openMappingWizardOnTransitionAction();
                 }}
                 className="full-page-empty"

--- a/app/javascript/react/screens/App/Overview/components/Migrations/InProgressWithDetailCard.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/InProgressWithDetailCard.js
@@ -7,7 +7,7 @@ const InProgressWithDetailCard = ({ plan, failedOverlay, handleClick, children }
   <InProgressCard
     onClick={e => {
       if (!e.target.classList.contains('pficon-error-circle-o')) {
-        handleClick(`/migration/plan/${plan.id}`);
+        handleClick(`/plan/${plan.id}`);
       }
     }}
     className="in-progress"

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
@@ -192,7 +192,7 @@ const MigrationsCompletedList = ({
                         onClick={e => {
                           e.stopPropagation();
 
-                          redirectTo(`/migration/plan/${plan.id}`);
+                          redirectTo(`/plan/${plan.id}`);
                         }}
                         key={plan.id}
                         leftContent={
@@ -236,7 +236,7 @@ const MigrationsCompletedList = ({
                           ),
                           !isMissingMapping && (
                             <ListView.InfoItem key={`${plan.id}-infraMappingName`}>
-                              <a href="/migration/mappings#">{plan.infraMappingName}</a>
+                              <a href="/migration#/mappings">{plan.infraMappingName}</a>
                             </ListView.InfoItem>
                           ),
                           !denied ? (

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
@@ -87,7 +87,7 @@ const MigrationsNotStartedList = ({
                         stacked
                         className="plans-not-started-list__list-item"
                         onClick={() => {
-                          redirectTo(`/migration/plan/${plan.id}`);
+                          redirectTo(`/plan/${plan.id}`);
                         }}
                         actions={
                           <div>
@@ -152,7 +152,7 @@ const MigrationsNotStartedList = ({
                           ),
                           !isMissingMapping && (
                             <ListView.InfoItem key={`${plan.id}-infraMappingName`}>
-                              <a href="/migration/mappings#">{plan.infraMappingName}</a>
+                              <a href="/migration#/mappings">{plan.infraMappingName}</a>
                             </ListView.InfoItem>
                           ),
                           migrationScheduled && !migrationStarting ? (

--- a/app/javascript/react/screens/App/Overview/components/Migrations/__test__/MigrationsNotStartedList.test.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/__test__/MigrationsNotStartedList.test.js
@@ -29,7 +29,7 @@ test('clicking on a plan fires redirectTo with the path to its details page', ()
     .at(0)
     .simulate('click');
 
-  expect(redirectTo).toHaveBeenLastCalledWith(`/migration/plan/${notStartedPlan.id}`);
+  expect(redirectTo).toHaveBeenLastCalledWith(`/plan/${notStartedPlan.id}`);
 });
 
 test.skip('clicking on the Migrate button fires migrateClick with the correct API endpoint', () => {

--- a/app/javascript/react/screens/App/Plan/Plan.js
+++ b/app/javascript/react/screens/App/Plan/Plan.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Immutable from 'seamless-immutable';
+import { Link } from 'react-router-dom';
 import { Breadcrumb, Spinner, Icon } from 'patternfly-react';
 import Toolbar from '../../../config/Toolbar';
 import PlanRequestDetailList from './components/PlanRequestDetailList/PlanRequestDetailList';
@@ -167,7 +168,7 @@ class Plan extends React.Component {
         <Toolbar>
           <Breadcrumb.Item href="/dashboard/maintab?tab=compute">{__('Compute')}</Breadcrumb.Item>
           <li>
-            <a href="/migration/plans">{__('Migration')}</a>
+            <Link to="/plans">{__('Migration')}</Link>
           </li>
           {!isRejectedPlan &&
             planName && (

--- a/app/javascript/react/screens/App/Settings/Settings.js
+++ b/app/javascript/react/screens/App/Settings/Settings.js
@@ -23,7 +23,7 @@ export class Settings extends React.Component {
     const toolbarContent = (
       <Toolbar>
         <Breadcrumb.Item href="/dashboard/maintab?tab=compute">{__('Compute')}</Breadcrumb.Item>
-        <Breadcrumb.Item href="/migration">{__('Migration')}</Breadcrumb.Item>
+        <Breadcrumb.Item href="#/plans">{__('Migration')}</Breadcrumb.Item>
         <Breadcrumb.Item active>{__('Migration Settings')}</Breadcrumb.Item>
       </Toolbar>
     );

--- a/app/javascript/react/screens/App/Settings/__tests__/__snapshots__/Settings.test.js.snap
+++ b/app/javascript/react/screens/App/Settings/__tests__/__snapshots__/Settings.test.js.snap
@@ -11,7 +11,7 @@ exports[`Settings component renders the settings page 1`] = `
     </BreadcrumbItem>
     <BreadcrumbItem
       active={false}
-      href="/migration"
+      href="#/plans"
     >
       Migration
     </BreadcrumbItem>

--- a/app/javascript/react/screens/App/common/NotificationList/NotificationList.js
+++ b/app/javascript/react/screens/App/common/NotificationList/NotificationList.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { TimedToastNotification, ToastNotificationList } from 'patternfly-react';
+import { Link } from 'react-router-dom';
 
 class NotificationList extends React.Component {
   render() {
@@ -24,7 +25,7 @@ class NotificationList extends React.Component {
               </span>
               {notification.actionEnabled && (
                 <div className="pull-right toast-pf-action">
-                  <a href={`/migration/plan/${notification.data.id}`}>{__('View Details')}</a>
+                  <Link to={`/plan/${notification.data.id}`}>{__('View Details')}</Link>
                 </div>
               )}
             </TimedToastNotification>

--- a/app/javascript/redux/actions/routerActions.js
+++ b/app/javascript/redux/actions/routerActions.js
@@ -1,3 +1,8 @@
-export const redirectTo = path => () => {
-  window.DoNav(path);
+import { push } from 'connected-react-router';
+
+export const redirectTo = path => (dispatch, getState) => {
+  // NOTE: to avoid pushing the same path to history and throwing error
+  if (getState().router.location.pathname !== path) {
+    dispatch(push(path));
+  }
 };

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,12 +1,13 @@
 # ManageIQ::V2V::Engine.routes.draw do
 Rails.application.routes.draw do
-  match '/migration' => redirect('/migration/plans'), :via => [:get]
-  match '/migration/plans' => 'migration#index', :via => [:get]
-  match '/migration/mappings' => 'migration#index', :via => [:get]
-  match '/migration/plan/:id' => 'migration#index', :via => [:get]
+  match '/migration' => 'migration#index', :via => [:get]
   match 'migration/*page' => 'migration#index', :via => [:get]
 
   get "migration_log/download_migration_log(/:id)",
     :action     => 'download_migration_log',
     :controller => 'migration_log'
+
+  post 'migration/menu_section_url',
+    :action     => 'menu_section_url',
+    :controller => 'migration'
 end

--- a/lib/manageiq/v2v/engine.rb
+++ b/lib/manageiq/v2v/engine.rb
@@ -13,9 +13,9 @@ module ManageIQ::V2V
     initializer 'plugin' do
       Menu::CustomLoader.register(
         Menu::Section.new(:migration, N_("Migration"), 'fa fa-plus', [
-          Menu::Item.new('plans', N_("Migration Plans"), 'migration', {:feature => 'migration', :any => true}, '/migration/plans'),
-          Menu::Item.new('mappings', N_("Infrastructure Mappings"), 'mappings', {:feature => 'mappings', :any => true}, '/migration/mappings'),
-          Menu::Item.new('settings', N_("Migration Settings"), 'migration_settings', {:feature => 'migration_settings', :any => true}, '/migration/settings')
+          Menu::Item.new('plans', N_("Migration Plans"), 'migration', {:feature => 'migration', :any => true}, '/migration#/plans'),
+          Menu::Item.new('mappings', N_("Infrastructure Mappings"), 'mappings', {:feature => 'mappings', :any => true}, '/migration#/mappings'),
+          Menu::Item.new('settings', N_("Migration Settings"), 'migration_settings', {:feature => 'migration_settings', :any => true}, '/migration#/settings')
         ], nil, nil, nil, nil, :compute)
       )
     end


### PR DESCRIPTION
This PR:
* restores `ConnectedRouter` and hash routing: this is to have swift & fully client-side routing with browsing history
* adds code to re-style vertical menu whenever we navigate between menu items (or screens that would ordinarily fall into different menu item): this is so that correct vertical menu item is highlighted
* adds code to do `POST /migration/menu_item_url`: this is to update `session[:tab_url]` when navigating between two menu items so that clicking on `Compute ➛ Migrate` takes you to previously visited url

Fixes: https://github.com/ManageIQ/manageiq-v2v/issues/811

Depends on:
https://github.com/ManageIQ/manageiq-ui-classic/pull/5063
https://github.com/ManageIQ/manageiq-ui-classic/pull/4999