### PR TITLE
[#835] Edit Plan: fetch correct status of pre-selected VMs using VM validation service

### DIFF
--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardAdvancedOptionsStep/index.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardAdvancedOptionsStep/index.js
@@ -30,15 +30,7 @@ const mapStateToProps = (
     editingPlan &&
     editingPlan.transformation_mapping &&
     editingPlan.transformation_mapping.id === infrastructure_mapping;
-  const validVmsDeduped = !shouldPrefillForEditing
-    ? planWizardVMStep.valid_vms
-    : planWizardVMStep.valid_vms.filter(
-        validVm => !planWizardVMStep.preselected_vms.some(preselectedVm => preselectedVm.id === validVm.id)
-      );
-  const allVms =
-    vm_choice_radio === 'vms_via_csv'
-      ? [...planWizardVMStep.valid_vms, ...planWizardVMStep.invalid_vms, ...planWizardVMStep.conflict_vms]
-      : [...planWizardVMStep.preselected_vms, ...validVmsDeduped];
+  const allVms = [...planWizardVMStep.valid_vms, ...planWizardVMStep.invalid_vms, ...planWizardVMStep.conflict_vms];
 
   const configInfo = editingPlan && editingPlan.options && editingPlan.options.config_info;
   const vmStepSelectedVms = getVMStepSelectedVms(allVms, selectedVms);

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardInstancePropertiesStep/index.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardInstancePropertiesStep/index.js
@@ -26,10 +26,7 @@ const mapStateToProps = (
   ownProps
 ) => {
   const editingPlan = findEditingPlan(transformationPlans, editingPlanId);
-  const allVms =
-    vm_choice_radio === 'vms_via_csv'
-      ? [...planWizardVMStep.valid_vms, ...planWizardVMStep.invalid_vms, ...planWizardVMStep.conflict_vms]
-      : [...planWizardVMStep.preselected_vms, ...planWizardVMStep.valid_vms];
+  const allVms = [...planWizardVMStep.valid_vms, ...planWizardVMStep.invalid_vms, ...planWizardVMStep.conflict_vms];
   const selectedMapping =
     transformationMappings &&
     infrastructure_mapping &&

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/PlanWizardVMStep.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/PlanWizardVMStep.js
@@ -139,7 +139,6 @@ class PlanWizardVMStep extends React.Component {
         validVms.filter(vm => vm.valid === false)
       );
       const conflictVms = Immutable.asMutable(conflict_vms, { deep: true });
-      // TODO handle removal of everything related to preselected_vms and isQueryingVms?
       const combined = [...inValidsVms, ...conflictVms, ...validVms];
       if (combined.length) {
         let initialSelectedRows = formSelectedVms || [];

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/PlanWizardVMStepActions.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/PlanWizardVMStepActions.js
@@ -5,7 +5,7 @@ import { V2V_VM_STEP_RESET, V2V_VALIDATE_VMS, QUERY_V2V_PLAN_VMS } from './PlanW
 
 export { showConfirmModalAction, hideConfirmModalAction } from '../../../../OverviewActions';
 
-const _validateVmsActionCreator = (url, vms, planId) => dispatch => {
+const _validateVmsActionCreator = (url, vms, planId, meta) => dispatch => {
   let postBody = {
     action: 'validate_vms',
     import: vms
@@ -13,7 +13,7 @@ const _validateVmsActionCreator = (url, vms, planId) => dispatch => {
   if (planId) {
     postBody = { ...postBody, service_template_id: planId };
   }
-  dispatch({
+  return dispatch({
     type: V2V_VALIDATE_VMS,
     payload: new Promise((resolve, reject) => {
       API.post(url, postBody)
@@ -23,14 +23,15 @@ const _validateVmsActionCreator = (url, vms, planId) => dispatch => {
         .catch(e => {
           reject(e);
         });
-    })
+    }),
+    meta
   });
 };
 
-export const validateVmsAction = (url, id, vms, planId) => {
+export const validateVmsAction = (url, id, vms, planId, meta = {}) => {
   const uri = new URI(`${url}/${id}`);
 
-  return _validateVmsActionCreator(uri.toString(), vms, planId);
+  return _validateVmsActionCreator(uri.toString(), vms, planId, meta);
 };
 
 export const csvImportAction = () => dispatch => {

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/PlanWizardVMStepReducer.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/PlanWizardVMStepReducer.js
@@ -1,7 +1,7 @@
 import Immutable from 'seamless-immutable';
 
 import { V2V_VALIDATE_VMS, V2V_VM_STEP_RESET, QUERY_V2V_PLAN_VMS } from './PlanWizardVMStepConstants';
-import { _formatConflictVms, _formatInvalidVms, _formatValidVms, _formatPreselectedVms } from './helpers';
+import { _formatConflictVms, _formatInvalidVms, _formatValidVms } from './helpers';
 
 const initialState = Immutable({
   isValidatingVms: false,
@@ -12,7 +12,6 @@ const initialState = Immutable({
   valid_vms: [],
   invalid_vms: [],
   conflict_vms: [],
-  preselected_vms: [],
   isQueryingVms: false,
   isVmsQueryRejected: false,
   vmsQueryError: null
@@ -68,36 +67,31 @@ export default (state = initialState, action) => {
       return state
         .set('isQueryingVms', true)
         .set('isVmsQueryRejected', false)
-        .set('vmsQueryError', null)
-        .set('preselected_vms', []);
+        .set('vmsQueryError', null);
     case `${QUERY_V2V_PLAN_VMS}_FULFILLED`: {
       const { payload } = action;
       if (payload && payload.data) {
         return state
           .set('isQueryingVms', false)
           .set('isVmsQueryRejected', false)
-          .set('vmsQueryError', null)
-          .set('preselected_vms', _formatPreselectedVms(action.payload.data.results));
+          .set('vmsQueryError', null);
       }
       return state
         .set('isQueryingVms', false)
         .set('isVmsQueryRejected', false)
-        .set('vmsQueryError', null)
-        .set('preselected_vms', []);
+        .set('vmsQueryError', null);
     }
     case `${QUERY_V2V_PLAN_VMS}_REJECTED`:
       return state
         .set('isQueryingVms', false)
         .set('isVmsQueryRejected', true)
-        .set('vmsQueryError', action.payload)
-        .set('preselected_vms', []);
+        .set('vmsQueryError', action.payload);
     case V2V_VM_STEP_RESET:
       return state
         .set('validationServiceCalled', false)
         .set('valid_vms', [])
         .set('invalid_vms', [])
         .set('conflict_vms', [])
-        .set('preselected_vms', [])
         .set('isRejectedValidatingVms', false)
         .set('isValidatingVms', false);
 

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/helpers.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/helpers.js
@@ -99,18 +99,3 @@ export const getVmIds = editingPlan =>
   editingPlan.options.config_info &&
   editingPlan.options.config_info.actions &&
   editingPlan.options.config_info.actions.map(action => action.vm_id);
-
-export const _formatPreselectedVms = vmsQueryResults =>
-  vmsQueryResults.map(result => ({
-    id: result.id,
-    name: result.name,
-    cluster: result.ems_cluster ? result.ems_cluster.name : '',
-    ems_cluster_id: result.ems_cluster ? result.ems_cluster.id : '',
-    path: result.ext_management_system
-      ? `${result.ext_management_system.name}/${result.v_parent_blue_folder_display_path}`
-      : '',
-    allocated_size: numeral(result.allocated_disk_storage).format('0.00b'),
-    selected: true,
-    valid: true,
-    reason: V2V_VM_POST_VALIDATION_REASONS.ok
-  }));


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1654865
Fixes #835.

In order to get the right status info, rather than using the VM API query results to populate the VM list, I took the list of VM names from those query results and ran them through the VM validation service like we do with CSV imports, then combining those results with the initial validation (discovery) request. This includes changes to the reducer so it can update state properly when two concurrent validation requests are made.