### PR TITLE
V2v specify migration log type

### DIFF
--- a/app/controllers/migration_log_controller.rb
+++ b/app/controllers/migration_log_controller.rb
@@ -4,7 +4,7 @@ class MigrationLogController < ApplicationController
 
   def download_migration_log
     plan_task = ServiceTemplateTransformationPlanTask.find(params[:id])
-    miq_tasks_id = plan_task.transformation_log_queue()
+    miq_tasks_id = plan_task.transformation_log_queue(:log_type => params[:log_type])
     task = MiqTask.wait_for_taskid(miq_tasks_id)
     task_results = task.task_results
     task_status = task.status

--- a/app/controllers/migration_log_controller.rb
+++ b/app/controllers/migration_log_controller.rb
@@ -4,7 +4,8 @@ class MigrationLogController < ApplicationController
 
   def download_migration_log
     plan_task = ServiceTemplateTransformationPlanTask.find(params[:id])
-    miq_tasks_id = plan_task.transformation_log_queue(:log_type => params[:log_type])
+    log_type = params[:log_type] || 'v2v'
+    miq_tasks_id = plan_task.transformation_log_queue(:log_type => log_type)
     task = MiqTask.wait_for_taskid(miq_tasks_id)
     task_results = task.task_results
     task_status = task.status


### PR DESCRIPTION
In the current implementation, we provide a download button in the UI that allows downloading the virt-v2v log file. It's been reported by field that the virt-v2v-wrapper log is more relevant and provides better error messages. This PR allows downloading the wrapper log.

We pass an extra parameter `log_type` that defaults to `v2v` to not break existing API calls. We have extended the ServiceTemplateTransformationPlanTask model accordingly in https://github.com/ManageIQ/manageiq/pull/18506.

Part of #885.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1655124