### PR TITLE
[BZ#1699343] Fix regression in CSV validation with invalid rows

### DIFF
--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/__tests__/helpers.test.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/__tests__/helpers.test.js
@@ -7,6 +7,10 @@ describe('parseVmPath', () => {
     expect(parseVmPath({ path: '' })).toEqual({ provider: '', datacenter: '', folder: '/' });
   });
 
+  it('should handle a vm with no path defined (invalid vm)', () => {
+    expect(parseVmPath({})).toEqual({ provider: '', datacenter: '', folder: '' });
+  });
+
   it('should handle a vm with a provider but no datacenter or folder', () => {
     expect(parseVmPath({ path: 'dummyProvider' })).toEqual({ provider: 'dummyProvider', datacenter: '', folder: '/' });
     expect(parseVmPath({ path: 'dummyProvider/' })).toEqual({ provider: 'dummyProvider', datacenter: '', folder: '/' });

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/helpers.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/helpers.js
@@ -30,6 +30,9 @@ const manageOddCSVImportErrors = (vm, vmIndex, uniqueIds) => {
 };
 
 export const parseVmPath = vm => {
+  if (vm.path === undefined) {
+    return { provider: '', datacenter: '', folder: '' };
+  }
   const [provider, datacenter, ...folderParts] = vm.path.split('/');
   return {
     provider,


### PR DESCRIPTION
Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1699343

When I added the VMWare path parsing in https://github.com/ManageIQ/manageiq-v2v/pull/917 I failed to test it with VM objects that have no defined path (such as objects corresponding to invalid CSV rows). The `parseVmPath` helper function was causing an error because it assumed the path property would be defined. This PR adds a guard against that case to the helper.

This is a CFME 5.10.3 regression, so it should be merged and backported ASAP.