### PR TITLE
[BZ#1701330] Only apply storage_domain_type filter on RHV datastores, not OSP.

### DIFF
--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStepActions.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStepActions.js
@@ -6,7 +6,7 @@ import {
   FETCH_V2V_TARGET_DATASTORES,
   QUERY_ATTRIBUTES
 } from './MappingWizardDatastoresStepConstants';
-import { V2V_TARGET_PROVIDER_STORAGE_KEYS } from '../../MappingWizardConstants';
+import { V2V_TARGET_PROVIDER_STORAGE_KEYS, RHV } from '../../MappingWizardConstants';
 
 const _filterSourceDatastores = response => {
   const { data } = response;
@@ -52,7 +52,7 @@ const _filterTargetDatastores = (response, targetProvider) => {
 
   if (data[V2V_TARGET_PROVIDER_STORAGE_KEYS[targetProvider]]) {
     const targetDatastores = data[V2V_TARGET_PROVIDER_STORAGE_KEYS[targetProvider]]
-      .filter(storage => storage.storage_domain_type === 'data')
+      .filter(storage => (targetProvider === RHV ? storage.storage_domain_type === 'data' : true))
       .map(storage => ({
         ...storage,
         providerName: data.ext_management_system.name

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardDatastoresStep/__tests__/MappingWizardDatastoresStepActions.test.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardDatastoresStep/__tests__/MappingWizardDatastoresStepActions.test.js
@@ -19,7 +19,7 @@ describe('fetchTargetDatastoresAction', () => {
     const targetProvider = V2V_TARGET_PROVIDERS[1].id;
     const [targetCloudTenant] = cloudTenants.resources;
 
-    test('dispatches PENDING and FULFILLED actions, adds provider name and filters to domain_type of data', () => {
+    test('dispatches PENDING and FULFILLED actions, adds provider name and does not filter by domain_type', () => {
       mockRequest({
         method: 'GET',
         url: '/api',
@@ -30,12 +30,10 @@ describe('fetchTargetDatastoresAction', () => {
             ext_management_system: { name: 'some provider' },
             [V2V_TARGET_PROVIDER_STORAGE_KEYS[targetProvider]]: [
               {
-                mock: 'datastore',
-                storage_domain_type: 'data'
+                mock: 'datastore'
               },
               {
-                mock: 'datastore that should NOT be in the snapshot',
-                storage_domain_type: 'export'
+                mock: 'datastore2'
               }
             ]
           }

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardDatastoresStep/__tests__/__snapshots__/MappingWizardDatastoresStepActions.test.js.snap
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardDatastoresStep/__tests__/__snapshots__/MappingWizardDatastoresStepActions.test.js.snap
@@ -13,7 +13,7 @@ Array [
 ]
 `;
 
-exports[`fetchTargetDatastoresAction if the target provider is OSP dispatches PENDING and FULFILLED actions, adds provider name and filters to domain_type of data 1`] = `
+exports[`fetchTargetDatastoresAction if the target provider is OSP dispatches PENDING and FULFILLED actions, adds provider name and does not filter by domain_type 1`] = `
 Array [
   Object {
     "type": "FETCH_V2V_TARGET_DATASTORES_PENDING",
@@ -24,7 +24,10 @@ Array [
         Object {
           "mock": "datastore",
           "providerName": "some provider",
-          "storage_domain_type": "data",
+        },
+        Object {
+          "mock": "datastore2",
+          "providerName": "some provider",
         },
       ],
     },


### PR DESCRIPTION
Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1701330
Target CFME release: 5.10.5

This PR fixes a bug I introduced in https://github.com/ManageIQ/manageiq-v2v/pull/947. That PR should only have applied its `storage_domain_type === 'data'` filter for RHV datastores, because OSP datastores do not have that property. As a result, the Mapping Wizard stopped showing any results for target datastores when mapping to an OSP target provider.

I discovered this when going over my 5.10.5 BZs... this PR corrects that mistake before we release it!