### PR TITLE
[#914] Plan Wizard VMs Step - VMWare Folder View

### DIFF
--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/__tests__/PlanWizardVMStepReducer.test.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/__tests__/PlanWizardVMStepReducer.test.js
@@ -66,6 +66,19 @@ describe('VM validation', () => {
     expect(state.valid_vms[0].folder).toBe('/');
   });
 
+  it('is fulfilled with path metadata even when there is no CSV metadata', () => {
+    const meta = {};
+    const action = { type: `${V2V_VALIDATE_VMS}_FULFILLED`, payload: payload1, meta };
+    const prevState = initialState
+      .set('isRejectedValidatingVms', true)
+      .set('isValidatingVms', true)
+      .set('numPendingValidationRequests', 1);
+    const state = planWizardVMStepReducer(prevState, action);
+    expect(state.valid_vms[0].provider).toBe('some');
+    expect(state.valid_vms[0].datacenter).toBe('path');
+    expect(state.valid_vms[0].folder).toBe('/');
+  });
+
   it('is fulfilled combining two concurrent requests', () => {
     const meta = { combineRequests: true };
     const action1 = { type: `${V2V_VALIDATE_VMS}_FULFILLED`, payload: payload1, meta };

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/__tests__/PlanWizardVMStepReducer.test.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/__tests__/PlanWizardVMStepReducer.test.js
@@ -4,16 +4,16 @@ import { V2V_VALIDATE_VMS } from '../PlanWizardVMStepConstants';
 describe('VM validation', () => {
   const payload1 = {
     data: {
-      valid: [{ id: '1', name: 'vm_1' }],
-      invalid: [{ id: '2', name: 'vm_2' }],
-      conflicted: [{ id: '3', name: 'vm_3' }]
+      valid: [{ id: '1', name: 'vm_1', path: 'some/path' }],
+      invalid: [{ id: '2', name: 'vm_2', path: 'some/path' }],
+      conflicted: [{ id: '3', name: 'vm_3', path: 'some/path' }]
     }
   };
   const payload2 = {
     data: {
-      valid: [{ id: '4', name: 'vm_4' }],
-      invalid: [{ id: '5', name: 'vm_5' }],
-      conflicted: [{ id: '6', name: 'vm_6' }]
+      valid: [{ id: '4', name: 'vm_4', path: 'some/path' }],
+      invalid: [{ id: '5', name: 'vm_5', path: 'some/path' }],
+      conflicted: [{ id: '6', name: 'vm_6', path: 'some/path' }]
     }
   };
 
@@ -44,7 +44,7 @@ describe('VM validation', () => {
     expect(state.conflict_vms.map(vm => vm.id)).toEqual(['3']);
   });
 
-  it('is fulfilled with attached CSV metadata', () => {
+  it('is fulfilled with attached CSV and path metadata', () => {
     const meta = {
       csvRows: [
         { name: 'vm_1', someArbitraryField: 'value_1' },
@@ -61,6 +61,9 @@ describe('VM validation', () => {
     expect(state.valid_vms.map(vm => vm.csvFields.someArbitraryField)).toEqual(['value_1']);
     expect(state.invalid_vms.map(vm => vm.csvFields.someArbitraryField)).toEqual(['value_2']);
     expect(state.conflict_vms.map(vm => vm.csvFields.someArbitraryField)).toEqual(['value_3']);
+    expect(state.valid_vms[0].provider).toBe('some');
+    expect(state.valid_vms[0].datacenter).toBe('path');
+    expect(state.valid_vms[0].folder).toBe('/');
   });
 
   it('is fulfilled combining two concurrent requests', () => {

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/__tests__/helpers.test.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/__tests__/helpers.test.js
@@ -1,0 +1,39 @@
+// Note: most of these helpers are tested indirectly in PlanWizardVMStepReducer.test.js, this file is for what isn't covered there.
+
+import { parseVmPath } from '../helpers';
+
+describe('parseVmPath', () => {
+  it('should handle a vm with an empty path', () => {
+    expect(parseVmPath({ path: '' })).toEqual({ provider: '', datacenter: '', folder: '/' });
+  });
+
+  it('should handle a vm with a provider but no datacenter or folder', () => {
+    expect(parseVmPath({ path: 'dummyProvider' })).toEqual({ provider: 'dummyProvider', datacenter: '', folder: '/' });
+    expect(parseVmPath({ path: 'dummyProvider/' })).toEqual({ provider: 'dummyProvider', datacenter: '', folder: '/' });
+  });
+
+  it('should handle a vm with a provider and datacenter but no folder', () => {
+    expect(parseVmPath({ path: 'dummyProvider/dummyDatacenter' })).toEqual({
+      provider: 'dummyProvider',
+      datacenter: 'dummyDatacenter',
+      folder: '/'
+    });
+    expect(parseVmPath({ path: 'dummyProvider/dummyDatacenter/' })).toEqual({
+      provider: 'dummyProvider',
+      datacenter: 'dummyDatacenter',
+      folder: '/'
+    });
+  });
+  it('should handle a vm with a full path', () => {
+    expect(parseVmPath({ path: 'dummyProvider/dummyDatacenter/dummyFolder' })).toEqual({
+      provider: 'dummyProvider',
+      datacenter: 'dummyDatacenter',
+      folder: '/dummyFolder'
+    });
+    expect(parseVmPath({ path: 'dummyProvider/dummyDatacenter/dummyFolder/deeply/nested' })).toEqual({
+      provider: 'dummyProvider',
+      datacenter: 'dummyDatacenter',
+      folder: '/dummyFolder/deeply/nested'
+    });
+  });
+});

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/components/PlanWizardVMStepTable.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/components/PlanWizardVMStepTable.js
@@ -77,15 +77,21 @@ class PlanWizardVMStepTable extends React.Component {
         filterType: 'text'
       },
       {
-        id: 'cluster',
-        title: __('Source Cluster'),
-        placeholder: __('Filter by Source Cluster'),
+        id: 'datacenter',
+        title: __('Datacenter'),
+        placeholder: __('Filter by Datacenter'),
         filterType: 'text'
       },
       {
-        id: 'path',
-        title: __('Path'),
-        placeholder: __('Filter by Path'),
+        id: 'cluster',
+        title: __('Cluster'),
+        placeholder: __('Filter by Cluster'),
+        filterType: 'text'
+      },
+      {
+        id: 'folder',
+        title: __('Folder'),
+        placeholder: __('Filter by Folder'),
         filterType: 'text'
       }
     ];
@@ -173,6 +179,7 @@ class PlanWizardVMStepTable extends React.Component {
             ]
           }
         },
+        // VM Name, Datacenter, Cluster, Folder
         {
           property: 'name',
           header: {
@@ -188,37 +195,17 @@ class PlanWizardVMStepTable extends React.Component {
           },
           cell: {
             props: {
-              index: 1
-            },
-            formatters: [Table.tableCellFormatter]
-          }
-        },
-        {
-          property: 'cluster',
-          header: {
-            label: __('Source Cluster'),
-            props: {
-              index: 3,
-              rowSpan: 1,
-              colSpan: 1
-            },
-            transforms: [sortableTransform],
-            formatters: [sortingFormatter],
-            customFormatters: [Table.sortableHeaderCellFormatter]
-          },
-          cell: {
-            props: {
               index: 2
             },
             formatters: [Table.tableCellFormatter]
           }
         },
         {
-          property: 'path',
+          property: 'datacenter',
           header: {
-            label: __('Path'),
+            label: __('Datacenter'),
             props: {
-              index: 4,
+              index: 3,
               rowSpan: 1,
               colSpan: 1
             },
@@ -234,9 +221,29 @@ class PlanWizardVMStepTable extends React.Component {
           }
         },
         {
-          property: 'allocated_size',
+          property: 'cluster',
           header: {
-            label: __('Allocated Size'),
+            label: __('Cluster'),
+            props: {
+              index: 4,
+              rowSpan: 1,
+              colSpan: 1
+            },
+            transforms: [sortableTransform],
+            formatters: [sortingFormatter],
+            customFormatters: [Table.sortableHeaderCellFormatter]
+          },
+          cell: {
+            props: {
+              index: 4
+            },
+            formatters: [Table.tableCellFormatter]
+          }
+        },
+        {
+          property: 'folder',
+          header: {
+            label: __('Folder'),
             props: {
               index: 5,
               rowSpan: 1,
@@ -248,7 +255,7 @@ class PlanWizardVMStepTable extends React.Component {
           },
           cell: {
             props: {
-              index: 4
+              index: 5
             },
             formatters: [Table.tableCellFormatter]
           }

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/helpers.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/helpers.js
@@ -39,21 +39,22 @@ export const parseVmPath = vm => {
 };
 
 const attachMetadata = (vms, meta) => {
-  if (vms && meta.csvRows && meta.csvRows.length > 0) {
-    const csvFieldsByVmName = meta.csvRows.reduce(
+  if (!vms) return [];
+  const csvFieldsByVmName =
+    meta.csvRows &&
+    meta.csvRows.length > 0 &&
+    meta.csvRows.reduce(
       (newObject, row) => ({
         ...newObject,
         [row.name]: row
       }),
       {}
     );
-    return vms.map(vm => ({
-      ...vm,
-      ...parseVmPath(vm),
-      csvFields: csvFieldsByVmName[vm.name]
-    }));
-  }
-  return vms;
+  return vms.map(vm => ({
+    ...vm,
+    ...parseVmPath(vm),
+    csvFields: csvFieldsByVmName && csvFieldsByVmName[vm.name]
+  }));
 };
 
 export const _formatValidVms = (payloadVms, meta) => {

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/helpers.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/helpers.js
@@ -29,8 +29,17 @@ const manageOddCSVImportErrors = (vm, vmIndex, uniqueIds) => {
   manageBlankReason(vm);
 };
 
+export const parseVmPath = vm => {
+  const [provider, datacenter, ...folderParts] = vm.path.split('/');
+  return {
+    provider,
+    datacenter: datacenter || '',
+    folder: `/${folderParts.join('/')}`
+  };
+};
+
 const attachMetadata = (vms, meta) => {
-  if (meta.csvRows && meta.csvRows.length > 0) {
+  if (vms && meta.csvRows && meta.csvRows.length > 0) {
     const csvFieldsByVmName = meta.csvRows.reduce(
       (newObject, row) => ({
         ...newObject,
@@ -40,6 +49,7 @@ const attachMetadata = (vms, meta) => {
     );
     return vms.map(vm => ({
       ...vm,
+      ...parseVmPath(vm),
       csvFields: csvFieldsByVmName[vm.name]
     }));
   }


### PR DESCRIPTION
Closes #914.
Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1593839

Re-arranges the columns in the VMs step of the Migration Plan wizard to better express the path of a VM and allow filtering by datacenter and folder separately. Also removes the Allocated Size column, which we determined was not useful in this context, in order to make room for longer VM names and folder paths.

Previously, there was one column "Path" which included `Provider/Datacenter/Folder` together. Now, Provider has been removed (as it will be obvious in this context), and Datacenter and Folder have been split into separate columns with their own filtering options.

Note that these are text-based filters which support a partial match, so you can type part of a folder and match all its subfolders, as shown below.

# Screens

## Before:
![Screenshot 2019-03-25 13 49 32](https://user-images.githubusercontent.com/811963/54943562-ea8d3980-4f07-11e9-9623-3ac597b6910d.png)

## After:
![Screenshot 2019-03-25 13 48 36](https://user-images.githubusercontent.com/811963/54943572-f24cde00-4f07-11e9-93bb-e8b83deb238a.png)

## Filter Options:
![Screenshot 2019-03-25 13 56 53](https://user-images.githubusercontent.com/811963/54943588-00026380-4f08-11e9-8267-0d3de068606c.png)

## Applying Multiple Filters:
![eKG21vwSOK](https://user-images.githubusercontent.com/811963/54944227-62a82f00-4f09-11e9-99fb-6f7b5014a3bc.gif)
