### PR TITLE
Conversion Host Configuration Wizard - use correct default cloud-user (with a dash) instead of cloud_user

### DIFF
--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/ConversionHostWizardAuthenticationStep.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/ConversionHostWizardAuthenticationStep.js
@@ -128,7 +128,7 @@ export default reduxForm({
   destroyOnUnmount: false,
   forceUnregisterOnUnmount: true,
   initialValues: {
-    openstackUser: 'cloud_user',
+    openstackUser: 'cloud-user',
     conversionHostSshKey: { filename: '', body: '' },
     vmwareSshKey: { filename: '', body: '' }
   }


### PR DESCRIPTION
@fdupont-redhat pointed out on the sprint demo that we had the wrong default value here. This PR changes the default value for "OpenStack User" on the Authentication step of the wizard from `cloud_user` to `cloud-user`.

Part of the conversion host enablement feature: https://bugzilla.redhat.com/show_bug.cgi?id=1622728

This is part of #855.