### PR TITLE
[HAMMER] Change layout of throttling settings form from horizontal to vertical

### DIFF
--- a/app/javascript/react/screens/App/Settings/Settings.scss
+++ b/app/javascript/react/screens/App/Settings/Settings.scss
@@ -2,6 +2,15 @@
   margin-bottom: 25px;
 }
 
+.migration-settings h3 {
+  margin-top: 40px;
+  margin-bottom: 15px;
+}
+
+.migration-settings label.control-label {
+  margin-bottom: 0;
+}
+
 .conversion-hosts-list .list-view-pf-main-info {
   padding: 10px 0;
 }

--- a/app/javascript/react/screens/App/Settings/screens/GeneralSettings/GeneralSettings.js
+++ b/app/javascript/react/screens/App/Settings/screens/GeneralSettings/GeneralSettings.js
@@ -62,41 +62,32 @@ export class GeneralSettings extends React.Component {
     return (
       <Spinner loading={isFetchingServers || isFetchingSettings} style={{ marginTop: 15 }}>
         <div className="migration-settings">
-          <Form className="form-horizontal" style={{ padding: '0 20px' }}>
+          <Form className="form-vertical" style={{ padding: '0 20px' }}>
             <div>
               <h3>{__('Concurrent Migrations')}</h3>
             </div>
             <Form.FormGroup>
-              <Form.ControlLabel className="col-md-5">
+              <Form.ControlLabel>
                 <span className="pull-left">
                   {__('Maximum concurrent migrations per conversion host')}
                   <OverlayTrigger
                     overlay={
                       <Popover id="maximum_concurrect_migrations_per_provider_popover">
-                        {__(
-                          'For VDDK transformations the maximum concurrent migrations per conversion host is limited to 20. See the product documentation for more information.'
-                        )}
+                        {__('For VDDK transformations the maximum concurrent migrations per conversion host is limited to 20. See the product documentation for more information.') /* prettier-ignore */}
                       </Popover>
                     }
                     placement="top"
-                    trigger={['hover']}
+                    trigger="click"
                     delay={500}
-                    rootClose={false}
+                    rootClose
                   >
-                    <Icon
-                      type="pf"
-                      name="info"
-                      size="md"
-                      style={{
-                        width: 'inherit',
-                        backgroundColor: 'transparent',
-                        padding: 10
-                      }}
-                    />
+                    <Button bsStyle="link" style={{ paddingTop: 0, paddingBottom: 0 }}>
+                      <Icon type="pf" name="info" />
+                    </Button>
                   </OverlayTrigger>
                 </span>
               </Form.ControlLabel>
-              <div className="col-md-2">
+              <div style={{ width: 150 }}>
                 <Field
                   id="max_concurrent_tasks_per_host"
                   name="max_concurrent_tasks_per_host"
@@ -108,10 +99,10 @@ export class GeneralSettings extends React.Component {
               </div>
             </Form.FormGroup>
             <Form.FormGroup>
-              <Form.ControlLabel className="col-md-5">
+              <Form.ControlLabel>
                 <div className="pull-left">{__('Maximum concurrent migrations per provider')}</div>
               </Form.ControlLabel>
-              <div className="col-md-2">
+              <div style={{ width: 150 }}>
                 <Field
                   id="max_concurrent_tasks_per_ems"
                   name="max_concurrent_tasks_per_ems"
@@ -135,8 +126,9 @@ export class GeneralSettings extends React.Component {
               postfix="％"
               inputEnabledFunction={inputEnabledFunction}
               initialUncheckedValue="unlimited"
+              vertical
             />
-            <Form.FormGroup className="col-md-1 pull-left" style={{ marginTop: '40px' }}>
+            <Form.FormGroup style={{ marginTop: '40px' }}>
               <Button
                 bsStyle="primary"
                 onClick={this.onApplyClick}

--- a/app/javascript/react/screens/App/Settings/screens/GeneralSettings/__tests__/GeneralSettings.test.js
+++ b/app/javascript/react/screens/App/Settings/screens/GeneralSettings/__tests__/GeneralSettings.test.js
@@ -30,7 +30,10 @@ describe('GeneralSettings component', () => {
   it('properly calls patchSettingsAction on apply click', () => {
     const patchSettingsAction = jest.fn();
     const component = shallow(<GeneralSettings {...getBaseProps()} patchSettingsAction={patchSettingsAction} />);
-    component.find('Button').simulate('click');
+    component
+      .find('Button')
+      .find({ bsStyle: 'primary' })
+      .simulate('click');
     expect(patchSettingsAction).toBeCalledWith(servers.resources, defaultFormValues);
   });
 });

--- a/app/javascript/react/screens/App/Settings/screens/GeneralSettings/__tests__/__snapshots__/GeneralSettings.test.js.snap
+++ b/app/javascript/react/screens/App/Settings/screens/GeneralSettings/__tests__/__snapshots__/GeneralSettings.test.js.snap
@@ -18,7 +18,7 @@ exports[`GeneralSettings component renders the general settings page 1`] = `
   >
     <Form
       bsClass="form"
-      className="form-horizontal"
+      className="form-vertical"
       componentClass="form"
       horizontal={false}
       inline={false}
@@ -38,7 +38,6 @@ exports[`GeneralSettings component renders the general settings page 1`] = `
       >
         <ControlLabel
           bsClass="control-label"
-          className="col-md-5"
           srOnly={false}
         >
           <span
@@ -58,30 +57,36 @@ exports[`GeneralSettings component renders the general settings page 1`] = `
                 </Popover>
               }
               placement="top"
-              rootClose={false}
-              trigger={
-                Array [
-                  "hover",
-                ]
-              }
+              rootClose={true}
+              trigger="click"
             >
-              <Icon
-                name="info"
-                size="md"
+              <Button
+                active={false}
+                block={false}
+                bsClass="btn"
+                bsStyle="link"
+                disabled={false}
                 style={
                   Object {
-                    "backgroundColor": "transparent",
-                    "padding": 10,
-                    "width": "inherit",
+                    "paddingBottom": 0,
+                    "paddingTop": 0,
                   }
                 }
-                type="pf"
-              />
+              >
+                <Icon
+                  name="info"
+                  type="pf"
+                />
+              </Button>
             </OverlayTrigger>
           </span>
         </ControlLabel>
         <div
-          className="col-md-2"
+          style={
+            Object {
+              "width": 150,
+            }
+          }
         >
           <Field
             component={[Function]}
@@ -98,7 +103,6 @@ exports[`GeneralSettings component renders the general settings page 1`] = `
       >
         <ControlLabel
           bsClass="control-label"
-          className="col-md-5"
           srOnly={false}
         >
           <div
@@ -108,7 +112,11 @@ exports[`GeneralSettings component renders the general settings page 1`] = `
           </div>
         </ControlLabel>
         <div
-          className="col-md-2"
+          style={
+            Object {
+              "width": 150,
+            }
+          }
         >
           <Field
             component={[Function]}
@@ -137,10 +145,10 @@ exports[`GeneralSettings component renders the general settings page 1`] = `
         name="cpu_limit_per_host"
         postfix="％"
         validate={[Function]}
+        vertical={true}
       />
       <FormGroup
         bsClass="form-group"
-        className="col-md-1 pull-left"
         style={
           Object {
             "marginTop": "40px",

--- a/app/javascript/react/screens/App/common/forms/TextInputWithCheckbox.js
+++ b/app/javascript/react/screens/App/common/forms/TextInputWithCheckbox.js
@@ -11,7 +11,7 @@ class TextInputWithCheckbox extends React.Component {
   }
 
   render() {
-    const { id, label, input, postfix, initialUncheckedValue, meta } = this.props;
+    const { id, label, input, postfix, initialUncheckedValue, meta, vertical } = this.props;
 
     const onCheckboxChange = event => {
       if (event.target.checked) {
@@ -28,7 +28,7 @@ class TextInputWithCheckbox extends React.Component {
 
     return (
       <Form.FormGroup validationState={meta.error ? 'error' : undefined}>
-        <Form.ControlLabel className="col-md-5">
+        <Form.ControlLabel className={vertical ? '' : 'col-md-5'}>
           <div className="checkbox-inline pull-left">
             <label>
               <input
@@ -42,7 +42,7 @@ class TextInputWithCheckbox extends React.Component {
             </label>
           </div>
         </Form.ControlLabel>
-        <div className="col-md-2">
+        <div className={vertical ? '' : 'col-md-2'} style={{ width: vertical ? '150px' : 'auto' }}>
           <InputGroup>
             <FormControl type="text" name={id} id={id} readOnly={!this.state.inputEnabled} {...input} />
             <InputGroup.Addon>{postfix}</InputGroup.Addon>
@@ -64,7 +64,8 @@ TextInputWithCheckbox.propTypes = {
   postfix: PropTypes.string,
   inputEnabledFunction: PropTypes.func.isRequired,
   initialUncheckedValue: PropTypes.string,
-  meta: PropTypes.object
+  meta: PropTypes.object,
+  vertical: PropTypes.bool
 };
 
 export default TextInputWithCheckbox;


### PR DESCRIPTION
This is a hammer-specific version of https://github.com/ManageIQ/manageiq-v2v/pull/943 which had backport conflicts.

In addition to the changes from #943, I included the change to the info popover (and associated test fix) from https://github.com/ManageIQ/manageiq-v2v/pull/931, since fixing up the layout of this form would have included fixing that info popover if we hadn't already, and that was the source of the conflict. I did not include the text changes from that PR because that was the actual content of that BZ which was not approved for 5.10.4 backport.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1701376