### PR TITLE
[#734] Add 'Status Detail' enhanced error message to info popover on a migration task

### DIFF
--- a/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
+++ b/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
@@ -293,6 +293,14 @@ class PlanRequestDetailList extends React.Component {
                       <b>{__('Conversion Host')}: </b>
                       {conversionHosts[task.id] && conversionHosts[task.id].name}
                     </div>
+                    <br />
+                    <div>
+                      <strong>{__('Status Detail')}: </strong>
+                      {task.options.progress &&
+                        task.options.progress.current_state &&
+                        task.options.progress.states &&
+                        task.options.progress.states[task.options.progress.current_state].message}
+                    </div>
                     {task.log_available && (
                       <div>
                         <br />


### PR DESCRIPTION
Closes #734.
Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1595365

Adds a "Status Detail" line to the info popover next to Status on list view items in the migration plan request details page. This line shows the message already available at `task.options.progress.states[task.options.progress.current_state].message`, which has been updated by https://github.com/ManageIQ/manageiq-content/pull/514 to include enhanced error details from the virt-v2v log.

# Screens

Note that these screenshots were taken from tasks that do not contain the new error messages, this is only to show the placement of the new "Status Detail" text.

![Screenshot 2019-03-25 16 09 47](https://user-images.githubusercontent.com/811963/54951343-c2a6d180-4f19-11e9-937e-d003685fc56d.png)

![Screenshot 2019-03-25 16 09 57](https://user-images.githubusercontent.com/811963/54951354-c63a5880-4f19-11e9-8507-2f054da89b4b.png)


