### PR TITLE
[BZ#1695470] Text changes to wizard errors and throttling info popover

### DIFF
--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardResultsStep/MappingWizardResultsStep.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardResultsStep/MappingWizardResultsStep.js
@@ -49,26 +49,16 @@ class MappingWizardResultsStep extends React.Component {
     } = this.props;
 
     if (isPostingMappings) {
-      return (
-        <WizardLoadingState
-          title={__('Creating Infrastructure Mapping...')}
-          message={__('Please wait while the infrastructure mapping is created.')}
-        />
-      );
+      return <WizardLoadingState title={__('Creating Infrastructure Mapping...')} />;
     } else if (isRejectedPostingMappings) {
       return (
         <WizardErrorState
           title={__('Error Creating Infrastructure Mapping')}
-          message={__("We're sorry, something went wrong. Please try again.")}
+          message={__('The mapping cannot be created. Check your settings and try again.')}
         />
       );
     } else if (isUpdatingMapping) {
-      return (
-        <WizardLoadingState
-          title={__('Saving Infrastructure Mapping...')}
-          message={__('Please wait while the infrastructure mapping is saved.')}
-        />
-      );
+      return <WizardLoadingState title={__('Saving Infrastructure Mapping...')} />;
     } else if (transformationMappingsResult) {
       return (
         <div className="wizard-pf-complete blank-slate-pf">

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardResultsStep/PlanWizardResultsStep.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardResultsStep/PlanWizardResultsStep.js
@@ -61,12 +61,7 @@ class PlanWizardResultsStep extends React.Component {
     } = this.props;
 
     if (isPostingPlans) {
-      return (
-        <WizardLoadingState
-          title={__('Creating Migration Plan...')}
-          message={__('Please wait while the migration plan is created.')}
-        />
-      );
+      return <WizardLoadingState title={__('Creating Migration Plan...')} />;
     } else if (isRejectedPostingPlans) {
       const errorData = errorPostingPlans && errorPostingPlans.data;
       const errorMessage = errorData && errorData.error && errorData.error.message;
@@ -78,12 +73,7 @@ class PlanWizardResultsStep extends React.Component {
         />
       );
     } else if (isPuttingPlans) {
-      return (
-        <WizardLoadingState
-          title={__('Saving Migration Plan...')}
-          message={__('Please wait while the migration plan is saved.')}
-        />
-      );
+      return <WizardLoadingState title={__('Saving Migration Plan...')} />;
     } else if (isRejectedPuttingPlans) {
       const errorData = errorPuttingPlans && errorPuttingPlans.data;
       const errorMessage = errorData && errorData.error && errorData.error.message;

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardResultsStep/ConversionHostWizardResultsStep.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardResultsStep/ConversionHostWizardResultsStep.js
@@ -20,7 +20,7 @@ class ConversionHostWizardResultsStep extends React.Component {
       return (
         <WizardErrorState
           title={__('Error Starting Conversion Host Configuration')}
-          message={__("We're sorry, something went wrong. Please try again.")}
+          message={__('The conversion host cannot be configured. Check your settings and try again.')}
         />
       );
     }

--- a/app/javascript/react/screens/App/Settings/screens/GeneralSettings/GeneralSettings.js
+++ b/app/javascript/react/screens/App/Settings/screens/GeneralSettings/GeneralSettings.js
@@ -56,27 +56,17 @@ export class GeneralSettings extends React.Component {
                   {__('Maximum concurrent migrations per conversion host')}
                   <OverlayTrigger
                     overlay={
-                      <Popover id="maximum_concurrect_migrations_per_provider_popover">
-                        {__(
-                          'For VDDK transformations the maximum concurrent migrations per conversion host is limited to 20. See the product documentation for more information.'
-                        )}
+                      <Popover id="maximum_concurrect_migrations_per_host_popover">
+                        {__('For VDDK transformations, the maximum concurrent migrations per conversion host should not exceed 20, to avoid network overload.') /* prettier-ignore */}
                       </Popover>
                     }
                     placement="top"
-                    trigger={['hover']}
-                    delay={500}
-                    rootClose={false}
+                    trigger="click"
+                    rootClose
                   >
-                    <Icon
-                      type="pf"
-                      name="info"
-                      size="md"
-                      style={{
-                        width: 'inherit',
-                        backgroundColor: 'transparent',
-                        padding: 10
-                      }}
-                    />
+                    <Button bsStyle="link">
+                      <Icon type="pf" name="info" />
+                    </Button>
                   </OverlayTrigger>
                 </span>
               </Form.ControlLabel>

--- a/app/javascript/react/screens/App/Settings/screens/GeneralSettings/__tests__/GeneralSettings.test.js
+++ b/app/javascript/react/screens/App/Settings/screens/GeneralSettings/__tests__/GeneralSettings.test.js
@@ -30,7 +30,10 @@ describe('GeneralSettings component', () => {
   it('properly calls patchSettingsAction on apply click', () => {
     const patchSettingsAction = jest.fn();
     const component = shallow(<GeneralSettings {...getBaseProps()} patchSettingsAction={patchSettingsAction} />);
-    component.find('Button').simulate('click');
+    component
+      .find('Button')
+      .find({ bsStyle: 'primary' })
+      .simulate('click');
     expect(patchSettingsAction).toBeCalledWith(servers.resources, defaultFormValues);
   });
 });

--- a/app/javascript/react/screens/App/Settings/screens/GeneralSettings/__tests__/__snapshots__/GeneralSettings.test.js.snap
+++ b/app/javascript/react/screens/App/Settings/screens/GeneralSettings/__tests__/__snapshots__/GeneralSettings.test.js.snap
@@ -47,36 +47,31 @@ exports[`GeneralSettings component renders the general settings page 1`] = `
             Maximum concurrent migrations per conversion host
             <OverlayTrigger
               defaultOverlayShown={false}
-              delay={500}
               overlay={
                 <Popover
                   bsClass="popover"
-                  id="maximum_concurrect_migrations_per_provider_popover"
+                  id="maximum_concurrect_migrations_per_host_popover"
                   placement="right"
                 >
-                  For VDDK transformations the maximum concurrent migrations per conversion host is limited to 20. See the product documentation for more information.
+                  For VDDK transformations, the maximum concurrent migrations per conversion host should not exceed 20, to avoid network overload.
                 </Popover>
               }
               placement="top"
-              rootClose={false}
-              trigger={
-                Array [
-                  "hover",
-                ]
-              }
+              rootClose={true}
+              trigger="click"
             >
-              <Icon
-                name="info"
-                size="md"
-                style={
-                  Object {
-                    "backgroundColor": "transparent",
-                    "padding": 10,
-                    "width": "inherit",
-                  }
-                }
-                type="pf"
-              />
+              <Button
+                active={false}
+                block={false}
+                bsClass="btn"
+                bsStyle="link"
+                disabled={false}
+              >
+                <Icon
+                  name="info"
+                  type="pf"
+                />
+              </Button>
             </OverlayTrigger>
           </span>
         </ControlLabel>


### PR DESCRIPTION
Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1695470

This PR updates the text of error messages at the end of the Conversion Host wizard and the Infrastructure Mapping wizard so they no longer say "We're sorry, something went wrong. Please try again." Errors at the end of the conversion host wizard will now say "The conversion host cannot be configured. Check your settings and try again." and at the end of the mapping wizard "The mapping cannot be created. Check your settings and try again."

I also removed the "please wait" messages in both the plan wizard and the mapping wizard, the "Creating Infrastructure Mapping..." and "Creating Migration Plan..." messages there are sufficient.

This PR also updates the info popover on the "Maximum concurrent migrations per conversion host" field of the settings page to be more clear about the limitations of VDDK transformations. While I was modifying that popover, I also changed its style and behavior to be more consistent with info popovers elsewhere in the UI (blue link-style icon, click to activate instead of hover)