### PR TITLE
[#842] Add "Flavor" and "Security Group" CSV columns and associated warnings

### DIFF
--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardInstancePropertiesStep/PlanWizardInstancePropertiesStep.scss
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardInstancePropertiesStep/PlanWizardInstancePropertiesStep.scss
@@ -113,3 +113,15 @@ table.pf-table-inline-edit tbody {
 .popover-with-max-width {
   max-width: 400px;
 }
+
+/**
+  Hover state for popover icons
+*/
+
+.instance-properties-step-table .clickable-icon {
+  margin-left: 5px;
+  opacity: 0.5;
+}
+.instance-properties-step-table .clickable-icon:hover {
+  opacity: 1;
+}

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardInstancePropertiesStep/PlanWizardInstancePropertiesStepReducer.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardInstancePropertiesStep/PlanWizardInstancePropertiesStepReducer.js
@@ -109,17 +109,23 @@ export default (state = initialState, action) => {
           }
         }
 
-        if (editingPlan && !preselectedFlavor && !preselectedGroup) {
+        if (editingPlan) {
           const existingVm = editingPlan.options.config_info.actions.find(
             vm => vm.vm_id === existingInstancePropertiesRow.id
           );
           if (existingVm) {
-            const existingFlavor =
-              tenantFlavors && tenantFlavors.find(flavor => flavor.id === existingVm.osp_flavor_id);
-            const existingGroup =
-              tenantSecurityGroups && tenantSecurityGroups.find(group => group.id === existingVm.osp_security_group_id);
-            preselectedFlavor = existingFlavor && { name: existingFlavor.name, id: existingFlavor.id };
-            preselectedGroup = existingGroup && { name: existingGroup.name, id: existingGroup.id };
+            const { csvFields } = existingInstancePropertiesRow;
+            if (!csvFields || !csvFields.osp_flavor) {
+              const existingFlavor =
+                tenantFlavors && tenantFlavors.find(flavor => flavor.id === existingVm.osp_flavor_id);
+              preselectedFlavor = existingFlavor && { name: existingFlavor.name, id: existingFlavor.id };
+            }
+            if (!csvFields || !csvFields.osp_security_group) {
+              const existingGroup =
+                tenantSecurityGroups &&
+                tenantSecurityGroups.find(group => group.id === existingVm.osp_security_group_id);
+              preselectedGroup = existingGroup && { name: existingGroup.name, id: existingGroup.id };
+            }
           }
         }
 

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardInstancePropertiesStep/PlanWizardInstancePropertiesStepReducer.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardInstancePropertiesStep/PlanWizardInstancePropertiesStepReducer.js
@@ -92,14 +92,20 @@ export default (state = initialState, action) => {
         let preselectedFlavor;
         let preselectedGroup;
 
-        /*
-        if (csv specified flavors and groups) {
-          preselectedFlavor = what's in the csv
-          preselectedGroup = what's in the csv
-        } else if (editingPlan) { ... }
-        */
+        if (existingInstancePropertiesRow.csvFields) {
+          const { osp_flavor, osp_security_group } = existingInstancePropertiesRow.csvFields;
+          if (osp_flavor) {
+            const matchingFlavor = tenantFlavors && tenantFlavors.find(flavor => flavor.name === osp_flavor);
+            preselectedFlavor = matchingFlavor && { name: matchingFlavor.name, id: matchingFlavor.id };
+          }
+          if (osp_security_group) {
+            const matchingGroup =
+              tenantSecurityGroups && tenantSecurityGroups.find(group => group.name === osp_security_group);
+            preselectedGroup = matchingGroup && { name: matchingGroup.name, id: matchingGroup.id };
+          }
+        }
 
-        if (editingPlan) {
+        if (editingPlan && !preselectedFlavor && !preselectedGroup) {
           const existingVm = editingPlan.options.config_info.actions.find(
             vm => vm.vm_id === existingInstancePropertiesRow.id
           );

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardInstancePropertiesStep/PlanWizardInstancePropertiesStepReducer.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardInstancePropertiesStep/PlanWizardInstancePropertiesStepReducer.js
@@ -92,6 +92,13 @@ export default (state = initialState, action) => {
         let preselectedFlavor;
         let preselectedGroup;
 
+        /*
+        if (csv specified flavors and groups) {
+          preselectedFlavor = what's in the csv
+          preselectedGroup = what's in the csv
+        } else if (editingPlan) { ... }
+        */
+
         if (editingPlan) {
           const existingVm = editingPlan.options.config_info.actions.find(
             vm => vm.vm_id === existingInstancePropertiesRow.id

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardInstancePropertiesStep/PlanWizardInstancePropertiesStepReducer.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardInstancePropertiesStep/PlanWizardInstancePropertiesStepReducer.js
@@ -90,18 +90,22 @@ export default (state = initialState, action) => {
         const bestGroup = { name: defaultSecurityGroupName, id: defaultSecurityGroupId };
 
         let preselectedFlavor;
+        let csvInvalidFlavorWarning = false;
         let preselectedGroup;
+        let csvInvalidGroupWarning = false;
 
         if (existingInstancePropertiesRow.csvFields) {
           const { osp_flavor, osp_security_group } = existingInstancePropertiesRow.csvFields;
           if (osp_flavor) {
             const matchingFlavor = tenantFlavors && tenantFlavors.find(flavor => flavor.name === osp_flavor);
             preselectedFlavor = matchingFlavor && { name: matchingFlavor.name, id: matchingFlavor.id };
+            csvInvalidFlavorWarning = !matchingFlavor;
           }
           if (osp_security_group) {
             const matchingGroup =
               tenantSecurityGroups && tenantSecurityGroups.find(group => group.name === osp_security_group);
             preselectedGroup = matchingGroup && { name: matchingGroup.name, id: matchingGroup.id };
+            csvInvalidGroupWarning = !matchingGroup;
           }
         }
 
@@ -122,7 +126,9 @@ export default (state = initialState, action) => {
         const rowUpdatedWithBestFlavor = {
           ...existingInstancePropertiesRow,
           osp_flavor: preselectedFlavor || bestFlavor,
+          csvInvalidFlavorWarning,
           osp_security_group: preselectedGroup || bestGroup,
+          csvInvalidGroupWarning,
           target_cluster_name: tenant.name
         };
         instancePropertiesRowsUpdatedWithBestFlavor.push(rowUpdatedWithBestFlavor);

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardInstancePropertiesStep/__tests__/PlanWizardInstancePropertiesStepReducer.test.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardInstancePropertiesStep/__tests__/PlanWizardInstancePropertiesStepReducer.test.js
@@ -206,6 +206,56 @@ describe('setting best fit flavors and default security groups', () => {
       name: 'dbservers'
     });
   });
+
+  test('with valid and invalid CSV-specified flavors and groups', () => {
+    const action = {
+      type: SET_V2V_BEST_FIT_FLAVORS_AND_DEFAULT_SECURITY_GROUPS,
+      payload: processedBestFitFlavors
+    };
+    const rowsWithCsvFields = [
+      {
+        ...instancePropertiesRows[0],
+        csvFields: {
+          osp_flavor: 'x1.xtra-small',
+          osp_security_group: 'invalidgroup'
+        }
+      },
+      {
+        ...instancePropertiesRows[1],
+        csvFields: {
+          osp_flavor: 'invalidflavor',
+          osp_security_group: 'webservers'
+        }
+      }
+    ];
+    const prevState = initialState
+      .set('tenantsWithAttributes', tenantsWithAttributes.results)
+      .set('isSettingSecurityGroupsAndBestFitFlavors', true)
+      .set('instancePropertiesRows', rowsWithCsvFields);
+    const state = instancePropertiesStepReducer(prevState, action);
+
+    expect(state.instancePropertiesRows[0].osp_flavor).toEqual({
+      id: '42000000000001',
+      name: 'x1.xtra-small'
+    });
+    expect(state.instancePropertiesRows[0].csvInvalidFlavorWarning).toBe(false);
+    expect(state.instancePropertiesRows[0].osp_security_group).toEqual({
+      id: '42000000000013',
+      name: 'default'
+    });
+    expect(state.instancePropertiesRows[0].csvInvalidGroupWarning).toBe(true);
+
+    expect(state.instancePropertiesRows[1].osp_flavor).toEqual({
+      id: '42000000000002',
+      name: 'x1.large'
+    });
+    expect(state.instancePropertiesRows[1].csvInvalidFlavorWarning).toBe(true);
+    expect(state.instancePropertiesRows[1].osp_security_group).toEqual({
+      id: '42000000000022',
+      name: 'webservers'
+    });
+    expect(state.instancePropertiesRows[1].csvInvalidGroupWarning).toBe(false);
+  });
 });
 
 it('sets instance properties rows', () => {

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardInstancePropertiesStep/__tests__/PlanWizardInstancePropertiesStepReducer.test.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardInstancePropertiesStep/__tests__/PlanWizardInstancePropertiesStepReducer.test.js
@@ -89,6 +89,45 @@ describe('querying best fit flavors', () => {
 });
 
 describe('setting best fit flavors and default security groups', () => {
+  const editingPlan = {
+    options: {
+      config_info: {
+        actions: [
+          {
+            vm_id: '42000000000017',
+            pre_service: false,
+            post_service: false,
+            osp_security_group_id: '42000000000016',
+            osp_flavor_id: '42000000000002'
+          },
+          {
+            vm_id: '42000000000006',
+            pre_service: false,
+            post_service: false,
+            osp_security_group_id: '42000000000020',
+            osp_flavor_id: '42000000000004'
+          }
+        ]
+      }
+    }
+  };
+  const rowsWithCsvFields = [
+    {
+      ...instancePropertiesRows[0],
+      csvFields: {
+        osp_flavor: 'x1.xtra-small',
+        osp_security_group: 'invalidgroup'
+      }
+    },
+    {
+      ...instancePropertiesRows[1],
+      csvFields: {
+        osp_flavor: 'invalidflavor',
+        osp_security_group: 'webservers'
+      }
+    }
+  ];
+
   test('with all matching flavors', () => {
     const action = {
       type: SET_V2V_BEST_FIT_FLAVORS_AND_DEFAULT_SECURITY_GROUPS,
@@ -160,28 +199,7 @@ describe('setting best fit flavors and default security groups', () => {
       type: SET_V2V_BEST_FIT_FLAVORS_AND_DEFAULT_SECURITY_GROUPS,
       payload: {
         ...processedBestFitFlavors,
-        editingPlan: {
-          options: {
-            config_info: {
-              actions: [
-                {
-                  vm_id: '42000000000017',
-                  pre_service: false,
-                  post_service: false,
-                  osp_security_group_id: '42000000000016',
-                  osp_flavor_id: '42000000000002'
-                },
-                {
-                  vm_id: '42000000000006',
-                  pre_service: false,
-                  post_service: false,
-                  osp_security_group_id: '42000000000020',
-                  osp_flavor_id: '42000000000004'
-                }
-              ]
-            }
-          }
-        }
+        editingPlan
       }
     };
     const prevState = initialState
@@ -212,22 +230,6 @@ describe('setting best fit flavors and default security groups', () => {
       type: SET_V2V_BEST_FIT_FLAVORS_AND_DEFAULT_SECURITY_GROUPS,
       payload: processedBestFitFlavors
     };
-    const rowsWithCsvFields = [
-      {
-        ...instancePropertiesRows[0],
-        csvFields: {
-          osp_flavor: 'x1.xtra-small',
-          osp_security_group: 'invalidgroup'
-        }
-      },
-      {
-        ...instancePropertiesRows[1],
-        csvFields: {
-          osp_flavor: 'invalidflavor',
-          osp_security_group: 'webservers'
-        }
-      }
-    ];
     const prevState = initialState
       .set('tenantsWithAttributes', tenantsWithAttributes.results)
       .set('isSettingSecurityGroupsAndBestFitFlavors', true)
@@ -255,6 +257,34 @@ describe('setting best fit flavors and default security groups', () => {
       name: 'webservers'
     });
     expect(state.instancePropertiesRows[1].csvInvalidGroupWarning).toBe(false);
+  });
+
+  test('does not use saved values from editing if there are CSV columns for flavors/groups', () => {
+    const action = {
+      type: SET_V2V_BEST_FIT_FLAVORS_AND_DEFAULT_SECURITY_GROUPS,
+      payload: { ...processedBestFitFlavors, editingPlan }
+    };
+    const prevState = initialState
+      .set('tenantsWithAttributes', tenantsWithAttributes.results)
+      .set('isSettingSecurityGroupsAndBestFitFlavors', true)
+      .set('instancePropertiesRows', rowsWithCsvFields);
+    const state = instancePropertiesStepReducer(prevState, action);
+    expect(state.instancePropertiesRows[0].osp_flavor).toEqual({
+      id: '42000000000001',
+      name: 'x1.xtra-small'
+    });
+    expect(state.instancePropertiesRows[0].osp_security_group).toEqual({
+      id: '42000000000013',
+      name: 'default'
+    });
+    expect(state.instancePropertiesRows[1].osp_flavor).toEqual({
+      id: '42000000000002',
+      name: 'x1.large'
+    });
+    expect(state.instancePropertiesRows[1].osp_security_group).toEqual({
+      id: '42000000000022',
+      name: 'webservers'
+    });
   });
 });
 

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardInstancePropertiesStep/components/PlanWizardInstancePropertiesStepTable.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardInstancePropertiesStep/components/PlanWizardInstancePropertiesStepTable.js
@@ -109,6 +109,34 @@ class PlanWizardInstancePropertiesStepTable extends React.Component {
     return needsAsterisk ? `${flavorName} *` : flavorName;
   };
 
+  renderCsvWarning = (property, rowData) => {
+    let warningMessage;
+    if (property === 'osp_security_group' && rowData.csvInvalidGroupWarning) {
+      warningMessage = __('The security group specified in the CSV file is invalid and has been replaced with the default security group. Edit the CSV file to include a valid security group or edit the table row to choose a different value.'); // prettier-ignore
+    }
+    if (property === 'osp_flavor' && rowData.csvInvalidFlavorWarning) {
+      warningMessage = __('The flavor specified in the CSV file is invalid and has been replaced with the best fit flavor. Edit the CSV file to include a valid flavor or edit the table row to choose a different value.'); // prettier-ignore
+    }
+    if (warningMessage) {
+      return (
+        <OverlayTrigger
+          overlay={
+            <Popover id="osp-csv-flavor-warning">
+              <div style={{ maxWidth: 400 }}>{warningMessage}</div>
+            </Popover>
+          }
+          placement="top"
+          trigger={['click']}
+          delay={500}
+          rootClose
+        >
+          <Icon type="pf" name="warning-triangle-o" className="clickable-icon" />
+        </OverlayTrigger>
+      );
+    }
+    return null;
+  };
+
   inlineEditFormatter = Table.inlineEditFormatterFactory({
     isEditing: additionalData => this.inlineEditController().isEditing(additionalData),
     renderValue: (value, additionalData) => {
@@ -122,7 +150,10 @@ class PlanWizardInstancePropertiesStepTable extends React.Component {
             );
       return (
         <td className="editable">
-          <span className="static">{renderedValue}</span>
+          <span className="static">
+            {renderedValue}
+            {this.renderCsvWarning(additionalData.property, additionalData.rowData)}
+          </span>
         </td>
       );
     },
@@ -470,6 +501,7 @@ class PlanWizardInstancePropertiesStepTable extends React.Component {
         >
           <Table.Header headerRows={resolve.headerRows({ columns: this.getColumns() })} />
           <Table.Body
+            className="instance-properties-step-table"
             rows={sortedPaginatedRows.rows || []}
             rowKey="id"
             onRow={(rowData, { rowIndex }) => ({

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardInstancePropertiesStep/components/PlanWizardInstancePropertiesStepTable.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardInstancePropertiesStep/components/PlanWizardInstancePropertiesStepTable.js
@@ -76,7 +76,14 @@ class PlanWizardInstancePropertiesStepTable extends React.Component {
         this.setState({ editing: false });
 
         const updatedRows = rows.map(
-          row => (row.id === rowData.id ? input.value.updatedInstancePropertiesRowOnStandby : row)
+          row =>
+            row.id === rowData.id
+              ? {
+                  ...input.value.updatedInstancePropertiesRowOnStandby,
+                  csvInvalidFlavorWarning: false,
+                  csvInvalidGroupWarning: false
+                }
+              : row
         );
         instancePropertiesRowsAction(updatedRows);
         input.onChange({ updatedInstancePropertiesRowOnStandby: {} });

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/PlanWizardVMStepActions.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/PlanWizardVMStepActions.js
@@ -24,7 +24,10 @@ const _validateVmsActionCreator = (url, vms, planId, meta) => dispatch => {
           reject(e);
         });
     }),
-    meta
+    meta: {
+      ...meta,
+      csvRows: vms
+    }
   });
 };
 

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/PlanWizardVMStepReducer.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/PlanWizardVMStepReducer.js
@@ -28,9 +28,9 @@ export default (state = initialState, action) => {
       const { payload, meta } = action;
       const numPendingRequests = state.numPendingValidationRequests - 1;
       if (payload && payload.data) {
-        const newValidVms = _formatValidVms(payload.data.valid) || [];
-        const newInvalidVms = _formatInvalidVms(payload.data.invalid) || [];
-        const newConflictedVms = _formatConflictVms(payload.data.conflicted) || [];
+        const newValidVms = _formatValidVms(payload.data.valid, meta) || [];
+        const newInvalidVms = _formatInvalidVms(payload.data.invalid, meta) || [];
+        const newConflictedVms = _formatConflictVms(payload.data.conflicted, meta) || [];
         return state
           .set('valid_vms', meta.combineRequests ? [...state.valid_vms, ...newValidVms] : newValidVms)
           .set('invalid_vms', meta.combineRequests ? [...state.invalid_vms, ...newInvalidVms] : newInvalidVms)

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/__tests__/PlanWizardVMStepActions.test.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/__tests__/PlanWizardVMStepActions.test.js
@@ -21,9 +21,9 @@ describe('validate VMs action creator', () => {
     const { method, response } = validateVMsData;
     const url = '/dummy/api/validateVms';
     const id = '1';
-    const meta = { some: 'metadata' };
+    const meta = { some: 'metadata', csvRows: [] };
     mockRequest({ method, url: `${url}/${id}`, response });
-    return store.dispatch(actions.validateVmsAction(url, id, [], '1', meta)).then(() => {
+    return store.dispatch(actions.validateVmsAction(url, id, [], '1', { some: 'metadata' })).then(() => {
       const storeActions = store.getActions();
       expect(storeActions[0]).toEqual({ type: `${V2V_VALIDATE_VMS}_PENDING`, meta });
       expect(storeActions[1]).toEqual({ type: `${V2V_VALIDATE_VMS}_FULFILLED`, meta, payload: response });
@@ -34,9 +34,9 @@ describe('validate VMs action creator', () => {
     const { method, response } = validateVMsData;
     const url = '/dummy/api/validateVms';
     const id = '1';
-    const meta = { some: 'metadata' };
+    const meta = { some: 'metadata', csvRows: [] };
     mockRequest({ method, url: `${url}/${id}`, response, status: 500 });
-    return store.dispatch(actions.validateVmsAction(url, id, [], '1', meta)).catch(() => {
+    return store.dispatch(actions.validateVmsAction(url, id, [], '1', { some: 'metadata' })).catch(() => {
       const storeActions = store.getActions();
       expect(storeActions[0]).toEqual({ type: `${V2V_VALIDATE_VMS}_PENDING`, meta });
       expect(storeActions[1].type).toEqual(`${V2V_VALIDATE_VMS}_REJECTED`);

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/__tests__/PlanWizardVMStepActions.test.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/__tests__/PlanWizardVMStepActions.test.js
@@ -21,9 +21,10 @@ describe('validate VMs action creator', () => {
     const { method, response } = validateVMsData;
     const url = '/dummy/api/validateVms';
     const id = '1';
-    const meta = { some: 'metadata', csvRows: [] };
+    const csvRows = [{ some: 'row' }];
+    const meta = { some: 'metadata', csvRows };
     mockRequest({ method, url: `${url}/${id}`, response });
-    return store.dispatch(actions.validateVmsAction(url, id, [], '1', { some: 'metadata' })).then(() => {
+    return store.dispatch(actions.validateVmsAction(url, id, csvRows, '1', { some: 'metadata' })).then(() => {
       const storeActions = store.getActions();
       expect(storeActions[0]).toEqual({ type: `${V2V_VALIDATE_VMS}_PENDING`, meta });
       expect(storeActions[1]).toEqual({ type: `${V2V_VALIDATE_VMS}_FULFILLED`, meta, payload: response });

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/__tests__/PlanWizardVMStepReducer.test.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/__tests__/PlanWizardVMStepReducer.test.js
@@ -44,6 +44,25 @@ describe('VM validation', () => {
     expect(state.conflict_vms.map(vm => vm.id)).toEqual(['3']);
   });
 
+  it('is fulfilled with attached CSV metadata', () => {
+    const meta = {
+      csvRows: [
+        { name: 'vm_1', someArbitraryField: 'value_1' },
+        { name: 'vm_2', someArbitraryField: 'value_2' },
+        { name: 'vm_3', someArbitraryField: 'value_3' }
+      ]
+    };
+    const action = { type: `${V2V_VALIDATE_VMS}_FULFILLED`, payload: payload1, meta };
+    const prevState = initialState
+      .set('isRejectedValidatingVms', true)
+      .set('isValidatingVms', true)
+      .set('numPendingValidationRequests', 1);
+    const state = planWizardVMStepReducer(prevState, action);
+    expect(state.valid_vms.map(vm => vm.csvFields.someArbitraryField)).toEqual(['value_1']);
+    expect(state.invalid_vms.map(vm => vm.csvFields.someArbitraryField)).toEqual(['value_2']);
+    expect(state.conflict_vms.map(vm => vm.csvFields.someArbitraryField)).toEqual(['value_3']);
+  });
+
   it('is fulfilled combining two concurrent requests', () => {
     const meta = { combineRequests: true };
     const action1 = { type: `${V2V_VALIDATE_VMS}_FULFILLED`, payload: payload1, meta };

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/components/CSVDropzoneField.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/components/CSVDropzoneField.js
@@ -58,6 +58,8 @@ class CSVDropzoneField extends React.Component {
     headerRow[headerRow.findIndex(k => k === __('Host'))] = 'host';
     headerRow[headerRow.findIndex(k => k === __('Provider'))] = 'provider';
     headerRow[headerRow.findIndex(k => k === __('UID'))] = 'uid_ems';
+    headerRow[headerRow.findIndex(k => k === __('Security Group'))] = 'osp_security_group';
+    headerRow[headerRow.findIndex(k => k === __('Flavor'))] = 'osp_flavor';
     return headerRow;
   };
 

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/helpers.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/helpers.js
@@ -29,7 +29,25 @@ const manageOddCSVImportErrors = (vm, vmIndex, uniqueIds) => {
   manageBlankReason(vm);
 };
 
-export const _formatValidVms = vms => {
+const attachMetadata = (vms, meta) => {
+  if (meta.csvRows && meta.csvRows.length > 0) {
+    const csvFieldsByVmName = meta.csvRows.reduce(
+      (newObject, row) => ({
+        ...newObject,
+        [row.name]: row
+      }),
+      {}
+    );
+    return vms.map(vm => ({
+      ...vm,
+      csvFields: csvFieldsByVmName[vm.name]
+    }));
+  }
+  return vms;
+};
+
+export const _formatValidVms = (payloadVms, meta) => {
+  const vms = attachMetadata(payloadVms, meta);
   const uniqueIds = vms && [...new Set(vms.map(value => value.id))];
   return (
     vms &&
@@ -43,7 +61,8 @@ export const _formatValidVms = vms => {
   );
 };
 
-export const _formatInvalidVms = vms => {
+export const _formatInvalidVms = (payloadVms, meta) => {
+  const vms = attachMetadata(payloadVms, meta);
   const backfilledVms = fillMissingIds(vms);
   const uniqueIds = backfilledVms && [...new Set(backfilledVms.map(vm => vm.id))];
   return (
@@ -65,7 +84,8 @@ export const _formatInvalidVms = vms => {
   );
 };
 
-export const _formatConflictVms = vms => {
+export const _formatConflictVms = (payloadVms, meta) => {
+  const vms = attachMetadata(payloadVms, meta);
   const inactiveVMCount = (vms && vms.filter(vm => vm.cluster === '' || vm.path === '').length) || 0;
   const allVMCount = (vms && vms.length) || 0;
   const vmCount = inactiveVMCount > 0 ? allVMCount - inactiveVMCount : allVMCount;


### PR DESCRIPTION
Closes #842.

# Testing

Use the `ospv2vbos` database.
To see the sunny-day case, create a new migration plan using the following CSV:
```
Name,Security Group,Flavor
Database-01,dbservers,x1.large
fdupont-test-migration,appservers,x1.xtra-large
```
Proceed to the Instance Properties step and you should see that the referenced groups and flavors have been pre-selected.

To see the warning case, create a new migration plan using the following CSV:
```
Name,Security Group,Flavor
Database-01,invalidgroup,x1.large
fdupont-test-migration,appservers,invalidflavor
```
Proceed to the Instance Properties step and you should see that the valid flavors/groups have been selected, but the invalid ones have reset to their defaults and displayed warnings (see screenshots below). If you click the Edit icon on each row and then click Confirm (whether you've made changes or not), the warnings will be dismissed (see recording below).

# Screens

![screenshot 2019-01-04 16 17 29](https://user-images.githubusercontent.com/811963/50711451-46000780-103c-11e9-9c81-a3b74fc9825d.png)
![screenshot 2019-01-04 16 17 11](https://user-images.githubusercontent.com/811963/50711471-4f896f80-103c-11e9-8dd8-91e0893e1ea3.png)
![screenshot 2019-01-04 16 17 17](https://user-images.githubusercontent.com/811963/50711477-544e2380-103c-11e9-92ca-50859ff1b829.png)

# Recording

![pz6cv2nyom](https://user-images.githubusercontent.com/811963/50711872-90ce4f00-103d-11e9-93b5-df55337dc560.gif)

