### PR TITLE
Conversion Hosts: add initial button for empty state screen

### DIFF
--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostsEmptyState.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostsEmptyState.js
@@ -1,11 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button } from 'patternfly-react';
+import ShowWizardEmptyState from '../../../../common/ShowWizardEmptyState/ShowWizardEmptyState';
 
 const ConversionHostsEmptyState = ({ showConversionHostWizard }) => (
   <React.Fragment>
-    <h2>TODO: render an EmptyState here</h2>;
-    <Button onClick={showConversionHostWizard}>{__('Configure Conversion Host')}</Button>
+    <ShowWizardEmptyState
+      description={
+        __('Select one or more hosts to be configured as IMS conversion hosts.') // prettier-ignore
+      }
+      showWizardAction={showConversionHostWizard}
+      buttonText={__('Configure Conversion Host')}
+      buttonHref=""
+      className="mappings"
+    />
   </React.Fragment>
 );
 


### PR DESCRIPTION

![empty-state](https://user-images.githubusercontent.com/6648365/51889361-a9f6c100-2399-11e9-97a1-bbecc86c2352.png)


Fixes: https://github.com/ManageIQ/manageiq-v2v/issues/854