### PR TITLE
Enable (un-hide) the Conversion Hosts tab of the Settings page

### DIFF
--- a/app/javascript/react/screens/App/Settings/Settings.js
+++ b/app/javascript/react/screens/App/Settings/Settings.js
@@ -15,31 +15,23 @@ const Settings = props => {
         <Breadcrumb.Item href="#/plans">{__('Migration')}</Breadcrumb.Item>
         <Breadcrumb.Item active>{__('Migration Settings')}</Breadcrumb.Item>
       </Toolbar>
-      {props.hideConversionHostSettings ? (
-        <React.Fragment>
-          <h2>{__('Migration Throttling')}</h2>
-          <GeneralSettings />
-        </React.Fragment>
-      ) : (
-        <div style={{ marginTop: 10 }}>
-          <Tabs id="settings-tabs" activeKey={match.path} onSelect={key => redirectTo(key)} unmountOnExit>
-            <Tab eventKey="/settings" title={__('Migration Throttling')}>
-              <GeneralSettings />
-            </Tab>
-            <Tab eventKey="/settings/conversion_hosts" title={__('Conversion Hosts')}>
-              <ConversionHostsSettings />
-            </Tab>
-          </Tabs>
-        </div>
-      )}
+      <div style={{ marginTop: 10 }}>
+        <Tabs id="settings-tabs" activeKey={match.path} onSelect={key => redirectTo(key)} unmountOnExit>
+          <Tab eventKey="/settings" title={__('Migration Throttling')}>
+            <GeneralSettings />
+          </Tab>
+          <Tab eventKey="/settings/conversion_hosts" title={__('Conversion Hosts')}>
+            <ConversionHostsSettings />
+          </Tab>
+        </Tabs>
+      </div>
     </React.Fragment>
   );
 };
 
 Settings.propTypes = {
   match: PropTypes.object,
-  redirectTo: PropTypes.func,
-  hideConversionHostSettings: PropTypes.bool // TODO remove this when we are ready to release ConversionHostsSettings
+  redirectTo: PropTypes.func
 };
 
 export default Settings;

--- a/app/javascript/react/screens/App/Settings/index.js
+++ b/app/javascript/react/screens/App/Settings/index.js
@@ -5,9 +5,7 @@ import * as RouterActions from '../../../../redux/actions/routerActions';
 
 export const reducers = { settings: reducer };
 
-const mapStateToProps = () => ({
-  hideConversionHostSettings: true // TODO remove this when we are ready to release ConversionHostsSettings
-});
+const mapStateToProps = () => ({});
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => Object.assign(stateProps, ownProps.data, dispatchProps);
 


### PR DESCRIPTION
This PR exposes the Conversion Hosts list view and wizard by removing the flag that prevented the Conversion Hosts tab from rendering. We should merge it only when the back end is ready and the feature is ready for release.

@fdupont-redhat wanted us to wait until he gives the green light after he tests the changes to the enablement playbook.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1695356