### PR TITLE
Fix conversion host removal modal

### DIFF
--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/DeleteConversionHostConfirmationModal.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/DeleteConversionHostConfirmationModal.js
@@ -20,10 +20,14 @@ const DeleteConversionHostConfirmationModal = ({
         <Icon type="pf" name="delete" />
       </div>
       <div className="warning-modal-body--list">
-        <h4>
-          {conversionHostToDelete &&
-            sprintf(__('Are you sure you want to remove conversion host %s ?'), conversionHostToDelete.name)}
-        </h4>
+        <h4>{__('Are you sure you want to remove the following conversion host?')}</h4>
+        <div>
+          <ul>
+            <h4>
+              <strong>{conversionHostToDelete && conversionHostToDelete.name}</strong>
+            </h4>
+          </ul>
+        </div>
       </div>
     </Modal.Body>
     <Modal.Footer>


### PR DESCRIPTION
This is to make the conversion host removal modal look consistent with other removal dialogs (infra mapping for example): conversion host name is inside  `<strong>` and on a separate line.

![conversion-host-delete](https://user-images.githubusercontent.com/6648365/54347743-e3cd0f80-4647-11e9-9d89-e1edba56bd28.png)

https://bugzilla.redhat.com/show_bug.cgi?id=1622728