### PR TITLE
Ignore invalid conversion hosts

### DIFF
--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardClustersStep/MappingWizardClustersStepSelectors.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardClustersStep/MappingWizardClustersStepSelectors.js
@@ -12,4 +12,4 @@ export const sourceClustersFilter = (sourceClustersToFilter, clustersStepMapping
 };
 
 export const conversionHostsFilter = (conversionHosts, providerType) =>
-  conversionHosts.filter(host => host.resource.type === CONVERSION_HOST_TYPES[providerType]);
+  conversionHosts.filter(host => host.resource && host.resource.type === CONVERSION_HOST_TYPES[providerType]);


### PR DESCRIPTION
Fixes #852 

In some extremely rare cases, it is possible for a conversion host to be
returned with a null resource attribute. This is an indication that the
conversion host was misconfigured.

Further, we rely on the conversion host's resource attribute to
determine it's provider (RHV or OSP), so we cannot provide any
meaningful error messaging in the Mapping Wizard.

https://bugzilla.redhat.com/show_bug.cgi?id=1667246