### PR TITLE
[HAMMER] [BZ#1680521] Filter cloud_tenants to Openstack providers explicitly (prevents errors with RHV-4.3 providers)

### DIFF
--- a/app/javascript/react/screens/App/Mappings/MappingsConstants.js
+++ b/app/javascript/react/screens/App/Mappings/MappingsConstants.js
@@ -12,7 +12,8 @@ export const SET_V2V_MAPPING_TO_DELETE = 'SET_V2V_MAPPING_TO_DELETE';
 export const SHOW_V2V_DELETE_CONFIRMATION_MODAL = 'SHOW_V2V_DELETE_CONFIRMATION_MODAL';
 export const YES_TO_DELETE_AND_HIDE_DELETE_CONFIRMATION_MODAL = 'YES_TO_DELETE_AND_HIDE_DELETE_CONFIRMATION_MODAL';
 
-export const FETCH_CLOUD_TENANTS_URL = '/api/cloud_tenants?expand=resources';
+export const FETCH_CLOUD_TENANTS_URL =
+  '/api/cloud_tenants?expand=resources&filter[]=ext_management_system.type=ManageIQ::Providers::Openstack::CloudManager';
 
 export const FETCH_TRANSFORMATION_MAPPINGS_URL =
   '/api/transformation_mappings?expand=resources' +

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardClustersStep/MappingWizardClustersStepConstants.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardClustersStep/MappingWizardClustersStepConstants.js
@@ -14,7 +14,8 @@ export const FETCH_TARGET_COMPUTE_URLS = {
     '/api/clusters?expand=resources' +
     '&attributes=ext_management_system.emstype,v_parent_datacenter,ext_management_system.name,hosts' +
     '&filter[]=ext_management_system.emstype=rhevm',
-  [OPENSTACK]: '/api/cloud_tenants?expand=resources&attributes=ext_management_system.name,ext_management_system.id'
+  [OPENSTACK]:
+    '/api/cloud_tenants?expand=resources&filter[]=ext_management_system.type=ManageIQ::Providers::Openstack::CloudManager&attributes=ext_management_system.name,ext_management_system.id'
 };
 
 export const QUERY_PROVIDERS_URL = '/api/providers';

--- a/app/javascript/react/screens/App/Overview/__test__/__snapshots__/index.test.js.snap
+++ b/app/javascript/react/screens/App/Overview/__test__/__snapshots__/index.test.js.snap
@@ -17,7 +17,7 @@ Object {
   "editPlanRequestAction": [Function],
   "fetchArchivedTransformationPlansUrl": "/api/dummyArchivedTransformationPlans",
   "fetchCloudTenantsAction": [Function],
-  "fetchCloudTenantsUrl": "/api/cloud_tenants?expand=resources",
+  "fetchCloudTenantsUrl": "/api/cloud_tenants?expand=resources&filter[]=ext_management_system.type=ManageIQ::Providers::Openstack::CloudManager",
   "fetchClustersUrl": "/api/dummyClusters",
   "fetchDatastoresUrl": "/api/dummyDatastores",
   "fetchNetworksUrl": "/api/dummyNetworks",


### PR DESCRIPTION
This PR backports https://github.com/ManageIQ/manageiq-v2v/pull/920 to the `hammer` branch directly, since that PR would not backport cleanly. (The FETCH_TARGET_COMPUTE_URLS constant we're changing here was moved to a new file in https://github.com/ManageIQ/manageiq-v2v/pull/871).

See #920 for details about this change.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1680521