### PR TITLE
Fix call to transformation_log_queue

### DIFF
--- a/app/controllers/migration_log_controller.rb
+++ b/app/controllers/migration_log_controller.rb
@@ -2,10 +2,17 @@ class MigrationLogController < ApplicationController
   before_action :check_privileges
   after_action :cleanup_action
 
+  # Download the V2V migration log as a background task. There are
+  # multiple log types possible, with the default set to 'v2v' if no
+  # :log_type parameter is found.
+  #
+  # Upon task completion the log contents, status and status message
+  # are rendered.
+  #
   def download_migration_log
     plan_task = ServiceTemplateTransformationPlanTask.find(params[:id])
     log_type = params[:log_type] || 'v2v'
-    miq_tasks_id = plan_task.transformation_log_queue(:log_type => log_type)
+    miq_tasks_id = plan_task.transformation_log_queue(nil, log_type)
     task = MiqTask.wait_for_taskid(miq_tasks_id)
     task_results = task.task_results
     task_status = task.status


### PR DESCRIPTION
The `ServiceTemplateTransformationPlanTask#transformation_log_queue` method takes two fixed arguments - a userid and log type -  rather than a hash of options. You can see the definition here:

https://github.com/ManageIQ/manageiq/blob/master/app/models/service_template_transformation_plan_task.rb#L139

I also added some comments.

~~WIP for now until I can confirm that this works as expected.~~