### PR TITLE
Conversion Host Settings page: Ensure task.meta will always be defined

### DIFF
--- a/app/javascript/react/screens/App/Settings/helpers.js
+++ b/app/javascript/react/screens/App/Settings/helpers.js
@@ -28,7 +28,7 @@ export const parseConversionHostTasksMetadata = tasks => {
   if (!tasks) return [];
   return tasks.map(task => {
     const result = taskNameRegex.exec(task.name);
-    if (!result) return task;
+    if (!result) return { ...task, meta: {} };
     const [, operation, resourceName, resourceType, resourceId] = result;
     return {
       ...task,


### PR DESCRIPTION
This prevents an unlikely error that would occur if the task name field from the API is malformed. We parse it with a regular expression, and if the format of it changes in the future, that would cause console errors before when we filter on `task.meta.operation`, and with this change a malformed task name will just cause that task to be filtered out.

Part of the conversion host enablement feature: https://bugzilla.redhat.com/show_bug.cgi?id=1622728