### PR TITLE
Conversion Hosts: list view phase 1

### DIFF
--- a/app/javascript/react/screens/App/Settings/Settings.scss
+++ b/app/javascript/react/screens/App/Settings/Settings.scss
@@ -1,3 +1,7 @@
 .migration-settings h2 {
   margin-bottom: 25px;
 }
+
+.conversion-hosts-list .list-view-pf-main-info {
+  padding: 10px 0;
+}

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostsList.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostsList.js
@@ -1,17 +1,61 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Grid, ListView, Toolbar } from 'patternfly-react';
+import ListViewToolbar from '../../../../common/ListViewToolbar/ListViewToolbar';
 
 const ConversionHostsList = ({ conversionHosts }) => (
-  <React.Fragment>
-    <h2>TODO: render a list view here using the ListViewToolbar pattern we have elsewhere</h2>
-    {conversionHosts.map(conversionHost => (
-      <pre key={conversionHost.id}>{JSON.stringify(conversionHost)}</pre>
-    ))}
-  </React.Fragment>
+  <ListViewToolbar
+    filterTypes={ConversionHostsList.filterTypes}
+    sortFields={ConversionHostsList.sortFields}
+    listItems={conversionHosts}
+  >
+    {({
+      filteredSortedPaginatedListItems,
+      renderFilterControls,
+      renderSortControls,
+      renderActiveFilters,
+      renderPaginationRow
+    }) => (
+      <React.Fragment>
+        <Grid.Row>
+          <Toolbar>
+            {renderFilterControls()}
+            {renderSortControls()}
+            {renderActiveFilters(filteredSortedPaginatedListItems)}
+          </Toolbar>
+        </Grid.Row>
+        <div style={{ overflow: 'auto', paddingBottom: 300, height: '100%' }}>
+          <ListView className="conversion-hosts-list" id="conversion_hosts">
+            {filteredSortedPaginatedListItems.items.map((host, n) => (
+              <ListView.Item key={host.id} heading={host.name} stacked />
+            ))}
+          </ListView>
+          {renderPaginationRow(filteredSortedPaginatedListItems)}
+        </div>
+      </React.Fragment>
+    )}
+  </ListViewToolbar>
 );
 
 ConversionHostsList.propTypes = {
   conversionHosts: PropTypes.arrayOf(PropTypes.object)
 };
+
+ConversionHostsList.sortFields = [
+  {
+    id: 'name',
+    title: __('Name'),
+    isNumeric: false
+  }
+];
+
+ConversionHostsList.filterTypes = [
+  {
+    id: 'name',
+    title: __('Name'),
+    placeholder: __('Filter by Name'),
+    filterType: 'text'
+  }
+];
 
 export default ConversionHostsList;


### PR DESCRIPTION
This PR implements:
- basic list view for conversion hosts
- pagination
- filtering
- sorting

Currently, the list view displays only conversion host name. The issue linked below also mentions showing provider type (or perhaps provider name): for that we'd need more information to be pulled from API.

![conversion-hosts-01](https://user-images.githubusercontent.com/6648365/52283111-2e30e180-2962-11e9-84a5-f7f7988c0c18.png)

Fixes: https://github.com/ManageIQ/manageiq-v2v/issues/860