### PR TITLE
[#802] Prevent Settings form from being destroyed on unmount

### DIFF
--- a/app/javascript/react/screens/App/Settings/index.js
+++ b/app/javascript/react/screens/App/Settings/index.js
@@ -13,7 +13,8 @@ const mapStateToProps = ({ settings, form }, ownProps) => ({
   ...ownProps.data,
   settingsForm: form.settings,
   initialValues: settings.savedSettings,
-  enableReinitialize: true
+  enableReinitialize: true,
+  destroyOnUnmount: false
 });
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => Object.assign(stateProps, ownProps.data, dispatchProps);


### PR DESCRIPTION
Fixes #802, which is re-exposed by #822 after having been hidden by #769.