### PR TITLE
Add Download Log action to conversion host list items that creates a file from context_data

### DIFF
--- a/app/javascript/react/screens/App/Settings/SettingsActions.js
+++ b/app/javascript/react/screens/App/Settings/SettingsActions.js
@@ -1,4 +1,5 @@
 import { reset } from 'redux-form';
+import { saveAs } from 'file-saver';
 import URI from 'urijs';
 import API from '../../../../common/API';
 
@@ -23,6 +24,7 @@ import {
 } from './SettingsConstants';
 import { getApiSettingsFromFormValues } from './helpers';
 import { stepIDs } from './screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardConstants';
+import { V2V_NOTIFICATION_ADD } from '../common/NotificationList/NotificationConstants';
 
 const _getServersActionCreator = url => dispatch =>
   dispatch({
@@ -152,3 +154,13 @@ export const hideConversionHostRetryModalAction = () => ({
 export const conversionHostRetryModalExitedAction = () => ({
   type: V2V_CONVERSION_HOST_RETRY_MODAL_EXITED
 });
+
+export const saveTextFileAction = ({ fileName, fileBody }) => dispatch => {
+  saveAs(new File([fileBody], fileName, { type: 'text/plain;charset=utf-8' }));
+  dispatch({
+    type: V2V_NOTIFICATION_ADD,
+    message: sprintf(__('"%s" download successful'), fileName),
+    notificationType: 'success',
+    actionEnabled: false
+  });
+};

--- a/app/javascript/react/screens/App/Settings/helpers.js
+++ b/app/javascript/react/screens/App/Settings/helpers.js
@@ -92,6 +92,21 @@ export const getCombinedConversionHostListItems = (conversionHosts, tasksWithMet
   return [...activeEnableTasks, ...conversionHostsWithTasks];
 };
 
+export const getConversionHostTaskLogFile = task => {
+  const {
+    meta: { resourceName, operation },
+    context_data: { conversion_host_enable, conversion_host_check, conversion_host_disable }
+  } = task;
+  const fileName = `${resourceName}-${operation}.log`;
+  if (task.meta.operation === 'enable') {
+    return { fileName, fileBody: [conversion_host_enable, conversion_host_check].join('\n\n') };
+  }
+  if (task.meta.operation === 'disable') {
+    return { fileName, fileBody: conversion_host_disable };
+  }
+  return null;
+};
+
 export const getConversionHostSshKeyInfoMessage = selectedProviderType => {
   if (selectedProviderType === RHV) {
     return __('RHV-M deploys a common SSH public key on all hosts when configuring them. This allows commands and playbooks to be run from RHV-M. The associated private key is in the file /etc/pki/ovirt-engine/keys/engine_id_rsa on RHV-M.'); // prettier-ignore

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/ConversionHostsSettings.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/ConversionHostsSettings.js
@@ -81,7 +81,8 @@ class ConversionHostsSettings extends React.Component {
       isPostingConversionHosts,
       setConversionHostTaskToRetryAction,
       showConversionHostRetryModalAction,
-      postConversionHostsUrl
+      postConversionHostsUrl,
+      saveTextFileAction
     } = this.props;
 
     const { hasMadeInitialFetch } = this.state;
@@ -137,6 +138,7 @@ class ConversionHostsSettings extends React.Component {
                 setConversionHostTaskToRetryAction={setConversionHostTaskToRetryAction}
                 showConversionHostRetryModalAction={showConversionHostRetryModalAction}
                 postConversionHostsUrl={postConversionHostsUrl}
+                saveTextFileAction={saveTextFileAction}
               />
             )}
             {conversionHostWizardMounted && <ConversionHostWizard />}
@@ -171,7 +173,8 @@ ConversionHostsSettings.propTypes = {
   isPostingConversionHosts: PropTypes.bool,
   setConversionHostTaskToRetryAction: PropTypes.func,
   showConversionHostRetryModalAction: PropTypes.func,
-  postConversionHostsUrl: PropTypes.string
+  postConversionHostsUrl: PropTypes.string,
+  saveTextFileAction: PropTypes.func
 };
 
 ConversionHostsSettings.defaultProps = {
@@ -179,7 +182,7 @@ ConversionHostsSettings.defaultProps = {
   fetchProvidersUrl: FETCH_V2V_PROVIDERS_URL,
   fetchConversionHostsUrl: '/api/conversion_hosts?attributes=resource&expand=resources',
   fetchConversionHostTasksUrl:
-    '/api/tasks?expand=resources&attributes=id,name,state,status,message,started_on,updated_on,pct_complete&filter[]=name="%25Configuring a conversion_host%25"&sort_by=updated_on&sort_order=descending',
+    '/api/tasks?expand=resources&attributes=id,name,state,status,message,started_on,updated_on,pct_complete,context_data&filter[]=name="%25Configuring a conversion_host%25"&sort_by=updated_on&sort_order=descending',
   postConversionHostsUrl: '/api/conversion_hosts'
 };
 

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostsList.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostsList.js
@@ -20,7 +20,8 @@ const ConversionHostsList = ({
   isPostingConversionHosts,
   setConversionHostTaskToRetryAction,
   showConversionHostRetryModalAction,
-  postConversionHostsUrl
+  postConversionHostsUrl,
+  saveTextFileAction
 }) => (
   <React.Fragment>
     <ListViewToolbar
@@ -58,6 +59,7 @@ const ConversionHostsList = ({
                     setConversionHostTaskToRetryAction={setConversionHostTaskToRetryAction}
                     showConversionHostRetryModalAction={showConversionHostRetryModalAction}
                     isPostingConversionHosts={isPostingConversionHosts}
+                    saveTextFileAction={saveTextFileAction}
                   />
                 );
               })}
@@ -96,7 +98,8 @@ ConversionHostsList.propTypes = {
   isPostingConversionHosts: PropTypes.bool,
   setConversionHostTaskToRetryAction: PropTypes.func,
   showConversionHostRetryModalAction: PropTypes.func,
-  postConversionHostsUrl: PropTypes.string
+  postConversionHostsUrl: PropTypes.string,
+  saveTextFileAction: PropTypes.func
 };
 
 ConversionHostsList.sortFields = [

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostsListItem.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostsListItem.js
@@ -6,8 +6,8 @@ import ConversionHostRemoveButton from './ConversionHostRemoveButton';
 import ConversionHostRetryButton from './ConversionHostRetryButton';
 import StopPropagationOnClick from '../../../../common/StopPropagationOnClick';
 import { FINISHED, ERROR, ENABLE, DISABLE } from '../ConversionHostsSettingsConstants';
+import { getConversionHostTaskLogFile } from '../../../helpers';
 
-const downloadLogSupported = false; // TODO remove me when the Download Log action works
 const removeFailedTaskSupported = false; // TODO remove me when the Remove button works
 
 const ConversionHostsListItem = ({
@@ -17,7 +17,8 @@ const ConversionHostsListItem = ({
   showConversionHostDeleteModalAction,
   setConversionHostTaskToRetryAction,
   showConversionHostRetryModalAction,
-  isPostingConversionHosts
+  isPostingConversionHosts,
+  saveTextFileAction
 }) => {
   let mostRecentTask = listItem;
   if (!isTask) {
@@ -102,7 +103,15 @@ const ConversionHostsListItem = ({
   const kebabMenu = mostRecentTask ? (
     <StopPropagationOnClick>
       <DropdownKebab id={`task-kebab-${mostRecentTask.id}`} pullRight>
-        <MenuItem disabled={mostRecentTask.state !== FINISHED}>{__('Download Log') /* TODO */}</MenuItem>
+        <MenuItem
+          disabled={mostRecentTask.state !== FINISHED}
+          onClick={() => {
+            const file = getConversionHostTaskLogFile(mostRecentTask);
+            if (file) saveTextFileAction(file);
+          }}
+        >
+          {__('Download Log')}
+        </MenuItem>
       </DropdownKebab>
     </StopPropagationOnClick>
   ) : null;
@@ -121,7 +130,7 @@ const ConversionHostsListItem = ({
       actions={
         <div className="conversion-hosts-list-actions">
           {actionButtons}
-          {downloadLogSupported && kebabMenu}
+          {kebabMenu}
         </div>
       }
     />
@@ -135,7 +144,8 @@ ConversionHostsListItem.propTypes = {
   showConversionHostDeleteModalAction: PropTypes.func,
   setConversionHostTaskToRetryAction: PropTypes.func,
   showConversionHostRetryModalAction: PropTypes.func,
-  isPostingConversionHosts: PropTypes.bool
+  isPostingConversionHosts: PropTypes.bool,
+  saveTextFileAction: PropTypes.func
 };
 
 export default ConversionHostsListItem;

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/index.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/index.js
@@ -11,7 +11,8 @@ import {
   showConversionHostDeleteModalAction,
   hideConversionHostDeleteModalAction,
   setConversionHostTaskToRetryAction,
-  showConversionHostRetryModalAction
+  showConversionHostRetryModalAction,
+  saveTextFileAction
 } from '../../SettingsActions';
 
 import { getCombinedConversionHostListItems } from '../../helpers';
@@ -63,7 +64,8 @@ export default connect(
     showConversionHostDeleteModalAction,
     hideConversionHostDeleteModalAction,
     setConversionHostTaskToRetryAction,
-    showConversionHostRetryModalAction
+    showConversionHostRetryModalAction,
+    saveTextFileAction
   },
   mergeProps
 )(ConversionHostsSettings);


### PR DESCRIPTION
Closes https://github.com/ManageIQ/manageiq-v2v/issues/902.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1705619
Targeted for release in CFME 5.10.5.

This PR adds a kebab menu to the list items in the Conversion Hosts settings page list view, with a single item "Download Log":
![Screenshot 2019-05-02 15 57 14](https://user-images.githubusercontent.com/811963/57103173-15cb2b80-6cf3-11e9-8d02-be28e58cd638.png)

When this is clicked, a file is constructed from the `context_data` property of the task.

For enable tasks, `context_data.conversion_host_enable` and `context_data.conversion_host_check` are concatenated together with two line breaks between them and downloaded as one file. For disable tasks, `context_data.conversion_host_disable` is downloaded as a file.

![Screenshot 2019-05-02 15 57 20](https://user-images.githubusercontent.com/811963/57103275-532fb900-6cf3-11e9-86d6-450004c09e88.png)
