### PR TITLE
[#927] Add option to sort plans by Completed time, and fix alignment in plan list views

### DIFF
--- a/app/javascript/react/screens/App/Overview/components/Migrations/EditScheduleMenuItems.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/EditScheduleMenuItems.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button, MenuItem, Icon } from 'patternfly-react';
+import { MenuItem, Icon } from 'patternfly-react';
 import { formatDateTime } from '../../../../../../components/dates/MomentDate';
 
-const ScheduleMigrationButtons = ({
+const EditScheduleMenuItems = ({
   showConfirmModalAction,
   hideConfirmModalAction,
   loading,
@@ -14,8 +14,7 @@ const ScheduleMigrationButtons = ({
   plan,
   isMissingMapping,
   migrationScheduled,
-  migrationStarting,
-  showInitialScheduleButton
+  migrationStarting
 }) => {
   const confirmationWarningText = (
     <React.Fragment>
@@ -52,54 +51,38 @@ const ScheduleMigrationButtons = ({
 
   return (
     <React.Fragment>
-      {showInitialScheduleButton && (
-        <Button
-          id={`schedule_${plan.id}`}
-          onClick={e => {
-            e.stopPropagation();
+      <MenuItem
+        id={`edit_schedule_${plan.id}`}
+        onClick={e => {
+          e.stopPropagation();
+          if (!editScheduleDisabled) {
             toggleScheduleMigrationModal({ plan });
-          }}
-          disabled={isMissingMapping || loading === plan.href || plan.schedule_type}
-        >
-          {__('Schedule')}
-        </Button>
-      )}
-      {!showInitialScheduleButton && (
-        <React.Fragment>
-          <MenuItem
-            id={`edit_schedule_${plan.id}`}
-            onClick={e => {
-              e.stopPropagation();
-              if (!editScheduleDisabled) {
-                toggleScheduleMigrationModal({ plan });
-              }
-            }}
-            disabled={editScheduleDisabled}
-          >
-            {__('Edit schedule')}
-          </MenuItem>
-          <MenuItem
-            id={`unschedule_${plan.id}`}
-            onClick={e => {
-              e.stopPropagation();
-              if (!editScheduleDisabled) {
-                showConfirmModalAction({
-                  ...confirmModalProps,
-                  onConfirm
-                });
-              }
-            }}
-            disabled={editScheduleDisabled}
-          >
-            {__('Delete schedule')}
-          </MenuItem>
-        </React.Fragment>
-      )}
+          }
+        }}
+        disabled={editScheduleDisabled}
+      >
+        {__('Edit schedule')}
+      </MenuItem>
+      <MenuItem
+        id={`unschedule_${plan.id}`}
+        onClick={e => {
+          e.stopPropagation();
+          if (!editScheduleDisabled) {
+            showConfirmModalAction({
+              ...confirmModalProps,
+              onConfirm
+            });
+          }
+        }}
+        disabled={editScheduleDisabled}
+      >
+        {__('Delete schedule')}
+      </MenuItem>
     </React.Fragment>
   );
 };
 
-ScheduleMigrationButtons.propTypes = {
+EditScheduleMenuItems.propTypes = {
   showConfirmModalAction: PropTypes.func,
   hideConfirmModalAction: PropTypes.func,
   loading: PropTypes.string,
@@ -110,8 +93,7 @@ ScheduleMigrationButtons.propTypes = {
   plan: PropTypes.object,
   isMissingMapping: PropTypes.bool,
   migrationScheduled: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  migrationStarting: PropTypes.bool,
-  showInitialScheduleButton: PropTypes.bool
+  migrationStarting: PropTypes.bool
 };
 
-export default ScheduleMigrationButtons;
+export default EditScheduleMenuItems;

--- a/app/javascript/react/screens/App/Overview/components/Migrations/Migrations.scss
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/Migrations.scss
@@ -28,7 +28,7 @@
 }
 
 @media (min-width: 992px) {
-  .migrations .plans-complete-list .list-view-pf-main-info .list-view-pf-body {
+  .migrations .list-view-pf-main-info .list-view-pf-body {
     .list-view-pf-description {
       width: 25%;
     }

--- a/app/javascript/react/screens/App/Overview/components/Migrations/Migrations.scss
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/Migrations.scss
@@ -26,3 +26,14 @@
     margin-right: 5px;
   }
 }
+
+@media (min-width: 992px) {
+  .migrations .plans-complete-list .list-view-pf-main-info .list-view-pf-body {
+    .list-view-pf-description {
+      width: 25%;
+    }
+    .list-view-pf-additional-info {
+      width: 75%;
+    }
+  }
+}

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
@@ -245,6 +245,14 @@ const MigrationsCompletedList = ({
                               {elapsedTime}
                             </ListView.InfoItem>
                           ) : null,
+                          !denied && mostRecentRequest.fulfilled_on ? (
+                            <ListView.InfoItem key={`${plan.id}-completed`} style={{ textAlign: 'left' }}>
+                              <Icon type="fa" name="clock-o" />
+                              {__('Completed:')}
+                              <br />
+                              {formatDateTime(mostRecentRequest.fulfilled_on)}
+                            </ListView.InfoItem>
+                          ) : null,
                           migrationScheduled && !staleMigrationSchedule && !migrationStarting ? (
                             <ListView.InfoItem key={`${plan.id}-scheduledTime`} style={{ textAlign: 'left' }}>
                               <Icon type="fa" name="clock-o" />

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
@@ -50,7 +50,7 @@ const MigrationsCompletedList = ({
           <ListViewToolbar
             filterTypes={MIGRATIONS_FILTER_TYPES}
             sortFields={!archived ? MIGRATIONS_COMPLETED_SORT_FIELDS : MIGRATIONS_ARCHIVED_SORT_FIELDS}
-            defaultSortTypeIndex={!archived ? 1 : 0}
+            defaultSortTypeIndex={1}
             listItems={finishedTransformationPlans}
           >
             {({

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
@@ -11,11 +11,13 @@ import {
   MIGRATIONS_FILTER_TYPES,
   MIGRATIONS_ARCHIVED_SORT_FIELDS
 } from './MigrationsConstants';
-import ScheduleMigrationButtons from './ScheduleMigrationButtons';
+import ScheduleMigrationButton from './ScheduleMigrationButton';
+import EditScheduleMenuItems from './EditScheduleMenuItems';
 import ScheduleMigrationModal from '../ScheduleMigrationModal/ScheduleMigrationModal';
 import { formatDateTime } from '../../../../../../components/dates/MomentDate';
 import DeleteMigrationMenuItem from './DeleteMigrationMenuItem';
 import StopPropagationOnClick from '../../../common/StopPropagationOnClick';
+import Visibility from '../../../common/Visibility';
 import getPlanScheduleInfo from './helpers/getPlanScheduleInfo';
 
 const MigrationsCompletedList = ({
@@ -168,23 +170,6 @@ const MigrationsCompletedList = ({
 
                     const isMissingMapping = !plan.infraMappingName;
 
-                    const scheduleButtons = (
-                      <ScheduleMigrationButtons
-                        showConfirmModalAction={showConfirmModalAction}
-                        hideConfirmModalAction={hideConfirmModalAction}
-                        loading={loading}
-                        toggleScheduleMigrationModal={toggleScheduleMigrationModal}
-                        scheduleMigration={scheduleMigration}
-                        fetchTransformationPlansAction={fetchTransformationPlansAction}
-                        fetchTransformationPlansUrl={fetchTransformationPlansUrl}
-                        plan={plan}
-                        isMissingMapping={isMissingMapping}
-                        migrationScheduled={migrationScheduled}
-                        migrationStarting={migrationStarting}
-                        showInitialScheduleButton={showInitialScheduleButton}
-                      />
-                    );
-
                     const showScheduledTime = migrationScheduled && !staleMigrationSchedule && !migrationStarting;
 
                     return (
@@ -270,22 +255,28 @@ const MigrationsCompletedList = ({
                           )
                         ]}
                         actions={
+                          // Visibility helper is used instead of conditional rendering
+                          // so hidden buttons still take up space and the list rows stay aligned
                           <div>
-                            {!archived &&
-                              (failed || denied) && (
-                                <React.Fragment>
-                                  {showInitialScheduleButton && scheduleButtons}
-                                  <Button
-                                    onClick={e => {
-                                      e.stopPropagation();
-                                      retryClick(plan.href, plan.id);
-                                    }}
-                                    disabled={isMissingMapping || loading === plan.href || migrationStarting}
-                                  >
-                                    {__('Retry')}
-                                  </Button>
-                                </React.Fragment>
-                              )}
+                            <Visibility hidden={archived || !(failed || denied)}>
+                              <Visibility hidden={!showInitialScheduleButton}>
+                                <ScheduleMigrationButton
+                                  loading={loading}
+                                  toggleScheduleMigrationModal={toggleScheduleMigrationModal}
+                                  plan={plan}
+                                  isMissingMapping={isMissingMapping}
+                                />
+                              </Visibility>
+                              <Button
+                                onClick={e => {
+                                  e.stopPropagation();
+                                  retryClick(plan.href, plan.id);
+                                }}
+                                disabled={isMissingMapping || loading === plan.href || migrationStarting}
+                              >
+                                {__('Retry')}
+                              </Button>
+                            </Visibility>
                             <StopPropagationOnClick>
                               <DropdownKebab id={`${plan.id}-kebab`} pullRight>
                                 {!archived && (
@@ -321,7 +312,21 @@ const MigrationsCompletedList = ({
                                   fetchTransformationMappingsAction={fetchTransformationMappingsAction}
                                   fetchTransformationMappingsUrl={fetchTransformationMappingsUrl}
                                 />
-                                {!showInitialScheduleButton && scheduleButtons}
+                                {!showInitialScheduleButton && (
+                                  <EditScheduleMenuItems
+                                    showConfirmModalAction={showConfirmModalAction}
+                                    hideConfirmModalAction={hideConfirmModalAction}
+                                    loading={loading}
+                                    toggleScheduleMigrationModal={toggleScheduleMigrationModal}
+                                    scheduleMigration={scheduleMigration}
+                                    fetchTransformationPlansAction={fetchTransformationPlansAction}
+                                    fetchTransformationPlansUrl={fetchTransformationPlansUrl}
+                                    plan={plan}
+                                    isMissingMapping={isMissingMapping}
+                                    migrationScheduled={migrationScheduled}
+                                    migrationStarting={migrationStarting}
+                                  />
+                                )}
                               </DropdownKebab>
                             </StopPropagationOnClick>
                           </div>

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
@@ -185,6 +185,8 @@ const MigrationsCompletedList = ({
                       />
                     );
 
+                    const showScheduledTime = migrationScheduled && !staleMigrationSchedule && !migrationStarting;
+
                     return (
                       <ListView.Item
                         stacked
@@ -245,7 +247,7 @@ const MigrationsCompletedList = ({
                               {elapsedTime}
                             </ListView.InfoItem>
                           ) : null,
-                          !denied && mostRecentRequest.fulfilled_on ? (
+                          !denied && !showScheduledTime && mostRecentRequest.fulfilled_on ? (
                             <ListView.InfoItem key={`${plan.id}-completed`} style={{ textAlign: 'left' }}>
                               <Icon type="fa" name="clock-o" />
                               {__('Completed:')}
@@ -253,7 +255,7 @@ const MigrationsCompletedList = ({
                               {formatDateTime(mostRecentRequest.fulfilled_on)}
                             </ListView.InfoItem>
                           ) : null,
-                          migrationScheduled && !staleMigrationSchedule && !migrationStarting ? (
+                          showScheduledTime ? (
                             <ListView.InfoItem key={`${plan.id}-scheduledTime`} style={{ textAlign: 'left' }}>
                               <Icon type="fa" name="clock-o" />
                               {__('Migration scheduled')}

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsConstants.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsConstants.js
@@ -15,7 +15,7 @@ export const MIGRATIONS_NOT_STARTED_SORT_FIELDS = [
 
 export const MIGRATIONS_ARCHIVED_SORT_FIELDS = [
   { id: 'name', title: __('Name'), isNumeric: false },
-  { id: 'requestedOn', title: __('Date Migrated'), isNumeric: false }
+  { id: 'fulfilledOn', title: __('Completed'), isNumeric: false }
 ];
 
 export const MIGRATIONS_COMPLETED_SORT_FIELDS = [

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsConstants.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsConstants.js
@@ -13,12 +13,15 @@ export const MIGRATIONS_NOT_STARTED_SORT_FIELDS = [
   { id: 'scheduleTime', title: __('Scheduled Time'), isNumeric: true }
 ];
 
-export const MIGRATIONS_COMPLETED_SORT_FIELDS = [
+export const MIGRATIONS_ARCHIVED_SORT_FIELDS = [
   { id: 'name', title: __('Name'), isNumeric: false },
-  { id: 'status', title: __('Status'), isNumeric: false }
+  { id: 'requestedOn', title: __('Date Migrated'), isNumeric: false }
 ];
 
-export const MIGRATIONS_ARCHIVED_SORT_FIELDS = [{ id: 'name', title: __('Name'), isNumeric: false }];
+export const MIGRATIONS_COMPLETED_SORT_FIELDS = [
+  ...MIGRATIONS_ARCHIVED_SORT_FIELDS,
+  { id: 'status', title: __('Status'), isNumeric: false }
+];
 
 export const MIGRATIONS_FILTER_TYPES = [
   {

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
@@ -6,8 +6,10 @@ import ShowWizardEmptyState from '../../../common/ShowWizardEmptyState/ShowWizar
 import ScheduleMigrationModal from '../ScheduleMigrationModal/ScheduleMigrationModal';
 import { formatDateTime } from '../../../../../../components/dates/MomentDate';
 import { MIGRATIONS_NOT_STARTED_SORT_FIELDS, MIGRATIONS_FILTER_TYPES } from './MigrationsConstants';
-import ScheduleMigrationButtons from './ScheduleMigrationButtons';
+import ScheduleMigrationButton from './ScheduleMigrationButton';
+import EditScheduleMenuItems from './EditScheduleMenuItems';
 import StopPropagationOnClick from '../../../common/StopPropagationOnClick';
+import Visibility from '../../../common/Visibility';
 import ListViewToolbar from '../../../common/ListViewToolbar/ListViewToolbar';
 import DeleteMigrationMenuItem from './DeleteMigrationMenuItem';
 import getPlanScheduleInfo from './helpers/getPlanScheduleInfo';
@@ -63,23 +65,6 @@ const MigrationsNotStartedList = ({
                     );
                     const isMissingMapping = !plan.infraMappingName;
 
-                    const scheduleButtons = (
-                      <ScheduleMigrationButtons
-                        showConfirmModalAction={showConfirmModalAction}
-                        hideConfirmModalAction={hideConfirmModalAction}
-                        loading={loading}
-                        toggleScheduleMigrationModal={toggleScheduleMigrationModal}
-                        scheduleMigration={scheduleMigration}
-                        fetchTransformationPlansAction={fetchTransformationPlansAction}
-                        fetchTransformationPlansUrl={fetchTransformationPlansUrl}
-                        plan={plan}
-                        isMissingMapping={isMissingMapping}
-                        migrationScheduled={migrationScheduled}
-                        migrationStarting={migrationStarting}
-                        showInitialScheduleButton={showInitialScheduleButton}
-                      />
-                    );
-
                     const editPlanDisabled = loading === plan.href;
 
                     return (
@@ -90,8 +75,17 @@ const MigrationsNotStartedList = ({
                           redirectTo(`/plan/${plan.id}`);
                         }}
                         actions={
+                          // Visibility helper is used instead of conditional rendering
+                          // so hidden buttons still take up space and the list rows stay aligned
                           <div>
-                            {showInitialScheduleButton && scheduleButtons}
+                            <Visibility hidden={!showInitialScheduleButton}>
+                              <ScheduleMigrationButton
+                                loading={loading}
+                                toggleScheduleMigrationModal={toggleScheduleMigrationModal}
+                                plan={plan}
+                                isMissingMapping={isMissingMapping}
+                              />
+                            </Visibility>
                             <Button
                               id={`migrate_${plan.id}`}
                               onClick={e => {
@@ -128,7 +122,21 @@ const MigrationsNotStartedList = ({
                                   fetchTransformationMappingsAction={fetchTransformationMappingsAction}
                                   fetchTransformationMappingsUrl={fetchTransformationMappingsUrl}
                                 />
-                                {!showInitialScheduleButton && scheduleButtons}
+                                {!showInitialScheduleButton && (
+                                  <EditScheduleMenuItems
+                                    showConfirmModalAction={showConfirmModalAction}
+                                    hideConfirmModalAction={hideConfirmModalAction}
+                                    loading={loading}
+                                    toggleScheduleMigrationModal={toggleScheduleMigrationModal}
+                                    scheduleMigration={scheduleMigration}
+                                    fetchTransformationPlansAction={fetchTransformationPlansAction}
+                                    fetchTransformationPlansUrl={fetchTransformationPlansUrl}
+                                    plan={plan}
+                                    isMissingMapping={isMissingMapping}
+                                    migrationScheduled={migrationScheduled}
+                                    migrationStarting={migrationStarting}
+                                  />
+                                )}
                               </DropdownKebab>
                             </StopPropagationOnClick>
                           </div>

--- a/app/javascript/react/screens/App/Overview/components/Migrations/ScheduleMigrationButton.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/ScheduleMigrationButton.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Button } from 'patternfly-react';
+
+const ScheduleMigrationButton = ({ loading, toggleScheduleMigrationModal, plan, isMissingMapping }) => (
+  <Button
+    id={`schedule_${plan.id}`}
+    onClick={e => {
+      e.stopPropagation();
+      toggleScheduleMigrationModal({ plan });
+    }}
+    disabled={isMissingMapping || loading === plan.href || plan.schedule_type}
+  >
+    {__('Schedule')}
+  </Button>
+);
+
+ScheduleMigrationButton.propTypes = {
+  loading: PropTypes.string,
+  toggleScheduleMigrationModal: PropTypes.func,
+  plan: PropTypes.object,
+  isMissingMapping: PropTypes.bool
+};
+
+export default ScheduleMigrationButton;

--- a/app/javascript/react/screens/App/Overview/helpers.js
+++ b/app/javascript/react/screens/App/Overview/helpers.js
@@ -8,6 +8,7 @@ export const planTransmutation = (plans = [], mappings = []) =>
       ...plan,
       infraMappingName: plan.transformation_mapping && plan.transformation_mapping.name,
       status: request ? request.status : null,
+      requestedOn: request ? request.created_on : null,
       configVmLength: plan.options.config_info.actions.length,
       scheduleTime: plan.schedules ? new Date(plan.schedules[0].run_at.start_time).getTime() : null
     };

--- a/app/javascript/react/screens/App/Overview/helpers.js
+++ b/app/javascript/react/screens/App/Overview/helpers.js
@@ -8,7 +8,7 @@ export const planTransmutation = (plans = [], mappings = []) =>
       ...plan,
       infraMappingName: plan.transformation_mapping && plan.transformation_mapping.name,
       status: request ? request.status : null,
-      requestedOn: request ? request.created_on : null,
+      fulfilledOn: request ? request.fulfilled_on : null,
       configVmLength: plan.options.config_info.actions.length,
       scheduleTime: plan.schedules ? new Date(plan.schedules[0].run_at.start_time).getTime() : null
     };

--- a/app/javascript/react/screens/App/Overview/overview.transformationPlans.fixtures.js
+++ b/app/javascript/react/screens/App/Overview/overview.transformationPlans.fixtures.js
@@ -20,7 +20,7 @@ export const transformationPlans = Immutable({
       created_on: '2018-05-01T12:15:00Z',
       id: '10',
       miq_requests: [],
-      requestedOn: null,
+      fulfilledOn: null,
       configVmLength: 2,
       scheduleTime: null,
       status: null
@@ -72,7 +72,7 @@ export const transformationPlans = Immutable({
           process: true
         }
       ],
-      requestedOn: '2018-04-06T12:31:30Z',
+      fulfilledOn: '2018-04-06T12:31:30Z',
       configVmLength: 2,
       scheduleTime: null,
       status: 'Ok'
@@ -162,7 +162,7 @@ export const transformationPlans = Immutable({
           process: true
         }
       ],
-      requestedOn: '2018-04-06T12:31:30Z',
+      fulfilledOn: '2018-04-06T12:31:30Z',
       configVmLength: 2,
       scheduleTime: null,
       status: 'Ok'
@@ -217,7 +217,7 @@ export const transformationPlans = Immutable({
           process: true
         }
       ],
-      requestedOn: '2018-04-06T12:31:30Z',
+      fulfilledOn: '2018-04-06T12:31:30Z',
       configVmLength: 2,
       scheduleTime: null,
       status: 'Error'
@@ -272,7 +272,7 @@ export const transformationPlans = Immutable({
           process: true
         }
       ],
-      requestedOn: '2018-04-06T12:31:30Z',
+      fulfilledOn: '2018-04-06T12:31:30Z',
       configVmLength: 2,
       scheduleTime: null,
       status: 'Ok'
@@ -327,7 +327,7 @@ export const transformationPlans = Immutable({
           process: true
         }
       ],
-      requestedOn: '2018-04-06T12:31:30Z',
+      fulfilledOn: '2018-04-06T12:31:30Z',
       configVmLength: 2,
       scheduleTime: null,
       status: 'Ok'
@@ -383,7 +383,7 @@ export const transformationPlans = Immutable({
           cancelation_status: 'cancel_requested'
         }
       ],
-      requestedOn: '2018-04-06T12:31:30Z',
+      fulfilledOn: '2018-04-06T12:31:30Z',
       configVmLength: 2,
       scheduleTime: null,
       status: 'Ok'
@@ -438,7 +438,7 @@ export const transformationPlans = Immutable({
           cancelation_status: null
         }
       ],
-      requestedOn: '2018-04-06T12:31:30Z',
+      fulfilledOn: '2018-04-06T12:31:30Z',
       configVmLength: 2,
       scheduleTime: null,
       status: 'Ok'

--- a/app/javascript/react/screens/App/Overview/overview.transformationPlans.fixtures.js
+++ b/app/javascript/react/screens/App/Overview/overview.transformationPlans.fixtures.js
@@ -20,6 +20,7 @@ export const transformationPlans = Immutable({
       created_on: '2018-05-01T12:15:00Z',
       id: '10',
       miq_requests: [],
+      requestedOn: null,
       configVmLength: 2,
       scheduleTime: null,
       status: null
@@ -71,6 +72,7 @@ export const transformationPlans = Immutable({
           process: true
         }
       ],
+      requestedOn: '2018-04-06T12:31:30Z',
       configVmLength: 2,
       scheduleTime: null,
       status: 'Ok'
@@ -160,6 +162,7 @@ export const transformationPlans = Immutable({
           process: true
         }
       ],
+      requestedOn: '2018-04-06T12:31:30Z',
       configVmLength: 2,
       scheduleTime: null,
       status: 'Ok'
@@ -214,6 +217,7 @@ export const transformationPlans = Immutable({
           process: true
         }
       ],
+      requestedOn: '2018-04-06T12:31:30Z',
       configVmLength: 2,
       scheduleTime: null,
       status: 'Error'
@@ -268,6 +272,7 @@ export const transformationPlans = Immutable({
           process: true
         }
       ],
+      requestedOn: '2018-04-06T12:31:30Z',
       configVmLength: 2,
       scheduleTime: null,
       status: 'Ok'
@@ -322,6 +327,7 @@ export const transformationPlans = Immutable({
           process: true
         }
       ],
+      requestedOn: '2018-04-06T12:31:30Z',
       configVmLength: 2,
       scheduleTime: null,
       status: 'Ok'
@@ -377,6 +383,7 @@ export const transformationPlans = Immutable({
           cancelation_status: 'cancel_requested'
         }
       ],
+      requestedOn: '2018-04-06T12:31:30Z',
       configVmLength: 2,
       scheduleTime: null,
       status: 'Ok'
@@ -431,6 +438,7 @@ export const transformationPlans = Immutable({
           cancelation_status: null
         }
       ],
+      requestedOn: '2018-04-06T12:31:30Z',
       configVmLength: 2,
       scheduleTime: null,
       status: 'Ok'

--- a/app/javascript/react/screens/App/Overview/overview.transformationPlans.fixtures.js
+++ b/app/javascript/react/screens/App/Overview/overview.transformationPlans.fixtures.js
@@ -72,7 +72,7 @@ export const transformationPlans = Immutable({
           process: true
         }
       ],
-      fulfilledOn: '2018-04-06T12:31:30Z',
+      fulfilledOn: null,
       configVmLength: 2,
       scheduleTime: null,
       status: 'Ok'

--- a/app/javascript/react/screens/App/common/Visibility.js
+++ b/app/javascript/react/screens/App/common/Visibility.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { noop } from 'patternfly-react';
+
+// This component has no role on the page, and will be hidden from screen readers (role="presentation").
+// Renders the children wrapped in visibility: hidden if the condition is met.
+// Either way, the children take up space, visibility will not change the flow of the layout.
+// The onKeyUp handler and role are used to satisfy eslint-plugin-jsx-a11y.
+const Visibility = ({ children, hidden }) => (
+  <span style={{ visibility: hidden ? 'hidden' : '' }} onKeyUp={noop} role="presentation">
+    {children}
+  </span>
+);
+
+Visibility.propTypes = {
+  children: PropTypes.node,
+  hidden: PropTypes.bool
+};
+
+export default Visibility;


### PR DESCRIPTION
Closes #927.
Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1694741

This PR:
* Adds a new sort option called "Completed" to the Completed Plans and Archived Plans list views, and sets it as the default sort.
* Adds the Completed timestamp to the list view items, to the right of the elapsed time. If the plan is scheduled for future (retry) migration, the Completed timestamp is not shown, because the Completed and Scheduled timestamps would not both fit comfortably in the row.
* Overrides the width of the list view's two main sections (name/description and additional info) from 50%/50% to 25% and 75% width respectively. This is in order to make more room in the additional info for the Completed timestamp and prevent the row from wrapping in an ugly way. This applies to all 3 list views (including Not Started) for consistency.
* Adds a `Visibility` helper component which conditionally applies `visibility: hidden` CSS to its children
* Uses the `Visibility` helper instead of conditional rendering to hide action buttons in the list view that should not appear. This ensures that the `.list-view-pf-actions` element will always have the same width in each row of the list (without having to specify a static width), which fixes the issues we were having with alignment of the details in the center of the list items (this also applies to the Plans Not Started list view).
* Refactors the `ScheduleMigrationButtons` component into two separate components `ScheduleMigrationButton` and `EditScheduleMenuItems` to make it easier to apply the visibility helper to the Schedule button without messing up the kebab menu. These shouldn't have been in the same component anyway ever since we moved the Edit/Delete schedule items into the kebab menu, so this cleanup eliminates some confusing code.

# Screens

"Completed" sort option:
![Screenshot 2019-05-06 14 08 06](https://user-images.githubusercontent.com/811963/57246251-ce9eac80-700a-11e9-94fa-8670bf55ee3a.png)

"Completed" timestamps in the list:
![Screenshot 2019-05-06 14 01 05](https://user-images.githubusercontent.com/811963/57246278-deb68c00-700a-11e9-8c71-dcc804fec9c8.png)

Scheduled timestamp taking precedence over Completed timestamp:
![Screenshot 2019-05-06 14 00 43](https://user-images.githubusercontent.com/811963/57246403-276e4500-700b-11e9-9bda-f1692a3f4fe8.png)

Alignment fixed in the Not Started list view:
![Screenshot 2019-05-06 13 56 42](https://user-images.githubusercontent.com/811963/57246483-600e1e80-700b-11e9-9290-d1a43dbaec2d.png)

