### PR TITLE
Mapping Wizard: filter datastores to only those with storage_domain_type === 'data'

### DIFF
--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStepActions.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStepActions.js
@@ -51,17 +51,15 @@ const _filterTargetDatastores = (response, targetProvider) => {
   const { data } = response;
 
   if (data[V2V_TARGET_PROVIDER_STORAGE_KEYS[targetProvider]]) {
-    const targetDatastores = data[V2V_TARGET_PROVIDER_STORAGE_KEYS[targetProvider]].map(storage => ({
-      ...storage,
-      providerName: data.ext_management_system.name
-    }));
-    return {
-      targetDatastores
-    };
+    const targetDatastores = data[V2V_TARGET_PROVIDER_STORAGE_KEYS[targetProvider]]
+      .filter(storage => storage.storage_domain_type === 'data')
+      .map(storage => ({
+        ...storage,
+        providerName: data.ext_management_system.name
+      }));
+    return { targetDatastores };
   }
-  return {
-    targetDatastores: []
-  };
+  return { targetDatastores: [] };
 };
 
 const _getTargetDatastoresActionCreator = (url, targetProvider) => dispatch =>

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardDatastoresStep/__tests__/MappingWizardDatastoresStepActions.test.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardDatastoresStep/__tests__/MappingWizardDatastoresStepActions.test.js
@@ -19,7 +19,7 @@ describe('fetchTargetDatastoresAction', () => {
     const targetProvider = V2V_TARGET_PROVIDERS[1].id;
     const [targetCloudTenant] = cloudTenants.resources;
 
-    test('dispatches PENDING and FULFILLED actions and adds the provider name', () => {
+    test('dispatches PENDING and FULFILLED actions, adds provider name and filters to domain_type of data', () => {
       mockRequest({
         method: 'GET',
         url: '/api',
@@ -28,7 +28,16 @@ describe('fetchTargetDatastoresAction', () => {
           data: {
             ...targetCloudTenant,
             ext_management_system: { name: 'some provider' },
-            [V2V_TARGET_PROVIDER_STORAGE_KEYS[targetProvider]]: [{}]
+            [V2V_TARGET_PROVIDER_STORAGE_KEYS[targetProvider]]: [
+              {
+                mock: 'datastore',
+                storage_domain_type: 'data'
+              },
+              {
+                mock: 'datastore that should NOT be in the snapshot',
+                storage_domain_type: 'export'
+              }
+            ]
           }
         }
       });
@@ -44,7 +53,7 @@ describe('fetchTargetDatastoresAction', () => {
     const targetProvider = V2V_TARGET_PROVIDERS[0].id;
     const [targetCluster] = targetClusters.resources;
 
-    test('dispatches PENDING and FULFILLED actions and adds the provider name', () => {
+    test('dispatches PENDING and FULFILLED actions, adds provider name and filters to domain_type of data', () => {
       mockRequest({
         method: 'GET',
         url: '/api',
@@ -53,7 +62,16 @@ describe('fetchTargetDatastoresAction', () => {
           data: {
             ...targetCluster,
             ext_management_system: { name: 'some provider' },
-            [V2V_TARGET_PROVIDER_STORAGE_KEYS[targetProvider]]: [{}]
+            [V2V_TARGET_PROVIDER_STORAGE_KEYS[targetProvider]]: [
+              {
+                mock: 'datastore',
+                storage_domain_type: 'data'
+              },
+              {
+                mock: 'datastore that should NOT be in the snapshot',
+                storage_domain_type: 'export'
+              }
+            ]
           }
         }
       });

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardDatastoresStep/__tests__/__snapshots__/MappingWizardDatastoresStepActions.test.js.snap
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardDatastoresStep/__tests__/__snapshots__/MappingWizardDatastoresStepActions.test.js.snap
@@ -13,7 +13,7 @@ Array [
 ]
 `;
 
-exports[`fetchTargetDatastoresAction if the target provider is OSP dispatches PENDING and FULFILLED actions and adds the provider name 1`] = `
+exports[`fetchTargetDatastoresAction if the target provider is OSP dispatches PENDING and FULFILLED actions, adds provider name and filters to domain_type of data 1`] = `
 Array [
   Object {
     "type": "FETCH_V2V_TARGET_DATASTORES_PENDING",
@@ -22,7 +22,9 @@ Array [
     "payload": Object {
       "targetDatastores": Array [
         Object {
+          "mock": "datastore",
           "providerName": "some provider",
+          "storage_domain_type": "data",
         },
       ],
     },
@@ -31,7 +33,7 @@ Array [
 ]
 `;
 
-exports[`fetchTargetDatastoresAction if the target provider is RHV dispatches PENDING and FULFILLED actions and adds the provider name 1`] = `
+exports[`fetchTargetDatastoresAction if the target provider is RHV dispatches PENDING and FULFILLED actions, adds provider name and filters to domain_type of data 1`] = `
 Array [
   Object {
     "type": "FETCH_V2V_TARGET_DATASTORES_PENDING",
@@ -40,7 +42,9 @@ Array [
     "payload": Object {
       "targetDatastores": Array [
         Object {
+          "mock": "datastore",
           "providerName": "some provider",
+          "storage_domain_type": "data",
         },
       ],
     },


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq-v2v/issues/942.
Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1701330
Target CFME release: 5.10.5

Before:

![Screenshot 2019-05-01 16 17 24](https://user-images.githubusercontent.com/811963/57042368-78102780-6c32-11e9-92e7-3c40af14f619.png)

After (note the absence of the datastore called "Export"):

![Screenshot 2019-05-01 16 57 50](https://user-images.githubusercontent.com/811963/57042419-94ac5f80-6c32-11e9-9bde-614bdc28a4a0.png)
