### PR TITLE
[#951] [BZ#1708359] Add OpenStack Trusted CA Certificates field to Conversion Host Wizard

### DIFF
--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/ConversionHostWizardAuthenticationStep.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/ConversionHostWizardAuthenticationStep.js
@@ -7,7 +7,7 @@ import { stepIDs, VDDK, SSH } from '../ConversionHostWizardConstants';
 import { FormField } from '../../../../../../common/forms/FormField';
 import { OPENSTACK } from '../../../../../../../../../common/constants';
 import { BootstrapSelect } from '../../../../../../common/forms/BootstrapSelect';
-import SshKeyField from '../../../../../../common/forms/SshKeyField';
+import TextFileField from '../../../../../../common/forms/TextFileField';
 import { getConversionHostSshKeyInfoMessage } from '../../../../../helpers';
 
 const requiredWithMessage = required({ msg: __('This field is required') });
@@ -29,10 +29,11 @@ const ConversionHostWizardAuthenticationStep = ({ selectedProviderType, selected
           validate={[requiredWithMessage]}
         />
       )}
-      <SshKeyField
+      <TextFileField
         {...fieldBaseProps}
         name="conversionHostSshKey"
         label={__('Conversion Host SSH private key')}
+        help={__('Upload your SSH key file or paste its contents below.')}
         controlId="host-ssh-key-input"
         info={getConversionHostSshKeyInfoMessage(selectedProviderType)}
       />
@@ -50,10 +51,11 @@ const ConversionHostWizardAuthenticationStep = ({ selectedProviderType, selected
         style={{ marginTop: 25 }}
       />
       {selectedTransformationMethod === SSH && (
-        <SshKeyField
+        <TextFileField
           {...fieldBaseProps}
           name="vmwareSshKey"
           label={__('VMware hypervisors SSH private key')}
+          help={__('Upload your SSH key file or paste its contents below.')}
           controlId="vmware-ssh-key-input"
         />
       )}

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/ConversionHostWizardAuthenticationStep.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/ConversionHostWizardAuthenticationStep.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { reduxForm, Field } from 'redux-form';
 import { required } from 'redux-form-validators';
-import { Form } from 'patternfly-react';
+import { Form, Switch } from 'patternfly-react';
 import { stepIDs, VDDK, SSH } from '../ConversionHostWizardConstants';
 import { FormField } from '../../../../../../common/forms/FormField';
 import { OPENSTACK } from '../../../../../../../../../common/constants';
@@ -12,7 +12,11 @@ import { getConversionHostSshKeyInfoMessage } from '../../../../../helpers';
 
 const requiredWithMessage = required({ msg: __('This field is required') });
 
-const ConversionHostWizardAuthenticationStep = ({ selectedProviderType, selectedTransformationMethod }) => {
+const ConversionHostWizardAuthenticationStep = ({
+  selectedProviderType,
+  selectedTransformationMethod,
+  verifyOpenstackCerts
+}) => {
   const fieldBaseProps = { labelWidth: 4, controlWidth: 7 };
 
   return (
@@ -84,6 +88,39 @@ const ConversionHostWizardAuthenticationStep = ({ selectedProviderType, selected
           )}
         </Field>
       )}
+      {selectedProviderType === OPENSTACK && (
+        <React.Fragment>
+          <Field
+            {...fieldBaseProps}
+            name="verifyOpenstackCerts"
+            label={__('Verify TLS Certificates for OpenStack')}
+            component={FormField}
+            controlId="verify-openstack-certs"
+            style={{ marginTop: 25 }}
+          >
+            {({ input: { value, onChange } }) => (
+              <Switch
+                bsSize="normal"
+                id="verify-openstack-certs-switch"
+                onText={__('Yes')}
+                offText={__('No')}
+                defaultValue={false}
+                value={value}
+                onChange={(element, state) => onChange(state)}
+              />
+            )}
+          </Field>
+          {verifyOpenstackCerts && (
+            <TextFileField
+              {...fieldBaseProps}
+              name="openstackCaCerts"
+              label={__('OpenStack Trusted CA Certificates')}
+              help={__('Upload your certificates file, in PEM format, or paste its contents below.')}
+              controlId="openstack-ca-certs-input"
+            />
+          )}
+        </React.Fragment>
+      )}
     </Form>
   );
 };
@@ -91,6 +128,7 @@ const ConversionHostWizardAuthenticationStep = ({ selectedProviderType, selected
 ConversionHostWizardAuthenticationStep.propTypes = {
   selectedProviderType: PropTypes.string,
   selectedTransformationMethod: PropTypes.string,
+  verifyOpenstackCerts: PropTypes.bool,
   unregisterFieldAction: PropTypes.func
 };
 
@@ -101,6 +139,8 @@ export default reduxForm({
   initialValues: {
     openstackUser: 'cloud-user',
     conversionHostSshKey: { filename: '', body: '' },
-    vmwareSshKey: { filename: '', body: '' }
+    vmwareSshKey: { filename: '', body: '' },
+    openstackCaCerts: { filename: '', body: '' },
+    verifyOpenstackCerts: false
   }
 })(ConversionHostWizardAuthenticationStep);

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/index.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/index.js
@@ -10,7 +10,8 @@ const mapStateToProps = ({ form }) => {
   const authStepValues = authStepForm && authStepForm.values;
   return {
     selectedProviderType: locationStepValues && locationStepValues.providerType,
-    selectedTransformationMethod: authStepValues && authStepValues.transformationMethod
+    selectedTransformationMethod: authStepValues && authStepValues.transformationMethod,
+    verifyOpenstackCerts: authStepValues && authStepValues.verifyOpenstackCerts
   };
 };
 

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardResultsStep/helpers.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardResultsStep/helpers.js
@@ -13,6 +13,7 @@ export const getConfigureConversionHostPostBodies = (locationStepValues, hostsSt
       resource_id: host.id,
       conversion_host_ssh_private_key: authStepValues.conversionHostSshKey.body,
       auth_user: locationStepValues.providerType === OPENSTACK ? authStepValues.openstackUser : 'root',
+      ...(authStepValues.openstackCaCerts.body && { openstack_tls_ca_certs: authStepValues.openstackCaCerts.body }),
       ...vmwareAuthProperties
     };
   });

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/RetryConversionHostConfirmationModal/RetryConversionHostConfirmationModal.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/RetryConversionHostConfirmationModal/RetryConversionHostConfirmationModal.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { reduxForm } from 'redux-form';
 import { Button, Modal, Form, Grid } from 'patternfly-react';
 import { CONVERSION_HOST_TYPES } from '../../../../../../../../common/constants';
-import SshKeyField from '../../../../../common/forms/SshKeyField';
+import TextFileField from '../../../../../common/forms/TextFileField';
 import { getConversionHostSshKeyInfoMessage } from '../../../../helpers';
 
 const fieldBaseProps = { labelWidth: 4, controlWidth: 7 };
@@ -56,18 +56,20 @@ const RetryConversionHostConfirmationModal = ({
               {conversionHostTaskToRetry.name}
             </Grid.Col>
           </Form.FormGroup>
-          <SshKeyField
+          <TextFileField
             {...fieldBaseProps}
             name="conversionHostSshKey"
             label={__('Conversion Host SSH private key')}
+            help={__('Upload your SSH key file or paste its contents below.')}
             controlId="host-ssh-key-input"
             info={getConversionHostSshKeyInfoMessage(selectedProviderType)}
           />
           {isUsingSshTransformation && (
-            <SshKeyField
+            <TextFileField
               {...fieldBaseProps}
               name="vmwareSshKey"
               label={__('VMware hypervisors SSH private key')}
+              help={__('Upload your SSH key file or paste its contents below.')}
               controlId="vmware-ssh-key-input"
               style={{ marginTop: 25 }}
             />

--- a/app/javascript/react/screens/App/common/forms/TextFileField.js
+++ b/app/javascript/react/screens/App/common/forms/TextFileField.js
@@ -8,10 +8,10 @@ import { FormField } from './FormField';
 const requiredWithMessage = required({ msg: __('This field is required') });
 const bodyIsRequired = value => requiredWithMessage(value.body);
 
-const TextFileField = ({ help, ...props }) => (
+const TextFileField = ({ help, hideBody, ...props }) => (
   <Field component={FormField} required validate={[bodyIsRequired]} {...props}>
     {({ input: { value, onChange, onBlur } }) => (
-      <TextFileInput help={help} value={value} onChange={onChange} onBlur={onBlur} />
+      <TextFileInput help={help} hideBody={hideBody} value={value} onChange={onChange} onBlur={onBlur} />
     )}
   </Field>
 );
@@ -20,7 +20,13 @@ TextFileField.propTypes = {
   name: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
   help: PropTypes.string,
+  hideBody: PropTypes.bool,
   controlId: PropTypes.string.isRequired
+};
+
+TextFileField.defaultProps = {
+  help: null,
+  hideBody: false
 };
 
 export default TextFileField;

--- a/app/javascript/react/screens/App/common/forms/TextFileField.js
+++ b/app/javascript/react/screens/App/common/forms/TextFileField.js
@@ -8,23 +8,19 @@ import { FormField } from './FormField';
 const requiredWithMessage = required({ msg: __('This field is required') });
 const bodyIsRequired = value => requiredWithMessage(value.body);
 
-const SshKeyField = props => (
+const TextFileField = ({ help, ...props }) => (
   <Field component={FormField} required validate={[bodyIsRequired]} {...props}>
     {({ input: { value, onChange, onBlur } }) => (
-      <TextFileInput
-        help={__('Upload your SSH key file or paste its contents below.')}
-        value={value}
-        onChange={onChange}
-        onBlur={onBlur}
-      />
+      <TextFileInput help={help} value={value} onChange={onChange} onBlur={onBlur} />
     )}
   </Field>
 );
 
-SshKeyField.propTypes = {
+TextFileField.propTypes = {
   name: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
+  help: PropTypes.string,
   controlId: PropTypes.string.isRequired
 };
 
-export default SshKeyField;
+export default TextFileField;

--- a/app/javascript/react/screens/App/common/forms/TextFileInput/TextFileInput.js
+++ b/app/javascript/react/screens/App/common/forms/TextFileInput/TextFileInput.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Form, Button } from 'patternfly-react';
+import { Form, Button, noop } from 'patternfly-react';
 import Dropzone from 'react-dropzone';
 import classNames from 'classnames';
 
-const TextFileInput = ({ value: { filename, body }, onChange, onBlur, help }) => {
+const TextFileInput = ({ value: { filename, body }, onChange, onBlur, help, hideBody }) => {
   const readFile = fileHandle => {
     const reader = new FileReader();
     reader.onload = () => onChange({ filename: fileHandle.name, body: reader.result });
@@ -37,14 +37,16 @@ const TextFileInput = ({ value: { filename, body }, onChange, onBlur, help }) =>
             </Form.InputGroup.Button>
           </Form.InputGroup>
           {help && <Form.HelpBlock>{help}</Form.HelpBlock>}
-          <Form.FormControl
-            className="text-file-input__textarea"
-            componentClass="textarea"
-            value={body}
-            onChange={event => onChange({ filename: '', body: event.target.value })}
-            onBlur={() => onBlur()}
-            disabled={filename !== ''}
-          />
+          {!hideBody && (
+            <Form.FormControl
+              className="text-file-input__textarea"
+              componentClass="textarea"
+              value={body}
+              onChange={event => onChange({ filename: '', body: event.target.value })}
+              onBlur={() => onBlur()}
+              disabled={filename !== ''}
+            />
+          )}
         </div>
       )}
     </Dropzone>
@@ -57,8 +59,17 @@ TextFileInput.propTypes = {
     filename: PropTypes.string,
     body: PropTypes.string
   }),
+  hideBody: PropTypes.bool,
   onChange: PropTypes.func,
   onBlur: PropTypes.func
+};
+
+TextFileInput.defaultProps = {
+  help: null,
+  value: { filename: '', body: '' },
+  hideBody: false,
+  onChange: noop,
+  onBlur: noop
 };
 
 export default TextFileInput;

--- a/app/javascript/react/screens/App/common/forms/TextFileInput/TextFileInput.scss
+++ b/app/javascript/react/screens/App/common/forms/TextFileInput/TextFileInput.scss
@@ -3,6 +3,6 @@
 }
 
 .text-file-input__textarea {
-  min-height: 175px;
+  min-height: 125px;
   width: 100%;
 }


### PR DESCRIPTION
Closes #951.
Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1708359
Depends on: ManageIQ/manageiq#18762

In the Conversion Host Wizard, on the Authentication step, this PR:
* adds the new toggle "Verify TLS Certificates for OpenStack", which appears if the user has selected an OpenStack provider in the Location step of the wizard
* adds the new file upload/paste field "OpenStack Trusted CA Certificates" which appears if the user has turned on the new toggle
* shrinks the height of the file upload/paste fields in this step of the wizard from 175px to 125px to make more room for the new fields
* passes the value, if present, of the certificates field to the API as a property called `openstack_tls_ca_certs`

# Screens

When the user first arrives at the wizard's Authentication step, the toggle is visible at the bottom:

<img width="899" alt="Screenshot 2019-05-14 16 37 56" src="https://user-images.githubusercontent.com/811963/57731716-4dc65d00-7669-11e9-977b-56263d0e5029.png">

As the user fills in the earlier fields, the toggle may be pushed off-screen. After scrolling down and turning on the toggle, the certificates field appears:

<img width="901" alt="Screenshot 2019-05-14 16 38 40" src="https://user-images.githubusercontent.com/811963/57731808-90883500-7669-11e9-890c-01abe7762110.png">

On a larger screen, all 3 file upload/paste fields are visible:

![Screenshot 2019-05-14 16 35 02](https://user-images.githubusercontent.com/811963/57731851-ab5aa980-7669-11e9-8f09-c06c40ef8492.png)

