### PR TITLE
[BZ#1680521] Filter cloud_tenants to Openstack providers explicitly (prevents errors with RHV-4.3 providers)

### DIFF
--- a/app/javascript/react/screens/App/Mappings/MappingsConstants.js
+++ b/app/javascript/react/screens/App/Mappings/MappingsConstants.js
@@ -12,7 +12,8 @@ export const SET_V2V_MAPPING_TO_DELETE = 'SET_V2V_MAPPING_TO_DELETE';
 export const SHOW_V2V_DELETE_CONFIRMATION_MODAL = 'SHOW_V2V_DELETE_CONFIRMATION_MODAL';
 export const YES_TO_DELETE_AND_HIDE_DELETE_CONFIRMATION_MODAL = 'YES_TO_DELETE_AND_HIDE_DELETE_CONFIRMATION_MODAL';
 
-export const FETCH_CLOUD_TENANTS_URL = '/api/cloud_tenants?expand=resources';
+export const FETCH_CLOUD_TENANTS_URL =
+  '/api/cloud_tenants?expand=resources&filter[]=ext_management_system.type=ManageIQ::Providers::Openstack::CloudManager';
 
 export const FETCH_TRANSFORMATION_MAPPINGS_URL =
   '/api/transformation_mappings?expand=resources' +

--- a/app/javascript/react/screens/App/Overview/__test__/__snapshots__/index.test.js.snap
+++ b/app/javascript/react/screens/App/Overview/__test__/__snapshots__/index.test.js.snap
@@ -18,7 +18,7 @@ Object {
   "errorFetchingProviders": null,
   "fetchArchivedTransformationPlansUrl": "/api/dummyArchivedTransformationPlans",
   "fetchCloudTenantsAction": [Function],
-  "fetchCloudTenantsUrl": "/api/cloud_tenants?expand=resources",
+  "fetchCloudTenantsUrl": "/api/cloud_tenants?expand=resources&filter[]=ext_management_system.type=ManageIQ::Providers::Openstack::CloudManager",
   "fetchClustersUrl": "/api/dummyClusters",
   "fetchDatastoresUrl": "/api/dummyDatastores",
   "fetchNetworksUrl": "/api/dummyNetworks",

--- a/app/javascript/redux/common/targetResources/targetResourcesConstants.js
+++ b/app/javascript/redux/common/targetResources/targetResourcesConstants.js
@@ -7,5 +7,6 @@ export const FETCH_TARGET_COMPUTE_URLS = {
     '/api/clusters?expand=resources' +
     '&attributes=ext_management_system.emstype,v_parent_datacenter,ext_management_system.name,hosts' +
     '&filter[]=ext_management_system.emstype=rhevm',
-  [OPENSTACK]: '/api/cloud_tenants?expand=resources&attributes=ext_management_system.name,ext_management_system.id,vms'
+  [OPENSTACK]:
+    '/api/cloud_tenants?expand=resources&filter[]=ext_management_system.type=ManageIQ::Providers::Openstack::CloudManager&attributes=ext_management_system.name,ext_management_system.id,vms'
 };


### PR DESCRIPTION
When loading cloud_tenants in the mappings page, overview page, and mapping wizard, we need to be sure to load only OpenStack cloud_tenants, since RHV can now also provide cloud_tenants.

Without this filter, requesting the cloud_volume_types for all cloud_tenants will cause errors (since RHV does not have cloud_volume_types), and RHV tenants will incorrectly appear in the list of target OSP projects in the mapping wizard (causing further errors if chosen for a mapping).

This PR adds an explicit filter on requests for lists of cloud_tenants restricting these requests to those tenants with an OpenStack provider, which prevents these errors.

The error can be reproduced (and the fix verified) by using this database: https://drive.google.com/open?id=1KydneIrh1diGPtM4bqUkH_MYCkz1_3D- and navigating to the mappings page.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1680521