### PR TITLE
[#885] Add Virt-v2v-wrapper log download menu item

### DIFF
--- a/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
+++ b/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
@@ -40,7 +40,9 @@ class PlanRequestDetailList extends React.Component {
   onSelect = (eventKey, task) => {
     const { downloadLogAction, fetchOrchestrationStackUrl, fetchOrchestrationStackAction } = this.props;
     if (eventKey === 'migration') {
-      downloadLogAction(task);
+      downloadLogAction(task, 'v2v');
+    } else if (eventKey === 'wrapper') {
+      downloadLogAction(task, 'wrapper');
     } else {
       fetchOrchestrationStackAction(fetchOrchestrationStackUrl, eventKey, task);
     }
@@ -415,6 +417,12 @@ class PlanRequestDetailList extends React.Component {
                         disabled={downloadLogInProgressTaskIds && downloadLogInProgressTaskIds.indexOf(task.id) > -1}
                       >
                         {__('Migration log')}
+                      </MenuItem>
+                      <MenuItem
+                        eventKey="wrapper"
+                        disabled={downloadLogInProgressTaskIds && downloadLogInProgressTaskIds.indexOf(task.id) > -1}
+                      >
+                        {__('Virt-v2v-wrapper log')}
                       </MenuItem>
                       {task.options.postPlaybookComplete && (
                         <MenuItem


### PR DESCRIPTION
As explained in https://github.com/ManageIQ/manageiq-v2v/pull/887, we will now have support for downloading the virt-v2v-wrapper log via the `migration_log_controller`. This PR adds support for making requests to that controller with a specified log type, defaults the current "Migration log" menu item to `log_type=v2v`, and adds a new "Virt-v2v-wrapper log" menu item with `log_type=wrapper`.

![screenshot 2019-03-01 12 31 31](https://user-images.githubusercontent.com/811963/53655622-b7180180-3c1e-11e9-805c-303f137e04d6.png)

This should not be merged until after both https://github.com/ManageIQ/manageiq/pull/18506 and https://github.com/ManageIQ/manageiq-v2v/pull/887 are merged.

Closes #885.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1655124