### PR TITLE
[#954] [BZ#1708365] Mapping Wizard: Clusters Step - hide RSA key warning if all conversion hosts have authentications

### DIFF
--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardClustersStep/MappingWizardClustersStep.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardClustersStep/MappingWizardClustersStep.js
@@ -56,6 +56,7 @@ class MappingWizardClustersStep extends React.Component {
       isRejectedTargetClusters,
       targetProvider,
       rhvConversionHosts,
+      ospConversionHosts,
       providers,
       isQueryingProviders
     } = this.props;
@@ -87,6 +88,7 @@ class MappingWizardClustersStep extends React.Component {
         isFetchingTargetClusters={isFetchingTargetClusters}
         targetProvider={targetProvider}
         rhvConversionHosts={rhvConversionHosts}
+        ospConversionHosts={ospConversionHosts}
         providers={providers}
         isQueryingProviders={isQueryingProviders}
       />

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardClustersStep/components/ClustersStepForm/ClustersStepForm.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardClustersStep/components/ClustersStepForm/ClustersStepForm.js
@@ -7,7 +7,7 @@ import DualPaneMapperList from '../../../DualPaneMapper/DualPaneMapperList';
 import DualPaneMapperCount from '../../../DualPaneMapper/DualPaneMapperCount';
 import DualPaneMapperListItem from '../../../DualPaneMapper/DualPaneMapperListItem';
 import ClustersStepTreeView from '../ClustersStepTreeView';
-import { createNewMapping, updateMapping, providerHasSshKeyPair } from './helpers';
+import { createNewMapping, updateMapping, providerHasSshKeyPair, everyConversionHostHasPrivateKey } from './helpers';
 import { sourceClustersFilter } from '../../MappingWizardClustersStepSelectors';
 import { TARGET_WARNING_MESSAGES } from '../../MappingWizardClustersStepConstants';
 import { OPENSTACK, RHV } from '../../../../MappingWizardConstants';
@@ -125,6 +125,7 @@ class ClustersStepForm extends React.Component {
       input,
       targetProvider,
       rhvConversionHosts,
+      ospConversionHosts,
       providers,
       isQueryingProviders
     } = this.props;
@@ -192,7 +193,11 @@ class ClustersStepForm extends React.Component {
                   );
                   showWarning = conversionHostsInCluster.length === 0;
                 } else if (targetProvider === OPENSTACK) {
-                  showWarning = providers.length && !isQueryingProviders && !providerHasSshKeyPair(item, providers);
+                  showWarning =
+                    providers.length &&
+                    !isQueryingProviders &&
+                    !providerHasSshKeyPair(item, providers) &&
+                    !everyConversionHostHasPrivateKey(ospConversionHosts);
                 }
 
                 return (
@@ -238,6 +243,7 @@ ClustersStepForm.propTypes = {
   isFetchingTargetClusters: PropTypes.bool,
   targetProvider: PropTypes.string,
   rhvConversionHosts: PropTypes.array,
+  ospConversionHosts: PropTypes.array,
   providers: PropTypes.array,
   isQueryingProviders: PropTypes.bool
 };

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardClustersStep/components/ClustersStepForm/__tests__/helpers.test.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardClustersStep/components/ClustersStepForm/__tests__/helpers.test.js
@@ -2,7 +2,9 @@ import {
   targetClusterWithExtendedData,
   sourceClusterWithExtendedData,
   updateMapping,
-  createNewMapping
+  createNewMapping,
+  providerHasSshKeyPair,
+  everyConversionHostHasPrivateKey
 } from '../helpers';
 
 import { srcClusters, tgtClusters } from '../clustersStepForm.fixtures';
@@ -48,4 +50,61 @@ test('createNewMapping constructs a clusters step mapping', () => {
   const [sourceCluster] = srcClusters;
 
   expect(createNewMapping(targetCluster, [sourceCluster])).toMatchSnapshot();
+});
+
+describe('providerHasSshKeyPair', () => {
+  test('is correct in the true case', () => {
+    const target = { ems_id: '1' };
+    const providers = [
+      {
+        id: '1',
+        authentications: [{ authtype: 'ssh_keypair' }]
+      }
+    ];
+    expect(providerHasSshKeyPair(target, providers)).toBeTruthy();
+  });
+
+  test('is correct in the false case', () => {
+    const target = { ems_id: '1' };
+    const providers = [
+      {
+        id: '1',
+        authentications: []
+      }
+    ];
+    expect(providerHasSshKeyPair(target, providers)).toBeFalsy();
+  });
+});
+
+describe('everyConversionHostHasPrivateKey', () => {
+  test('is correct in the true case', () => {
+    const conversionHosts = [
+      {
+        mock: 'hostWithRightAuthentication',
+        authentications: [{ type: 'AuthPrivateKey', authtype: 'v2v' }]
+      },
+      {
+        mock: 'hostWithRightAndWrongAuthentications',
+        authentications: [{ type: 'foo', authtype: 'bar' }, { type: 'AuthPrivateKey', authtype: 'v2v' }]
+      }
+    ];
+    expect(everyConversionHostHasPrivateKey(conversionHosts)).toBeTruthy();
+  });
+
+  test('is correct in the false case', () => {
+    const conversionHosts = [
+      {
+        mock: 'hostWithoutAuthentications'
+      },
+      {
+        mock: 'hostWithWrongAuthentication',
+        authentications: [{ type: 'foo', authtype: 'bar' }]
+      },
+      {
+        mock: 'hostWithRightAuthentication',
+        authentications: [{ type: 'foo', authtype: 'bar' }, { type: 'AuthPrivateKey', authtype: 'v2v' }]
+      }
+    ];
+    expect(everyConversionHostHasPrivateKey(conversionHosts)).toBeFalsy();
+  });
 });

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardClustersStep/components/ClustersStepForm/helpers.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardClustersStep/components/ClustersStepForm/helpers.js
@@ -58,3 +58,10 @@ export const providerHasSshKeyPair = (target, providers) => {
     provider.authentications.some(authentication => authentication.authtype === 'ssh_keypair')
   );
 };
+
+const conversionHostHasPrivateKey = conversionHost =>
+  conversionHost.authentications &&
+  conversionHost.authentications.some(auth => auth.type === 'AuthPrivateKey' && auth.authtype === 'v2v');
+
+export const everyConversionHostHasPrivateKey = conversionHosts =>
+  conversionHosts && conversionHosts.every(conversionHostHasPrivateKey);

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardGeneralStep/MappingWizardGeneralStep.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardGeneralStep/MappingWizardGeneralStep.js
@@ -108,7 +108,7 @@ MappingWizardGeneralStep.propTypes = {
 MappingWizardGeneralStep.defaultProps = {
   targetProvider: '',
   conversionHosts: [],
-  fetchConversionHostsUrl: '/api/conversion_hosts?attributes=resource&expand=resources',
+  fetchConversionHostsUrl: '/api/conversion_hosts?attributes=resource,authentications&expand=resources',
   dispatch: noop
 };
 


### PR DESCRIPTION
Fixes #954.
Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1708365

This can be tested using the `conversion-host-enabled` database from [my collection](https://drive.google.com/open?id=1psxWLopcPUFeJCoHcnMiOgF40x2V0h3Q). That database has conversion hosts configured via the UI with an SSH key, and an OSP provider without an SSH key. In this case, on master, this warning will appear when trying to create a mapping to OpenStack:

![Screenshot 2019-05-16 15 15 43](https://user-images.githubusercontent.com/811963/57880731-7d9e6d80-77ed-11e9-9654-5015a1efe635.png)

And after this PR, it will not. The warning will still appear if the conversion host has been configured manually (the old way, directly running the playbook) without an SSH key, and there is no key in the provider.