### PR TITLE
[BZ#1692087] Fix breadcrumb bars to be consistent with the rest of CloudForms

### DIFF
--- a/app/javascript/react/screens/App/Mappings/Mappings.js
+++ b/app/javascript/react/screens/App/Mappings/Mappings.js
@@ -174,9 +174,11 @@ class Mappings extends Component {
     return (
       <React.Fragment>
         <Toolbar>
-          <Breadcrumb.Item href="/dashboard/maintab?tab=compute">{__('Compute')}</Breadcrumb.Item>
-          <Breadcrumb.Item href="#/plans">{__('Migration')}</Breadcrumb.Item>
-          <Breadcrumb.Item active>{__('Infrastructure Mappings')}</Breadcrumb.Item>
+          <Breadcrumb.Item active>{__('Compute')}</Breadcrumb.Item>
+          <Breadcrumb.Item active>{__('Migration')}</Breadcrumb.Item>
+          <Breadcrumb.Item active>
+            <strong>{__('Infrastructure Mappings')}</strong>
+          </Breadcrumb.Item>
         </Toolbar>
         <Spinner
           loading={

--- a/app/javascript/react/screens/App/Overview/Overview.js
+++ b/app/javascript/react/screens/App/Overview/Overview.js
@@ -413,8 +413,11 @@ class Overview extends React.Component {
 
     const toolbarContent = (
       <Toolbar>
-        <Breadcrumb.Item href="/dashboard/maintab?tab=compute">{__('Compute')}</Breadcrumb.Item>
+        <Breadcrumb.Item active>{__('Compute')}</Breadcrumb.Item>
         <Breadcrumb.Item active>{__('Migration')}</Breadcrumb.Item>
+        <Breadcrumb.Item active>
+          <strong>{__('Migration Plans')}</strong>
+        </Breadcrumb.Item>
       </Toolbar>
     );
 

--- a/app/javascript/react/screens/App/Plan/Plan.js
+++ b/app/javascript/react/screens/App/Plan/Plan.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Immutable from 'seamless-immutable';
-import { Link } from 'react-router-dom';
 import { Breadcrumb, Spinner, Icon } from 'patternfly-react';
 import Toolbar from '../../../config/Toolbar';
 import PlanRequestDetailList from './components/PlanRequestDetailList/PlanRequestDetailList';
@@ -166,15 +165,16 @@ class Plan extends React.Component {
     return (
       <React.Fragment>
         <Toolbar>
-          <Breadcrumb.Item href="/dashboard/maintab?tab=compute">{__('Compute')}</Breadcrumb.Item>
-          <li>
-            <Link to="/plans">{__('Migration')}</Link>
-          </li>
+          <Breadcrumb.Item active>{__('Compute')}</Breadcrumb.Item>
+          <Breadcrumb.Item active>{__('Migration')}</Breadcrumb.Item>
+          <Breadcrumb.Item href="#/plans">{__('Migration Plans')}</Breadcrumb.Item>
           {!isRejectedPlan &&
             planName && (
               <Breadcrumb.Item active>
-                {breadcrumbIcon}
-                {breadcrumbIcon ? ` ${planName}` : planName}
+                <strong>
+                  {breadcrumbIcon}
+                  {breadcrumbIcon ? ` ${planName}` : planName}
+                </strong>
               </Breadcrumb.Item>
             )}
         </Toolbar>

--- a/app/javascript/react/screens/App/Settings/Settings.js
+++ b/app/javascript/react/screens/App/Settings/Settings.js
@@ -11,9 +11,11 @@ const Settings = props => {
   return (
     <React.Fragment>
       <Toolbar>
-        <Breadcrumb.Item href="/dashboard/maintab?tab=compute">{__('Compute')}</Breadcrumb.Item>
-        <Breadcrumb.Item href="#/plans">{__('Migration')}</Breadcrumb.Item>
-        <Breadcrumb.Item active>{__('Migration Settings')}</Breadcrumb.Item>
+        <Breadcrumb.Item active>{__('Compute')}</Breadcrumb.Item>
+        <Breadcrumb.Item active>{__('Migration')}</Breadcrumb.Item>
+        <Breadcrumb.Item active>
+          <strong>{__('Migration Settings')}</strong>
+        </Breadcrumb.Item>
       </Toolbar>
       {props.hideConversionHostSettings ? (
         <React.Fragment>

--- a/app/javascript/react/screens/App/Settings/__tests__/__snapshots__/Settings.test.js.snap
+++ b/app/javascript/react/screens/App/Settings/__tests__/__snapshots__/Settings.test.js.snap
@@ -4,21 +4,21 @@ exports[`Settings component renders correctly 1`] = `
 <React.Fragment>
   <Toolbar>
     <BreadcrumbItem
-      active={false}
-      href="/dashboard/maintab?tab=compute"
+      active={true}
     >
       Compute
     </BreadcrumbItem>
     <BreadcrumbItem
-      active={false}
-      href="#/plans"
+      active={true}
     >
       Migration
     </BreadcrumbItem>
     <BreadcrumbItem
       active={true}
     >
-      Migration Settings
+      <strong>
+        Migration Settings
+      </strong>
     </BreadcrumbItem>
   </Toolbar>
   <div


### PR DESCRIPTION
Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1692087

As pointed out in that BZ, the breadcrumb from the Migration Plans page still displayed "Compute > Migration" as it did when it was an overview page. @vconzola pointed out that the rest of the breadcrumbs should also be updated so the "Compute" and "Migration" parts are not links, the final item in each is bolded, and in the Migration Details page, the "Migration Plans" part is a link.

# Before:

Plans page:
![Screenshot 2019-04-02 15 53 26](https://user-images.githubusercontent.com/811963/55431874-84379500-555f-11e9-8ea3-a58279f4d789.png)

Plan Details page:
![Screenshot 2019-04-02 15 54 16](https://user-images.githubusercontent.com/811963/55431900-94e80b00-555f-11e9-8abc-55a99041f952.png)

Mappings page:
![Screenshot 2019-04-02 15 54 44](https://user-images.githubusercontent.com/811963/55431924-a3cebd80-555f-11e9-902f-c66470f937fc.png)

Settings page:
![Screenshot 2019-04-02 15 55 02](https://user-images.githubusercontent.com/811963/55431964-b77a2400-555f-11e9-9239-760979ceeef0.png)


# After:

Plans page:
![Screenshot 2019-04-02 15 19 09](https://user-images.githubusercontent.com/811963/55431663-15f2d280-555f-11e9-8719-2b2cddbb4ad7.png)

Plan Details page:
![Screenshot 2019-04-02 15 51 21](https://user-images.githubusercontent.com/811963/55431710-31f67400-555f-11e9-8d41-6ed9364eeeb4.png)

Mappings page:
![Screenshot 2019-04-02 15 52 01](https://user-images.githubusercontent.com/811963/55431776-4cc8e880-555f-11e9-97c9-333f0e4ea3a6.png)

Settings page:
![Screenshot 2019-04-02 15 52 10](https://user-images.githubusercontent.com/811963/55431783-505c6f80-555f-11e9-8779-4837f6253c7d.png)
