### PR TITLE
Conversion Host Configuration Wizard - Properly pass SSH keys and VDDK path to API

### DIFF
--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/ConversionHostWizardAuthenticationStep.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/ConversionHostWizardAuthenticationStep.js
@@ -39,7 +39,7 @@ const ConversionHostWizardAuthenticationStep = ({ selectedProviderType, selected
       <Field
         {...fieldBaseProps}
         name="conversionHostSshKey"
-        label={__('Conversion Host SSH key')}
+        label={__('Conversion Host SSH private key')}
         component={FormField}
         info={sshKeyInfo}
         controlId="host-ssh-key-input"
@@ -72,7 +72,7 @@ const ConversionHostWizardAuthenticationStep = ({ selectedProviderType, selected
         <Field
           {...fieldBaseProps}
           name="vmwareSshKey"
-          label={__('VMware hypervisors SSH key')}
+          label={__('VMware hypervisors SSH private key')}
           component={FormField}
           controlId="vmware-ssh-key-input"
           required

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardResultsStep/helpers.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardResultsStep/helpers.js
@@ -5,18 +5,16 @@ export const getConfigureConversionHostPostBodies = (locationStepValues, hostsSt
   hostsStepValues.hosts.map(host => {
     const openstackSpecificProperties =
       locationStepValues.providerType === OPENSTACK ? { auth_user: authStepValues.openstackUser } : {};
-    const vddkSpecificProperties =
+    const vmwareAuthProperties =
       authStepValues.transformationMethod === VDDK
-        ? { param_v2v_vddk_package_url: authStepValues.vddkLibraryPath }
-        : {};
+        ? { vmware_vddk_package_url: authStepValues.vddkLibraryPath }
+        : { vmware_ssh_private_key: authStepValues.vmwareSshKey.body };
     return {
       name: host.name,
       resource_type: host.type,
       resource_id: host.id,
       ...openstackSpecificProperties,
-      ...vddkSpecificProperties
+      ...vmwareAuthProperties
     };
-    // TODO: handle authStepValues.conversionHostSshKey
-    // TODO: handle authStepValues.transformationMethod (explicitly?)
-    // TODO: handle authStepValues.vmwareSshKey (if transformationMethod === SSH)
+    // TODO: handle authStepValues.conversionHostSshKey.body
   });

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardResultsStep/helpers.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardResultsStep/helpers.js
@@ -13,8 +13,8 @@ export const getConfigureConversionHostPostBodies = (locationStepValues, hostsSt
       name: host.name,
       resource_type: host.type,
       resource_id: host.id,
+      ssh_key: authStepValues.conversionHostSshKey.body,
       ...openstackSpecificProperties,
       ...vmwareAuthProperties
     };
-    // TODO: handle authStepValues.conversionHostSshKey.body
   });


### PR DESCRIPTION
Part of the conversion host enablement feature: https://bugzilla.redhat.com/show_bug.cgi?id=1622728

Closes #898.
Closes #899.

This PR also adds the word "private" to the labels for **_Conversion Host SSH private key_** and **_VMware hypervisors SSH private key_**:

![Screenshot 2019-03-13 17 16 46](https://user-images.githubusercontent.com/811963/54315207-e120da80-45b3-11e9-80ec-fa9b4659da9a.png)


This corresponds to API support introduced by https://github.com/ManageIQ/manageiq/pull/18537 and https://github.com/ManageIQ/manageiq/pull/18309.