### PR TITLE
Conversion Host Wizard: set the auth_user to 'root' for RHV hosts

### DIFF
--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardResultsStep/helpers.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardResultsStep/helpers.js
@@ -3,8 +3,6 @@ import { VDDK } from '../ConversionHostWizardConstants';
 
 export const getConfigureConversionHostPostBodies = (locationStepValues, hostsStepValues, authStepValues) =>
   hostsStepValues.hosts.map(host => {
-    const openstackSpecificProperties =
-      locationStepValues.providerType === OPENSTACK ? { auth_user: authStepValues.openstackUser } : {};
     const vmwareAuthProperties =
       authStepValues.transformationMethod === VDDK
         ? { vmware_vddk_package_url: authStepValues.vddkLibraryPath }
@@ -14,7 +12,7 @@ export const getConfigureConversionHostPostBodies = (locationStepValues, hostsSt
       resource_type: host.type,
       resource_id: host.id,
       conversion_host_ssh_private_key: authStepValues.conversionHostSshKey.body,
-      ...openstackSpecificProperties,
+      auth_user: locationStepValues.providerType === OPENSTACK ? authStepValues.openstackUser : 'root',
       ...vmwareAuthProperties
     };
   });


### PR DESCRIPTION
Part of the Conversion Hosts UI feature BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1693339

Per @fdupont-redhat's request, the wizard should use `root` for the value of the `auth_user` param if the user is configuring RHV hosts. Previously we only included this param for OpenStack hosts.