### PR TITLE
Migration Plans in Progress page: fix error with deleted target provider

### DIFF
--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsInProgressCard.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsInProgressCard.js
@@ -71,7 +71,8 @@ const MigrationsInProgressCard = ({
     );
 
     const targetIsOsp = getMappingType(plan.transformation_mapping.transformation_mapping_items) === OPENSTACK;
-    const cardMessage = targetIsOsp && !plan.targetProvider.hasRsaKey ? 'noRsaKey' : 'notAvailable';
+    const cardMessage =
+      targetIsOsp && plan.targetProvider && !plan.targetProvider.hasRsaKey ? 'noRsaKey' : 'notAvailable';
 
     return (
       <InProgressCard

--- a/app/javascript/react/screens/App/Overview/helpers.js
+++ b/app/javascript/react/screens/App/Overview/helpers.js
@@ -25,6 +25,9 @@ export const attachTargetProvider = (plan, providers, clusters, targetProviderTy
     item => item.destination_type === TRANSFORMATION_MAPPING_ITEM_DESTINATION_TYPES[targetProviderType].cluster
   );
   const targetCluster = clusters.find(cluster => cluster.id === clusterMapping.destination_id);
+  if (targetCluster === undefined) {
+    return plan;
+  }
   const targetProvider = providers.find(provider => provider.id === targetCluster.ems_id);
 
   return { ...plan, targetProvider };


### PR DESCRIPTION
1. Create migration mapping: vmware to openstack
2. Create migration plan for the above mapping
3. Start the above plan
4. After starting the plan, delete the target OpenStack provider
5. Navigate to screen showing migration plans in progress and witness the following error:

```
vendor-340c92bee2eeaef68d4f.js:sourcemap:619 TypeError: Cannot read property 'ems_id' of undefined
    at helpers.js:33
    at Array.find (<anonymous>)
    at t.attachTargetProvider (helpers.js:33)
    at OverviewSelectors.js:75
    at Array.map (<anonymous>)
    at Array.<anonymous> (vendor-340c92bee2eeaef68d4f.js:sourcemap:13)
    at t.attachTargetProviderToOspPlans (OverviewSelectors.js:69)
    at Function.mapToProps (index.js:29)
    at o (vendor-340c92bee2eeaef68d4f.js:sourcemap:166)
    at vendor-340c92bee2eeaef68d4f.js:sourcemap:230
si @ vendor-340c92bee2eeaef68d4f.js:sourcemap:619
n.callback @ vendor-340c92bee2eeaef68d4f.js:sourcemap:619
io @ vendor-340c92bee2eeaef68d4f.js:sourcemap:619
oo @ vendor-340c92bee2eeaef68d4f.js:sourcemap:619
pa @ vendor-340c92bee2eeaef68d4f.js:sourcemap:619
fa @ vendor-340c92bee2eeaef68d4f.js:sourcemap:619
da @ vendor-340c92bee2eeaef68d4f.js:sourcemap:619
ji @ vendor-340c92bee2eeaef68d4f.js:sourcemap:619
enqueueSetState @ vendor-340c92bee2eeaef68d4f.js:sourcemap:619
b.setState @ vendor-340c92bee2eeaef68d4f.js:sourcemap:627
o.onStateChange @ vendor-340c92bee2eeaef68d4f.js:sourcemap:166
y @ vendor-340c92bee2eeaef68d4f.js:sourcemap:138
(anonymous) @ vendor-340c92bee2eeaef68d4f.js:sourcemap:504
(anonymous) @ vendor-340c92bee2eeaef68d4f.js:sourcemap:504
(anonymous) @ vendor-340c92bee2eeaef68d4f.js:sourcemap:504
dispatch @ vendor-340c92bee2eeaef68d4f.js:sourcemap:138
(anonymous) @ vendor-340c92bee2eeaef68d4f.js:sourcemap:504
Promise.then (async)
(anonymous) @ vendor-340c92bee2eeaef68d4f.js:sourcemap:504
(anonymous) @ vendor-340c92bee2eeaef68d4f.js:sourcemap:504
(anonymous) @ vendor-340c92bee2eeaef68d4f.js:sourcemap:504
dispatch @ vendor-340c92bee2eeaef68d4f.js:sourcemap:138
(anonymous) @ OverviewActions.js:123
(anonymous) @ vendor-340c92bee2eeaef68d4f.js:sourcemap:504
(anonymous) @ vendor-340c92bee2eeaef68d4f.js:sourcemap:504
(anonymous) @ vendor-340c92bee2eeaef68d4f.js:sourcemap:230
(anonymous) @ Overview.js:45
Promise.then (async)
value @ Overview.js:44
pa @ vendor-340c92bee2eeaef68d4f.js:sourcemap:619
fa @ vendor-340c92bee2eeaef68d4f.js:sourcemap:619
da @ vendor-340c92bee2eeaef68d4f.js:sourcemap:619
ji @ vendor-340c92bee2eeaef68d4f.js:sourcemap:619
ba @ vendor-340c92bee2eeaef68d4f.js:sourcemap:619
_a @ vendor-340c92bee2eeaef68d4f.js:sourcemap:619
xa.render @ vendor-340c92bee2eeaef68d4f.js:sourcemap:619
(anonymous) @ vendor-340c92bee2eeaef68d4f.js:sourcemap:619
ya @ vendor-340c92bee2eeaef68d4f.js:sourcemap:619
Ta @ vendor-340c92bee2eeaef68d4f.js:sourcemap:619
render @ vendor-340c92bee2eeaef68d4f.js:sourcemap:619
n @ application-common-e00a08200dbdb5bf73ff.js:1
create @ application-common-e00a08200dbdb5bf73ff.js:1
f @ application-common-e00a08200dbdb5bf73ff.js:1
t.componentFactory @ application-common-e00a08200dbdb5bf73ff.js:1
(anonymous) @ plans:1480
helpers.js:33 Uncaught (in promise) TypeError: Cannot read property 'ems_id' of undefined
    at helpers.js:33
    at Array.find (<anonymous>)
    at t.attachTargetProvider (helpers.js:33)
    at OverviewSelectors.js:75
    at Array.map (<anonymous>)
    at Array.<anonymous> (vendor-340c92bee2eeaef68d4f.js:sourcemap:13)
    at t.attachTargetProviderToOspPlans (OverviewSelectors.js:69)
    at Function.mapToProps (index.js:29)
    at o (vendor-340c92bee2eeaef68d4f.js:sourcemap:166)
    at vendor-340c92bee2eeaef68d4f.js:sourcemap:230
```

Not sure if this is the best fix for the problem @mturley but it does stop the error.

https://bugzilla.redhat.com/show_bug.cgi?id=1691992