### PR TITLE
Conversion Host Configuration Wizard - Step #2 - Host(s)

### DIFF
--- a/app/assets/stylesheets/manageiq-v2v/base.scss
+++ b/app/assets/stylesheets/manageiq-v2v/base.scss
@@ -1,4 +1,5 @@
 @import '../../../javascript/react/app.scss';
+@import './type-ahead-select.scss';
 
 .react-wrapper {
   height: 100%;

--- a/app/assets/stylesheets/manageiq-v2v/type-ahead-select.scss
+++ b/app/assets/stylesheets/manageiq-v2v/type-ahead-select.scss
@@ -10,6 +10,10 @@
   padding: 2px 6px;
 }
 
+.form-control.rbt-input-multi {
+  height: auto;
+}
+
 .rbt-menu.dropdown-menu {
   &.show {
     margin: 0;

--- a/app/assets/stylesheets/manageiq-v2v/type-ahead-select.scss
+++ b/app/assets/stylesheets/manageiq-v2v/type-ahead-select.scss
@@ -1,0 +1,61 @@
+/*
+  Until we can properly import patternfly-react CSS extensions
+  (which will probably require changes to manageiq-ui-classic's webpack config)
+  we need to include the styles for react-bootstrap-typeahead manually.
+
+  This can probably be removed after https://github.com/patternfly/patternfly-react/issues/673 is fixed.
+  This is a copy of https://github.com/patternfly/patternfly-react/blob/master/packages/patternfly-3/patternfly-react/sass/patternfly-react/_type-ahead-select.scss
+*/
+
+@import 'react-bootstrap-typeahead/css/Typeahead';
+
+.rbt-input-main {
+  padding: 2px 6px;
+}
+
+.rbt-input-multi {
+  height: fit-content;
+}
+
+.rbt-menu.dropdown-menu {
+  &.show {
+    margin: 0;
+  }
+
+  .dropdown-item.disabled {
+    color: $color-pf-black-600;
+  }
+}
+
+.rbt-token {
+  margin-right: 6px;
+  border-radius: 5px;
+
+  &.rbt-token-removeable {
+    background-color: $color-pf-black-200;
+    height: 20px;
+    font-size: 12px;
+    color: #363636;
+  }
+
+  .rbt-token-remove-button {
+    color: #363636;
+    font-size: 10px;
+    padding: 0 6px;
+    top: 0;
+  }
+
+  .rbt-input-multi {
+    &.rbt-input-wrapper {
+      margin-bottom: -3px;
+    }
+
+    &.rbt-input {
+      height: auto;
+    }
+  }
+}
+
+.rbt-aux .rbt-close {
+  margin-top: 0;
+}

--- a/app/assets/stylesheets/manageiq-v2v/type-ahead-select.scss
+++ b/app/assets/stylesheets/manageiq-v2v/type-ahead-select.scss
@@ -1,9 +1,6 @@
 /*
-  Until we can properly import patternfly-react CSS extensions
-  (which will probably require changes to manageiq-ui-classic's webpack config)
-  we need to include the styles for react-bootstrap-typeahead manually.
-
-  This can probably be removed after https://github.com/patternfly/patternfly-react/issues/673 is fixed.
+  Until we can properly import patternfly-react CSS extensions, we need to include the styles for react-bootstrap-typeahead manually.
+  This can be replaced with a proper import after https://github.com/patternfly/patternfly-react/issues/673 is fixed.
   This is a copy of https://github.com/patternfly/patternfly-react/blob/master/packages/patternfly-3/patternfly-react/sass/patternfly-react/_type-ahead-select.scss
 */
 
@@ -11,10 +8,6 @@
 
 .rbt-input-main {
   padding: 2px 6px;
-}
-
-.rbt-input-multi {
-  height: fit-content;
 }
 
 .rbt-menu.dropdown-menu {

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardHostsStep/ConversionHostWizardHostsStep.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardHostsStep/ConversionHostWizardHostsStep.js
@@ -1,10 +1,26 @@
 import React from 'react';
-import { Form } from 'patternfly-react';
+import { Form, TypeAheadSelect } from 'patternfly-react';
+import { RHV, OPENSTACK } from '../../../../../../../../../common/constants';
 
-const ConversionHostWizardHostsStep = () => (
-  <Form className="form-horizontal">
-    <h2>TODO: Hosts Step Contents</h2>
-  </Form>
-);
+const ConversionHostWizardHostsStep = ({ selectedProviderType, selectedCluster }) => {
+  let hostOptions = [];
+  if (selectedProviderType === RHV) hostOptions = selectedCluster.hosts;
+  if (selectedProviderType === OPENSTACK) hostOptions = selectedCluster.vms;
+
+  console.log('HOST OPTIONS?', hostOptions);
+
+  return (
+    <Form className="form-horizontal">
+      <TypeAheadSelect
+        multiple
+        clearButton
+        //selected (get this from redux-form?)
+        options={hostOptions}
+        labelKey="name"
+        placeholder={__('Select one or more hosts...')}
+      />
+    </Form>
+  );
+};
 
 export default ConversionHostWizardHostsStep;

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardHostsStep/ConversionHostWizardHostsStep.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardHostsStep/ConversionHostWizardHostsStep.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { reduxForm, Field } from 'redux-form';
+import { length } from 'redux-form-validators';
 import { Form } from 'patternfly-react';
 import { RHV, OPENSTACK } from '../../../../../../../../../common/constants';
 import TypeAheadSelectField from '../../../../../../common/forms/TypeAheadSelectField';
@@ -25,6 +26,7 @@ const ConversionHostWizardHostsStep = ({ selectedProviderType, selectedCluster }
           placeholder={__('Select one or more hosts...')}
           highlightOnlyResult
           selectHintOnEnter
+          validate={[length({ min: 1 })]}
         />
       </Form.FormGroup>
     </Form>

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardHostsStep/ConversionHostWizardHostsStep.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardHostsStep/ConversionHostWizardHostsStep.js
@@ -9,8 +9,15 @@ import { stepIDs } from '../ConversionHostWizardConstants';
 
 const ConversionHostWizardHostsStep = ({ selectedProviderType, selectedCluster }) => {
   let hostOptions = [];
-  if (selectedProviderType === RHV) hostOptions = selectedCluster.hosts;
-  if (selectedProviderType === OPENSTACK) hostOptions = selectedCluster.vms;
+  let emptyLabel = '';
+  if (selectedProviderType === RHV) {
+    hostOptions = selectedCluster.hosts;
+    emptyLabel = __('No hosts available for the selected cluster.');
+  }
+  if (selectedProviderType === OPENSTACK) {
+    hostOptions = selectedCluster.vms;
+    emptyLabel = __('No hosts available for the selected project.');
+  }
   return (
     <Form className="form-vertical">
       <Form.FormGroup controlId="host-selection">
@@ -24,6 +31,7 @@ const ConversionHostWizardHostsStep = ({ selectedProviderType, selectedCluster }
           options={hostOptions}
           labelKey="name"
           placeholder={__('Select one or more hosts...')}
+          emptyLabel={hostOptions.length === 0 ? emptyLabel : __('No matches found.')}
           highlightOnlyResult
           selectHintOnEnter
           validate={[length({ min: 1 })]}

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardHostsStep/ConversionHostWizardHostsStep.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardHostsStep/ConversionHostWizardHostsStep.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Form, TypeAheadSelect } from 'patternfly-react';
+import { Form, Grid, TypeAheadSelect } from 'patternfly-react';
 import { RHV, OPENSTACK } from '../../../../../../../../../common/constants';
 
 const ConversionHostWizardHostsStep = ({ selectedProviderType, selectedCluster }) => {
@@ -10,15 +10,19 @@ const ConversionHostWizardHostsStep = ({ selectedProviderType, selectedCluster }
   console.log('HOST OPTIONS?', hostOptions);
 
   return (
-    <Form className="form-horizontal">
-      <TypeAheadSelect
-        multiple
-        clearButton
-        //selected (get this from redux-form?)
-        options={hostOptions}
-        labelKey="name"
-        placeholder={__('Select one or more hosts...')}
-      />
+    <Form className="form-vertical">
+      <Form.FormGroup controlId="host-selection">
+        <Form.ControlLabel>{__('Hosts to configure as conversion hosts')}</Form.ControlLabel>
+        <TypeAheadSelect
+          multiple
+          clearButton
+          options={hostOptions}
+          labelKey="name"
+          placeholder={__('Select one or more hosts...')}
+          highlightOnlyResult
+          selectHintOnEnter
+        />
+      </Form.FormGroup>
     </Form>
   );
 };

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardHostsStep/ConversionHostWizardHostsStep.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardHostsStep/ConversionHostWizardHostsStep.js
@@ -1,19 +1,23 @@
 import React from 'react';
-import { Form, Grid, TypeAheadSelect } from 'patternfly-react';
+import PropTypes from 'prop-types';
+import { reduxForm, Field } from 'redux-form';
+import { Form } from 'patternfly-react';
 import { RHV, OPENSTACK } from '../../../../../../../../../common/constants';
+import TypeAheadSelectField from '../../../../../../common/forms/TypeAheadSelectField';
+import { stepIDs } from '../ConversionHostWizardConstants';
 
 const ConversionHostWizardHostsStep = ({ selectedProviderType, selectedCluster }) => {
   let hostOptions = [];
   if (selectedProviderType === RHV) hostOptions = selectedCluster.hosts;
   if (selectedProviderType === OPENSTACK) hostOptions = selectedCluster.vms;
-
-  console.log('HOST OPTIONS?', hostOptions);
-
   return (
     <Form className="form-vertical">
       <Form.FormGroup controlId="host-selection">
         <Form.ControlLabel>{__('Hosts to configure as conversion hosts')}</Form.ControlLabel>
-        <TypeAheadSelect
+        <Field
+          component={TypeAheadSelectField}
+          name="hosts"
+          controlId="host-selection"
           multiple
           clearButton
           options={hostOptions}
@@ -27,4 +31,13 @@ const ConversionHostWizardHostsStep = ({ selectedProviderType, selectedCluster }
   );
 };
 
-export default ConversionHostWizardHostsStep;
+ConversionHostWizardHostsStep.propTypes = {
+  selectedProviderType: PropTypes.string,
+  selectedCluster: PropTypes.object
+};
+
+export default reduxForm({
+  form: stepIDs.hostsStep,
+  destroyOnUnmount: false,
+  initialValues: { hosts: [] }
+})(ConversionHostWizardHostsStep);

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardHostsStep/index.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardHostsStep/index.js
@@ -1,3 +1,22 @@
+import { connect } from 'react-redux';
 import ConversionHostWizardHostsStep from './ConversionHostWizardHostsStep';
 
-export default ConversionHostWizardHostsStep;
+import { stepIDs } from '../ConversionHostWizardConstants';
+
+const mapStateToProps = ({ form, targetResources: { targetClusters } }) => {
+  const locationStepForm = form[stepIDs.locationStep];
+  const locationStepValues = locationStepForm && locationStepForm.values;
+  const selectedClusterId = locationStepValues && locationStepValues.cluster;
+  return {
+    selectedProviderType: locationStepValues && locationStepValues.providerType,
+    selectedCluster: targetClusters.find(cluster => cluster.id === selectedClusterId)
+  };
+};
+
+const mergeProps = (stateProps, dispatchProps, ownProps) => Object.assign(stateProps, ownProps.data, dispatchProps);
+
+export default connect(
+  mapStateToProps,
+  {},
+  mergeProps
+)(ConversionHostWizardHostsStep);

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardLocationStep/ConversionHostWizardLocationStep.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardLocationStep/ConversionHostWizardLocationStep.js
@@ -12,25 +12,20 @@ import { stepIDs } from '../ConversionHostWizardConstants';
 
 class ConversionHostWizardLocationStep extends React.Component {
   componentDidUpdate(prevProps) {
-    const { fetchTargetClustersAction, fetchTargetComputeUrls } = this.props;
-    const prevDerivedProps = this.getDerivedProps(prevProps);
-    const newDerivedProps = this.getDerivedProps();
-    if (prevDerivedProps.selectedProviderType !== newDerivedProps.selectedProviderType) {
-      fetchTargetClustersAction(fetchTargetComputeUrls[newDerivedProps.selectedProviderType]);
+    const { fetchTargetClustersAction, fetchTargetComputeUrls, selectedProviderType } = this.props;
+    if (prevProps.selectedProviderType !== selectedProviderType) {
+      fetchTargetClustersAction(fetchTargetComputeUrls[selectedProviderType]);
     }
   }
 
-  getDerivedProps = (props = this.props) => {
-    const { locationStepForm } = props;
-    return {
-      selectedProviderType: locationStepForm.values && locationStepForm.values.providerType,
-      selectedProviderId: locationStepForm.values && locationStepForm.values.provider
-    };
-  };
-
   render() {
-    const { providers, isFetchingTargetClusters, targetClusters } = this.props;
-    const { selectedProviderType, selectedProviderId } = this.getDerivedProps();
+    const {
+      providers,
+      isFetchingTargetClusters,
+      targetClusters,
+      selectedProviderType,
+      selectedProviderId
+    } = this.props;
 
     const availableProviderOptions = V2V_TARGET_PROVIDERS.filter(option =>
       providers.some(provider => provider.type === option.type)
@@ -39,8 +34,8 @@ class ConversionHostWizardLocationStep extends React.Component {
     const providersFilteredBySelectedType =
       selectedProviderOption && providers.filter(provider => provider.type === selectedProviderOption.type);
 
-    const targetComputeFilteredBySelectedProvider = targetClusters.filter(
-      computeResource => computeResource.ems_id === selectedProviderId
+    const targetClustersFilteredBySelectedProvider = targetClusters.filter(
+      cluster => cluster.ems_id === selectedProviderId
     );
 
     const selectFieldBaseProps = {
@@ -53,6 +48,10 @@ class ConversionHostWizardLocationStep extends React.Component {
       required: true,
       validate: [required()]
     };
+
+    let clusterLabel = '';
+    if (selectedProviderType === RHV) clusterLabel = __('Cluster');
+    if (selectedProviderType === OPENSTACK) clusterLabel = __('Project');
 
     return (
       <Form className="form-horizontal">
@@ -70,24 +69,13 @@ class ConversionHostWizardLocationStep extends React.Component {
               label={__('Provider')}
               options={providersFilteredBySelectedType}
             />
-            {selectedProviderType === RHV && (
-              <Field
-                {...selectFieldBaseProps}
-                name="cluster"
-                label={__('Cluster')}
-                options={targetComputeFilteredBySelectedProvider}
-                disabled={!selectedProviderId}
-              />
-            )}
-            {selectedProviderType === OPENSTACK && (
-              <Field
-                {...selectFieldBaseProps}
-                name="project"
-                label={__('Project')}
-                options={targetComputeFilteredBySelectedProvider}
-                disabled={!selectedProviderId}
-              />
-            )}
+            <Field
+              {...selectFieldBaseProps}
+              name="cluster"
+              label={clusterLabel}
+              options={targetClustersFilteredBySelectedProvider}
+              disabled={!selectedProviderId}
+            />
           </Spinner>
         )}
       </Form>
@@ -96,7 +84,8 @@ class ConversionHostWizardLocationStep extends React.Component {
 }
 
 ConversionHostWizardLocationStep.propTypes = {
-  locationStepForm: PropTypes.object,
+  selectedProviderType: PropTypes.string,
+  selectedProviderId: PropTypes.string,
   providers: PropTypes.arrayOf(PropTypes.object),
   fetchTargetClustersAction: PropTypes.func,
   fetchTargetComputeUrls: PropTypes.object,
@@ -105,7 +94,6 @@ ConversionHostWizardLocationStep.propTypes = {
 };
 
 ConversionHostWizardLocationStep.defaultProps = {
-  locationStepForm: {},
   fetchTargetComputeUrls: FETCH_TARGET_COMPUTE_URLS
 };
 

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardLocationStep/ConversionHostWizardLocationStep.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardLocationStep/ConversionHostWizardLocationStep.js
@@ -24,7 +24,8 @@ class ConversionHostWizardLocationStep extends React.Component {
       isFetchingTargetClusters,
       targetClusters,
       selectedProviderType,
-      selectedProviderId
+      selectedProviderId,
+      resetFormAction
     } = this.props;
 
     const availableProviderOptions = V2V_TARGET_PROVIDERS.filter(option =>
@@ -75,6 +76,7 @@ class ConversionHostWizardLocationStep extends React.Component {
               label={clusterLabel}
               options={targetClustersFilteredBySelectedProvider}
               disabled={!selectedProviderId}
+              onChange={() => resetFormAction(stepIDs.hostsStep)}
             />
           </Spinner>
         )}
@@ -90,7 +92,8 @@ ConversionHostWizardLocationStep.propTypes = {
   fetchTargetClustersAction: PropTypes.func,
   fetchTargetComputeUrls: PropTypes.object,
   isFetchingTargetClusters: PropTypes.bool,
-  targetClusters: PropTypes.arrayOf(PropTypes.object)
+  targetClusters: PropTypes.arrayOf(PropTypes.object),
+  resetFormAction: PropTypes.func
 };
 
 ConversionHostWizardLocationStep.defaultProps = {

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardLocationStep/index.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardLocationStep/index.js
@@ -1,4 +1,5 @@
 import { connect } from 'react-redux';
+import { reset } from 'redux-form';
 import ConversionHostWizardLocationStep from './ConversionHostWizardLocationStep';
 
 import { fetchTargetClustersAction } from '../../../../../../../../../redux/common/targetResources/targetResourcesActions';
@@ -25,6 +26,6 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => Object.assign(stateP
 
 export default connect(
   mapStateToProps,
-  { fetchTargetClustersAction },
+  { fetchTargetClustersAction, resetFormAction: reset },
   mergeProps
 )(ConversionHostWizardLocationStep);

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardLocationStep/index.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardLocationStep/index.js
@@ -9,12 +9,17 @@ const mapStateToProps = ({
   form,
   providers: { providers },
   targetResources: { isFetchingTargetClusters, targetClusters }
-}) => ({
-  locationStepForm: form[stepIDs.locationStep],
-  providers,
-  isFetchingTargetClusters,
-  targetClusters
-});
+}) => {
+  const locationStepForm = form[stepIDs.locationStep];
+  const locationStepValues = locationStepForm && locationStepForm.values;
+  return {
+    selectedProviderType: locationStepValues && locationStepValues.providerType,
+    selectedProviderId: locationStepValues && locationStepValues.provider,
+    providers,
+    isFetchingTargetClusters,
+    targetClusters
+  };
+};
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => Object.assign(stateProps, ownProps.data, dispatchProps);
 

--- a/app/javascript/react/screens/App/common/forms/TypeAheadSelectField.js
+++ b/app/javascript/react/screens/App/common/forms/TypeAheadSelectField.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { TypeAheadSelect } from 'patternfly-react';
+
+// Wraps TypeAheadSelect for use as the `component` prop of a redux-form Field.
+const TypeAheadSelectField = ({ input: { value, onChange }, controlId, ...props }) => (
+  <TypeAheadSelect selected={value} onChange={onChange} inputProps={{ id: controlId }} {...props} />
+);
+
+TypeAheadSelectField.propTypes = {
+  controlId: PropTypes.string.isRequired,
+  input: PropTypes.shape({
+    value: PropTypes.array,
+    onChange: PropTypes.func
+  })
+};
+
+export default TypeAheadSelectField;

--- a/app/javascript/redux/common/targetResources/targetResourcesConstants.js
+++ b/app/javascript/redux/common/targetResources/targetResourcesConstants.js
@@ -7,5 +7,5 @@ export const FETCH_TARGET_COMPUTE_URLS = {
     '/api/clusters?expand=resources' +
     '&attributes=ext_management_system.emstype,v_parent_datacenter,ext_management_system.name,hosts' +
     '&filter[]=ext_management_system.emstype=rhevm',
-  [OPENSTACK]: '/api/cloud_tenants?expand=resources&attributes=ext_management_system.name,ext_management_system.id'
+  [OPENSTACK]: '/api/cloud_tenants?expand=resources&attributes=ext_management_system.name,ext_management_system.id,vms'
 };


### PR DESCRIPTION
This is part of #855.

For now, to get the TypeAheadSelect working, this PR introduces CSS duplicated from patternfly-react because we can't import that CSS directly due to https://github.com/patternfly/patternfly-react/issues/673.

This PR removes the `getDerivedProps` pattern I had introduced in the Location step, because it makes more sense to compute those props in the `mapStateToProps` function so the component doesn't have to care about how they are derived. The new Host(s) step follows the same pattern.

This PR adds the `vms` attribute to the `FETCH_TARGET_COMPUTE_URLS[OPENSTACK]` constant so that we can get the list of VMs for this step, which has the side effect of unnecessarily loading those VMs when the same constant is used in the mapping wizard. However I think the performance hit there is negligible, and coming up with a way to share these URLs with different sets of attributes seemed outside the scope of this PR. I think the ease of reuse here outweighs the drawbacks.

This PR also introduces the `TypeAheadSelectField` component, which is a thin wrapper around the `TypeAheadSelect` from patternfly-react, which makes it compatible to be used as the `component` prop of a redux-form `Field`. We can reuse this new component if we need typeahead-select anywhere else in the UI.

Another important detail to note is that the selected hosts will remain in place if you step back and forward through the wizard, unless the selected Project or Cluster is changed on the Location step. This change resets the Hosts step, so that we don't allow the user to select hosts from multiple projects/clusters. You can see this reset happening towards the end of the screen recording here:

![54hzkvrnav](https://user-images.githubusercontent.com/811963/52507703-5158cc80-2bc0-11e9-80bc-274224952915.gif)
