### PR TITLE
[#803] Return the 'continue to plan' link to the end of the mapping wizard

### DIFF
--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardResultsStep/MappingWizardResultsStep.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardResultsStep/MappingWizardResultsStep.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { noop, Spinner } from 'patternfly-react';
+import { noop, Spinner, Button } from 'patternfly-react';
 
 import { transformationHasBeenEdited } from './helpers';
 import { FETCH_TRANSFORMATION_MAPPINGS_URL } from '../../../../../Mappings/MappingsConstants';
@@ -88,6 +88,11 @@ class MappingWizardResultsStep extends React.Component {
           <h3 className="blank-slate-pf-main-action">
             {sprintf(__('All mappings in %s have been mapped.'), transformationsBody.name)}
           </h3>
+          <p className="blank-slate-pf-secondary-action">
+            <Button bsStyle="link" onClick={() => this.onContinueToPlanWizard(transformationMappingsResult.id)}>
+              {__('Continue to the plan wizard to create a migration plan using the infrastructure mapping.')}
+            </Button>
+          </p>
         </div>
       );
     }


### PR DESCRIPTION
This was removed in #800 as it was broken by the move away from ConnectedRouter, now that we have ConnectedRouter back we can add this feature back to the mapping wizard.

Closes #803.