### PR TITLE
[WIP][V2V] Move V2V-Related Models from Core to this Repo

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -1,0 +1,394 @@
+require 'resolv'
+
+class ConversionHost < ApplicationRecord
+  include NewWithTypeStiMixin
+  include AuthenticationMixin
+
+  acts_as_miq_taggable
+
+  belongs_to :resource, :polymorphic => true
+  has_many :service_template_transformation_plan_tasks, :dependent => :nullify
+  has_many :active_tasks, -> { where(:state => ['active', 'migrate']) },
+    :class_name => "ServiceTemplateTransformationPlanTask",
+    :inverse_of => :conversion_host
+
+  delegate :ext_management_system, :hostname, :ems_ref, :to => :resource, :allow_nil => true
+
+  validates :name, :presence => true
+  validates :resource, :presence => true
+
+  validates :address,
+    :uniqueness => true,
+    :format     => { :with => Resolv::AddressRegex },
+    :inclusion  => { :in => ->(conversion_host) { conversion_host.resource.ipaddresses } },
+    :unless     => ->(conversion_host) { conversion_host.address.blank? || conversion_host.resource.blank? || conversion_host.resource.ipaddresses.blank? },
+    :presence   => false
+
+  validate :resource_supports_conversion_host
+
+  before_validation :name, :default_name, :on => :create
+
+  include_concern 'Configurations'
+
+  after_create :tag_resource_as_enabled
+  after_destroy :tag_resource_as_disabled
+
+  # Use the +auth_type+ if present, or check the first associated authentication
+  # if any are directly associated with the conversion host. Otherwise, use the
+  # default check which uses the associated resource's authentications.
+  #
+  # In practice there should only be one associated authentication.
+  #
+  # Subclasses should pass provider-specific +options+, such as proxy information.
+  #
+  # This method is necessary to comply with AuthenticationMixin interface.
+  #--
+  # TODO: Use the verify_credentials_ssh method in host.rb? Move that to the
+  # AuthenticationMixin?
+  #
+  def verify_credentials(auth_type = nil, options = {})
+    if authentications.empty?
+      check_ssh_connection
+    else
+      require 'net/ssh'
+      host = hostname || ipaddress
+
+      auth = authentication_type(auth_type) || authentications.first
+
+      ssh_options = { :timeout => 10, :logger => $log, :verbose => :error }
+
+      case auth
+      when AuthUseridPassword
+        ssh_options[:auth_methods] = %w[password]
+        ssh_options[:password] = auth.password
+      when AuthPrivateKey
+        ssh_options[:auth_methods] = %w[publickey hostbased]
+        ssh_options[:key_data] = auth.auth_key
+      else
+        raise MiqException::MiqInvalidCredentialsError, _("Unknown auth type: #{auth.authtype}")
+      end
+
+      # Options from STI subclasses will override the defaults we've set above.
+      ssh_options.merge!(options)
+
+      Net::SSH.start(host, auth.userid, ssh_options) { |ssh| ssh.exec!('uname -a') }
+    end
+  rescue Net::SSH::AuthenticationFailed => err
+    raise MiqException::MiqInvalidCredentialsError, _("Incorrect credentials - %{error_message}") % {:error_message => err.message}
+  rescue Net::SSH::HostKeyMismatch => err
+    raise MiqException::MiqSshUtilHostKeyMismatch, _("Host key mismatch - %{error_message}") % {:error_message => err.message}
+  rescue Exception => err
+    raise _("Unknown error - %{error_message}") % {:error_message => err.message}
+  else
+    true
+  end
+
+  # Returns a boolean indicating whether or not the conversion host is eligible
+  # for use. To be eligible, a conversion host must have the following properties:
+  #
+  #  - A transport mechanism is configured for source (set by 3rd party).
+  #  - Credentials are set on the conversion host and the SSH connection works.
+  #  - The number of concurrent tasks has not reached the limit.
+  #
+  def eligible?
+    source_transport_method.present? && verify_credentials && check_concurrent_tasks
+  end
+
+  # Returns a boolean indicating whether or not the current number of active tasks
+  # exceeds the maximum number of allowable concurrent tasks specified in settings.
+  #
+  def check_concurrent_tasks
+    max_tasks = max_concurrent_tasks || Settings.transformation.limits.max_concurrent_tasks_per_host
+    active_tasks.size < max_tasks
+  end
+
+  # Check to see if we can connect to the conversion host using a simple 'uname -a'
+  # command on the connection. The exact nature of the connection will depend on the
+  # underlying provider.
+  #
+  def check_ssh_connection
+    connect_ssh { |ssu| ssu.shell_exec('uname -a') }
+    true
+  rescue StandardError
+    false
+  end
+
+  # If set, returns a string indicating the source transport method. This is
+  # either 'vddk' or 'ssh'. If not set, returns nil.
+  #
+  def source_transport_method
+    return 'vddk' if vddk_transport_supported?
+    return 'ssh' if ssh_transport_supported?
+  end
+
+  # Returns the associated IP address for the conversion host in the given +family+.
+  # If an address is set for the conversion host, then that address will be
+  # returned. Otherwise, it will return the IP address of the associated resource.
+  #
+  def ipaddress(family = 'ipv4')
+    return address if address.present? && IPAddr.new(address).send("#{family}?")
+    resource.ipaddresses.detect { |ip| IPAddr.new(ip).send("#{family}?") }
+  end
+
+  # Write the limits calculated by InfraConversionThrottler to a specific task.
+  #
+  # @param [String] path The path of the throttling file for the task
+  # @param [Hash] limits The limits to apply, accordingly to virt-v2v-wrapper documentation
+  #
+  # @return [Integer] length of data written to file
+  #
+  # @raise [MiqException::MiqInvalidCredentialsError] if conversion host credentials are invalid
+  # @raise [MiqException::MiqSshUtilHostKeyMismatch] if conversion host key has changed
+  # @raise [JSON::GeneratorError] if limits hash can't be converted to JSON
+  # @raise [StandardError] if any other problem happens
+  def apply_task_limits(path, limits = {})
+    connect_ssh { |ssu| ssu.put_file(path, limits.to_json) }
+  rescue MiqException::MiqInvalidCredentialsError, MiqException::MiqSshUtilHostKeyMismatch => err
+    raise "Failed to connect and apply limits in file '#{path}' with [#{err.class}: #{err}]"
+  rescue JSON::GeneratorError => err
+    raise "Could not generate JSON from limits '#{limits}' with [#{err.class}: #{err}]"
+  rescue StandardError => err
+    raise "Could not apply the limits in '#{path}' on '#{resource.name}' with [#{err.class}: #{err}]"
+  end
+
+  def run_conversion(conversion_options)
+    result = connect_ssh { |ssu| ssu.shell_exec('/usr/bin/virt-v2v-wrapper.py', nil, nil, conversion_options.to_json) }
+    JSON.parse(result)
+  rescue MiqException::MiqInvalidCredentialsError, MiqException::MiqSshUtilHostKeyMismatch => err
+    raise "Failed to connect and run conversion using options #{conversion_options} with [#{err.class}: #{err}]"
+  rescue JSON::ParserError
+    raise "Could not parse result data after running virt-v2v-wrapper.py using options: #{conversion_options}. Result was: #{result}."
+  rescue StandardError => err
+    raise "Starting conversion failed on '#{resource.name}' with [#{err.class}: #{err}]"
+  end
+
+  # Kill a specific remote process over ssh, sending the specified +signal+, or 'TERM'
+  # if no signal is specified.
+  #
+  def kill_process(pid, signal = 'TERM')
+    connect_ssh { |ssu| ssu.shell_exec("/bin/kill -s #{signal} #{pid}") }
+    true
+  rescue
+    false
+  end
+
+  # Retrieve the conversion state information from a remote file as a stream.
+  # Then parse and return the stream data as a hash using JSON.parse.
+  #
+  def get_conversion_state(path)
+    json_state = connect_ssh { |ssu| ssu.get_file(path, nil) }
+    JSON.parse(json_state)
+  rescue MiqException::MiqInvalidCredentialsError, MiqException::MiqSshUtilHostKeyMismatch => err
+    raise "Failed to connect and retrieve conversion state data from file '#{path}' with [#{err.class}: #{err}"
+  rescue JSON::ParserError
+    raise "Could not parse conversion state data from file '#{path}': #{json_state}"
+  rescue StandardError => err
+    raise "Error retrieving and parsing conversion state file '#{path}' from '#{resource.name}' with [#{err.class}: #{err}"
+  end
+
+  # Get and return the contents of the remote conversion log at +path+.
+  #
+  def get_conversion_log(path)
+    connect_ssh { |ssu| ssu.get_file(path, nil) }
+  rescue => e
+    raise "Could not get conversion log '#{path}' from '#{resource.name}' with [#{e.class}: #{e}"
+  end
+
+  def check_conversion_host_role(miq_task_id = nil)
+    playbook = "/usr/share/v2v-conversion-host-ansible/playbooks/conversion_host_check.yml"
+    extra_vars = {
+      :v2v_host_type        => resource.ext_management_system.emstype,
+      :v2v_transport_method => source_transport_method
+    }
+    ansible_playbook(playbook, extra_vars, miq_task_id)
+    tag_resource_as('enabled')
+  rescue
+    tag_resource_as('disabled')
+  end
+
+  def enable_conversion_host_role(vmware_vddk_package_url = nil, vmware_ssh_private_key = nil, openstack_tls_ca_certs = nil, miq_task_id = nil)
+    raise "vmware_vddk_package_url is mandatory if transformation method is vddk" if vddk_transport_supported && vmware_vddk_package_url.nil?
+    raise "vmware_ssh_private_key is mandatory if transformation_method is ssh" if ssh_transport_supported && vmware_ssh_private_key.nil?
+    playbook = "/usr/share/v2v-conversion-host-ansible/playbooks/conversion_host_enable.yml"
+    extra_vars = {
+      :v2v_host_type        => resource.ext_management_system.emstype,
+      :v2v_transport_method => source_transport_method,
+      :v2v_vddk_package_url => vmware_vddk_package_url,
+      :v2v_ssh_private_key  => vmware_ssh_private_key,
+      :v2v_ca_bundle        => openstack_tls_ca_certs || resource.ext_management_system.connection_configurations['default'].certificate_authority
+    }.compact
+    ansible_playbook(playbook, extra_vars, miq_task_id)
+  ensure
+    check_conversion_host_role(miq_task_id)
+  end
+
+  def disable_conversion_host_role(miq_task_id = nil)
+    playbook = "/usr/share/v2v-conversion-host-ansible/playbooks/conversion_host_disable.yml"
+    extra_vars = {
+      :v2v_host_type        => resource.ext_management_system.emstype,
+      :v2v_transport_method => source_transport_method
+    }
+    ansible_playbook(playbook, extra_vars, miq_task_id)
+  ensure
+    check_conversion_host_role(miq_task_id)
+  end
+
+  private
+
+  # The Vm or Host provider subclass must support conversion hosts
+  # using the SupportsFeature mixin.
+  #
+  def resource_supports_conversion_host
+    if resource && !resource.supports_conversion_host?
+      errors.add(:resource, resource.unsupported_reason(:conversion_host))
+    end
+  end
+
+  # Find the credentials for the associated resource. By default it will
+  # look for a v2v auth type if no argument is passed in.
+  #
+  # If one isn't found, then it will look for the authentication associated
+  # with the resource using the 'ssh_keypair' auth type, and finally 'default'.
+  #
+  def find_credentials(auth_type = 'v2v')
+    authentication = authentications.detect { |a| a.authtype == auth_type }
+
+    if authentication.blank?
+      res = resource.respond_to?(:authentication_type) ? resource : resource.ext_management_system
+      authentication = res.authentication_type('ssh_keypair') || res.authentication_type('default')
+    end
+
+    unless authentication
+      error_msg = "Credentials not found for conversion host #{name} or resource #{resource.name}"
+      _log.error(error_msg)
+      raise MiqException::Error, error_msg
+    end
+
+    authentication
+  end
+
+  # Connect to the conversion host using the MiqSshUtil wrapper using the authentication
+  # parameters appropriate for that type of resource.
+  #
+  def connect_ssh
+    require 'MiqSshUtil'
+    MiqSshUtil.shell_with_su(*miq_ssh_util_args) do |ssu, _shell|
+      yield(ssu)
+    end
+  rescue Exception => e
+    _log.error("SSH connection failed for [#{ipaddress}] with [#{e.class}: #{e}]")
+    raise e
+  end
+
+  # Collect appropriate authentication information based on the resource type.
+  #--
+  # TODO: This should be handled by a ConversionHost subclass within each supported provider.
+  #
+  def miq_ssh_util_args
+    send("miq_ssh_util_args_#{resource.type.gsub('::', '_').downcase}")
+  end
+
+  # For the Redhat provider, use the userid and password associated directly with the resource.
+  #--
+  # TODO: Move this to ManageIQ::Providers::Redhat::InfraManager::ConversionHost
+  #
+  def miq_ssh_util_args_manageiq_providers_redhat_inframanager_host
+    authentication = find_credentials
+    [hostname || ipaddress, authentication.userid, authentication.password, nil, nil]
+  end
+
+  # For the OpenStack provider, use the first authentication containing an ssh keypair that has
+  # both a userid and auth key.
+  #--
+  # TODO: Move this to ManageIQ::Providers::OpenStack::CloudManager::ConversionHost
+  #
+  def miq_ssh_util_args_manageiq_providers_openstack_cloudmanager_vm
+    authentication = find_credentials
+    [hostname || ipaddress, authentication.userid, nil, nil, nil, { :key_data => authentication.auth_key, :passwordless_sudo => true }]
+  end
+
+  # Run the specified ansible playbook using the ansible-playbook command. The
+  # +extra_vars+ option should be a hash of key/value pairs which, if present,
+  # will be passed to the '-e' flag.
+  #
+  def ansible_playbook(playbook, extra_vars = {}, miq_task_id = nil, auth_type = 'v2v')
+    task = MiqTask.find(miq_task_id) if miq_task_id.present?
+
+    host = hostname || ipaddress
+
+    command = "ansible-playbook #{playbook} --inventory #{host}, --become --extra-vars=\"ansible_ssh_common_args='-o StrictHostKeyChecking=no'\""
+
+    auth = find_credentials(auth_type)
+    command << " --user #{auth.userid}"
+
+    case auth
+    when AuthUseridPassword
+      extra_vars[:ansible_ssh_pass] = auth.password
+    when AuthPrivateKey
+      ssh_private_key_file = Tempfile.new('ansible_key')
+      begin
+        ssh_private_key_file.write(auth.auth_key)
+      ensure
+        ssh_private_key_file.close
+      end
+      command << " --private-key #{ssh_private_key_file.path}"
+    else
+      raise MiqException::MiqInvalidCredentialsError, _("Unknown auth type: #{auth.authtype}")
+    end
+
+    command << " --extra-vars '#{extra_vars.to_json}'"
+
+    result = AwesomeSpawn.run(command)
+
+    if result.failure?
+      error_message = result.error.presence || result.output
+      _log.error("#{result.command_line} ==> #{error_message}")
+      raise
+    end
+  ensure
+    task&.update_context(task.context_data.merge!(File.basename(playbook, '.yml') => result.output)) unless result.nil?
+    ssh_private_key_file&.unlink
+  end
+
+  # Wrapper method for the various tag_resource_as_xxx methods.
+  #--
+  # TODO: Do we need this?
+  #
+  def tag_resource_as(status)
+    send("tag_resource_as_#{status}")
+  end
+
+  # Tag the associated resource as enabled. The following tags are set or removed:
+  #
+  # - 'v2v_transformation_host/true'  (added)
+  # - 'v2v_transformation_host/vddk'  (added if vddk supported)
+  # - 'v2v_transformation_host/ssh'   (added if ssh supported)
+  # - 'v2v_transformation_host/false' (removed if present)
+  #
+  def tag_resource_as_enabled
+    resource.tag_add('v2v_transformation_host/true')
+    resource.tag_add('v2v_transformation_method/vddk') if vddk_transport_supported?
+    resource.tag_add('v2v_transformation_method/ssh') if ssh_transport_supported?
+    resource.tag_remove('v2v_transformation_host/false')
+  end
+
+  # Tag the associated resource as disabled. The following tags are set or removed:
+  #
+  # - 'v2v_transformation_host/false' (added)
+  # - 'v2v_transformation_host/true'  (removed if present)
+  # - 'v2v_transformation_host/vddk'  (removed if present)
+  # - 'v2v_transformation_host/ssh'   (removed if present)
+  #
+  def tag_resource_as_disabled
+    resource.tag_add('v2v_transformation_host/false')
+    resource.tag_remove('v2v_transformation_host/true')
+    resource.tag_remove('v2v_transformation_method/vddk')
+    resource.tag_remove('v2v_transformation_method/ssh')
+  end
+
+  # Set the default name to the name of the associated resource.
+  #
+  def default_name
+    self.name ||= resource&.name
+  end
+end

--- a/app/models/conversion_host/configurations.rb
+++ b/app/models/conversion_host/configurations.rb
@@ -1,0 +1,116 @@
+module ConversionHost::Configurations
+  extend ActiveSupport::Concern
+  module ClassMethods
+    def notify_configuration_result(op, success, resource_info)
+      Notification.create(
+        :type    => success ? :conversion_host_config_success : :conversion_host_config_failure,
+        :options => {
+          :op_name => op,
+          :op_arg  => resource_info,
+        }
+      )
+    end
+
+    def queue_configuration(op, instance_id, resource, params, auth_user = nil)
+      task_opts = {
+        :action => "Configuring a conversion_host: operation=#{op} resource=(name: #{resource.name} type: #{resource.class.name} id: #{resource.id})",
+        :userid => auth_user
+      }
+
+      queue_opts = {
+        :class_name  => name,
+        :method_name => op,
+        :instance_id => instance_id,
+        :role        => 'ems_operations',
+        :zone        => resource.ext_management_system.my_zone,
+        :args        => [params, auth_user]
+      }
+
+      task_id = MiqTask.generic_action_with_callback(task_opts, queue_opts)
+
+      # Set the context_data after the fact because the above call only accepts
+      # certain options while ignoring the rest. We also don't want to store
+      # any ssh key information. Useful for a retry option in the UI, and
+      # informational purposes in general.
+      #
+      MiqTask.find(task_id).tap do |task|
+        params = params&.except(:task_id, :miq_task_id)
+        hash = {:request_params => params&.reject { |key, _value| key.to_s.end_with?('private_key') }}
+        task.context_data = hash
+        task.save
+      end
+
+      task_id
+    end
+
+    def enable_queue(params, auth_user = nil)
+      params = params.symbolize_keys
+      resource = params.delete(:resource)
+
+      params[:resource_id] = resource.id
+      params[:resource_type] = resource.class.base_class.name
+
+      queue_configuration('enable', nil, resource, params, auth_user)
+    end
+
+    def enable(params, auth_user = nil)
+      params = params.symbolize_keys
+      _log.debug("Enabling a conversion_host with parameters: #{params}")
+
+      params.delete(:task_id) # In case this is being called through *_queue which will stick in a :task_id
+      miq_task_id = params.delete(:miq_task_id) # The miq_queue.activate_miq_task will stick in a :miq_task_id
+
+      vmware_vddk_package_url = params.delete(:vmware_vddk_package_url)
+      params[:vddk_transport_supported] = vmware_vddk_package_url.present?
+
+      vmware_ssh_private_key = params.delete(:vmware_ssh_private_key)
+      params[:ssh_transport_supported] = vmware_ssh_private_key.present?
+
+      ssh_key = params.delete(:conversion_host_ssh_private_key)
+
+      openstack_tls_ca_certs = params.delete(:openstack_tls_ca_certs)
+
+      new(params).tap do |conversion_host|
+        if ssh_key
+          conversion_host.authentications << AuthPrivateKey.create!(
+            :name     => conversion_host.name,
+            :auth_key => ssh_key,
+            :userid   => auth_user,
+            :authtype => 'v2v'
+          )
+        end
+
+        conversion_host.enable_conversion_host_role(vmware_vddk_package_url, vmware_ssh_private_key, openstack_tls_ca_certs, miq_task_id)
+        conversion_host.save!
+
+        if miq_task_id
+          MiqTask.find(miq_task_id).tap do |task|
+            task.context_data.to_h[:conversion_host_id] = conversion_host.id
+            task.save
+          end
+        end
+      end
+    rescue StandardError => error
+      raise
+    ensure
+      resource_info = "type=#{params[:resource_type]} id=#{params[:resource_id]}"
+      notify_configuration_result('enable', error.nil?, resource_info)
+    end
+  end
+
+  def disable_queue(auth_user = nil)
+    self.class.queue_configuration('disable', id, resource, {}, auth_user)
+  end
+
+  def disable(_params = nil, _auth_user = nil)
+    resource_info = "type=#{resource.class.name} id=#{resource.id}"
+    _log.debug("Disabling a conversion_host #{resource_info}")
+
+    disable_conversion_host_role
+    destroy!
+  rescue StandardError => error
+    raise
+  ensure
+    self.class.notify_configuration_result('disable', error.nil?, resource_info)
+  end
+end

--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -1,0 +1,159 @@
+class InfraConversionJob < Job
+  def self.create_job(options)
+    # TODO: from settings/user plan settings
+    options[:conversion_polling_interval] ||= Settings.transformation.limits.conversion_polling_interval # in seconds
+    options[:poll_conversion_max] ||= Settings.transformation.limits.poll_conversion_max
+    options[:poll_post_stage_max] ||= Settings.transformation.limits.poll_post_stage_max
+    super(name, options)
+  end
+
+  #
+  # State-transition diagram:
+  #                              :poll_conversion                         :poll_post_stage
+  #    *                          /-------------\                        /---------------\
+  #    | :initialize              |             |                        |               |
+  #    v               :start     v             |                        v               |
+  # waiting_to_start --------> running ------------------------------> post_conversion --/
+  #     |                         |                :start_post_stage       |
+  #     | :abort_job              | :abort_job                             |
+  #     \------------------------>|                                        | :finish
+  #                               v                                        |
+  #                             aborting --------------------------------->|
+  #                                                    :finish             v
+  #                                                                    finished
+  #
+
+  alias_method :initializing, :dispatch_start
+  alias_method :finish,       :process_finished
+  alias_method :abort_job,    :process_abort
+  alias_method :cancel,       :process_cancel
+  alias_method :error,        :process_error
+
+  def load_transitions
+    self.state ||= 'initialize'
+
+    {
+      :initializing     => {'initialize'       => 'waiting_to_start'},
+      :start            => {'waiting_to_start' => 'running'},
+      :poll_conversion  => {'running'          => 'running'},
+      :start_post_stage => {'running'          => 'post_conversion'},
+      :poll_post_stage  => {'post_conversion'  => 'post_conversion'},
+      :finish           => {'*'                => 'finished'},
+      :abort_job        => {'*'                => 'aborting'},
+      :cancel           => {'*'                => 'canceling'},
+      :error            => {'*'                => '*'}
+    }
+  end
+
+  def migration_task
+    @migration_task ||= target_entity
+    # valid states: %w(migrated pending finished active queued)
+  end
+
+  def start
+    # TransformationCleanup 3 things:
+    #  - kill v2v: ignored because no converion_host is there yet in the original automate-based logic
+    #  - power_on: ignored
+    #  - check_power_on: ignore
+
+    migration_task.preflight_check
+    _log.info(prep_message("Preflight check passed, task.state=#{migration_task.state}. continue ..."))
+    queue_signal(:poll_conversion)
+  rescue => error
+    message = prep_message("Preflight check has failed: #{error}")
+    _log.info(message)
+    abort_conversion(message, 'error')
+  end
+
+  def abort_conversion(message, status)
+    migration_task.cancel
+    queue_signal(:abort_job, message, status)
+  end
+
+  def polling_timeout(poll_type)
+    count = "#{poll_type}_count".to_sym
+    max = "#{poll_type}_max".to_sym
+    context[count] = (context[count] || 0) + 1
+    context[count] > options[max]
+  end
+
+  def poll_conversion
+    return abort_conversion("Polling times out", 'error') if polling_timeout(:poll_conversion)
+
+    message = "Getting conversion state"
+    _log.info(prep_message(message))
+
+    unless migration_task.options.fetch_path(:virtv2v_wrapper, 'state_file')
+      message = "Virt v2v state file not available, continuing poll_conversion"
+      _log.info(prep_message(message))
+      update_attributes(:message => message)
+      return queue_signal(:poll_conversion, :deliver_on => Time.now.utc + options[:conversion_polling_interval])
+    end
+
+    begin
+      migration_task.get_conversion_state # migration_task.options will be updated
+    rescue => exception
+      _log.log_backtrace(exception)
+      return abort_conversion("Conversion error: #{exception}", 'error')
+    end
+
+    v2v_status = migration_task.options[:virtv2v_status]
+    message = "virtv2v_status=#{v2v_status}"
+    _log.info(prep_message(message))
+    update_attributes(:message => message)
+
+    case v2v_status
+    when 'active'
+      queue_signal(:poll_conversion, :deliver_on => Time.now.utc + options[:conversion_polling_interval])
+    when 'failed'
+      message = "disk conversion failed"
+      abort_conversion(prep_message(message), 'error')
+    when 'succeeded'
+      message = "disk conversion succeeded"
+      _log.info(prep_message(message))
+      queue_signal(:start_post_stage)
+    else
+      message = prep_message("Unknown converstion status: #{v2v_status}")
+      abort_conversion(message, 'error')
+    end
+  end
+
+  def start_post_stage
+    # once we refactor Automate's PostTransformation into a job, we kick start it here
+    message = "To wait for Post-Transformation progress"
+    _log.info(prep_message(message))
+    update_attributes(:message => message)
+    queue_signal(:poll_post_stage, :deliver_on => Time.now.utc + options[:conversion_polling_interval])
+  end
+
+  def poll_post_stage
+    return abort_conversion("Polling times out", 'error') if polling_timeout(:poll_post_stage)
+
+    message = "PostTransformation state=#{migration_task.state}, status=#{migration_task.status}"
+    _log.info(prep_message(message))
+    update_attributes(:message => message)
+    if migration_task.state == 'finished'
+      self.status = migration_task.status
+      queue_signal(:finish)
+    else
+      queue_signal(:poll_post_stage, :deliver_on => Time.now.utc + options[:conversion_polling_interval])
+    end
+  end
+
+  def queue_signal(*args, deliver_on: nil)
+    MiqQueue.put(
+      :class_name  => self.class.name,
+      :method_name => "signal",
+      :instance_id => id,
+      :role        => "ems_operations",
+      :zone        => zone,
+      :task_id     => guid,
+      :args        => args,
+      :deliver_on  => deliver_on
+    )
+  end
+
+  def prep_message(contents)
+    "MiqRequestTask id=#{migration_task.id}, InfraConversionJob id=#{id}. #{contents}"
+  end
+end

--- a/app/models/service_template_transformation_plan.rb
+++ b/app/models/service_template_transformation_plan.rb
@@ -1,0 +1,99 @@
+class ServiceTemplateTransformationPlan < ServiceTemplate
+  include_concern 'ValidateConfigInfo'
+  virtual_has_one :transformation_mapping, :uses => :transformation_mapping
+  def request_class
+    ServiceTemplateTransformationPlanRequest
+  end
+
+  def request_type
+    "transformation_plan"
+  end
+
+  default_value_for :internal, true
+
+  def transformation_mapping
+    service_resources.find_by(:resource_type => 'TransformationMapping').resource
+  end
+
+  def vm_resources
+    service_resources.where(:resource_type => 'VmOrTemplate')
+  end
+
+  def transformation_mapping_resource
+    service_resources.where(:resource_type => 'TransformationMapping')
+  end
+
+  def validate_order
+    true
+  end
+  alias orderable? validate_order
+
+  def self.default_provisioning_entry_point(_service_type)
+    '/Transformation/StateMachines/VMTransformation/Transformation'
+  end
+
+  def self.default_retirement_entry_point
+    nil
+  end
+
+  def self.default_reconfiguration_entry_point
+    nil
+  end
+
+  validates :name, :presence => true, :uniqueness => {:scope => [:tenant_id]}
+
+  # create ServiceTemplate and supporting ServiceResources and ResourceActions
+  # options
+  #   :name
+  #   :description
+  #   :config_info
+  #     :transformation_mapping_id
+  #     :pre_service_id
+  #     :post_service_id
+  #     :actions => [
+  #        {:vm_id => "1", :pre_service => true, :post_service => false},
+  #        {:vm_id => "2", :pre_service => true, :post_service => true},
+  #     ]
+  #
+  def self.create_catalog_item(options, _auth_user = nil)
+    enhanced_config_info = validate_config_info(options)
+    default_options =  {
+      :display      => false,
+      :prov_type    => 'transformation_plan'
+    }
+
+    transaction do
+      create_from_options(options.merge(default_options)).tap do |service_template|
+        service_template.add_resource(enhanced_config_info[:transformation_mapping])
+        enhanced_config_info[:vms].each { |vm_hash| service_template.add_resource(vm_hash[:vm], :status => ServiceResource::STATUS_QUEUED, :options => vm_hash[:options]) }
+        service_template.create_resource_actions(enhanced_config_info)
+      end
+    end
+  end
+
+  def update_catalog_item(options, _auth_user = nil)
+    raise _("Editing a plan in progress is prohibited") if %w(active pending).include?(miq_requests.sort_by(&:created_on).last.try(:request_state))
+
+    if miq_requests.any? || options[:config_info].nil?
+      update_attributes(:name => options[:name], :description => options[:description])
+      return reload
+    end
+
+    added_vms_enhanced_config_info = validate_config_info(options)
+
+    transaction do
+      vm_resources.destroy_all
+      reload
+      update_from_options(options)
+      transformation_mapping_resource.update(:resource_id => added_vms_enhanced_config_info[:transformation_mapping][:id])
+      added_vms_enhanced_config_info[:vms].each { |vm_hash| add_resource(vm_hash[:vm], :status => ServiceResource::STATUS_QUEUED, :options => vm_hash[:options]) }
+      save!
+    end
+    reload
+  end
+
+  private
+
+  def enforce_single_service_parent(_resource)
+  end
+end

--- a/app/models/service_template_transformation_plan/validate_config_info.rb
+++ b/app/models/service_template_transformation_plan/validate_config_info.rb
@@ -1,0 +1,48 @@
+module ServiceTemplateTransformationPlan::ValidateConfigInfo
+  extend ActiveSupport::Concern
+
+  def validate_config_info(options)
+    self.class.validate_config_info(options)
+  end
+
+  module ClassMethods
+    def validate_config_info(options)
+      config_info = options[:config_info]
+
+      mapping = if config_info[:transformation_mapping_id]
+                  TransformationMapping.find(config_info[:transformation_mapping_id])
+                else
+                  config_info[:transformation_mapping]
+                end
+
+      raise _('Must provide an existing transformation mapping') if mapping.blank?
+
+      pre_service_id  = config_info[:pre_service].try(:id) || config_info[:pre_service_id]
+      post_service_id = config_info[:post_service].try(:id) || config_info[:post_service_id]
+
+      vms = []
+      if config_info[:actions]
+        vm_objects = VmOrTemplate.where(:id => config_info[:actions].collect { |vm_hash| vm_hash[:vm_id] }.compact).index_by(&:id).stringify_keys
+        config_info[:actions].each do |vm_hash|
+          vm_obj = vm_objects[vm_hash[:vm_id]] || vm_hash[:vm]
+          next if vm_obj.nil?
+
+          vm_options = {}
+          vm_options[:pre_ansible_playbook_service_template_id] = pre_service_id if vm_hash[:pre_service]
+          vm_options[:post_ansible_playbook_service_template_id] = post_service_id if vm_hash[:post_service]
+          vm_options[:osp_security_group_id] = vm_hash[:osp_security_group_id] if vm_hash[:osp_security_group_id].present?
+          vm_options[:osp_flavor_id] = vm_hash[:osp_flavor_id] if vm_hash[:osp_flavor_id].present?
+          vms << {:vm => vm_obj, :options => vm_options}
+        end
+      end
+
+      raise _('Must select a list of valid vms') if vms.blank?
+
+      {
+        :transformation_mapping => mapping,
+        :vms                    => vms,
+        :provision              => config_info[:provision] || {}
+      }
+    end
+  end
+end

--- a/app/models/service_template_transformation_plan_request.rb
+++ b/app/models/service_template_transformation_plan_request.rb
@@ -1,0 +1,60 @@
+class ServiceTemplateTransformationPlanRequest < ServiceTemplateProvisionRequest
+  TASK_DESCRIPTION = 'VM Transformations'.freeze
+
+  delegate :transformation_mapping, :vm_resources, :to => :source
+
+  def requested_task_idx
+    vm_resources.where(:status => ServiceResource::STATUS_APPROVED)
+  end
+
+  def customize_request_task_attributes(req_task_attrs, vm_resource)
+    req_task_attrs[:source] = vm_resource.resource
+  end
+
+  def source_vms
+    vm_resources.where(:status => [ServiceResource::STATUS_QUEUED, ServiceResource::STATUS_FAILED]).pluck(:resource_id)
+  end
+
+  def validate_conversion_hosts
+    transformation_mapping.transformation_mapping_items.select do |item|
+      %w(EmsCluster CloudTenant).include?(item.source_type)
+    end.all? do |item|
+      item.destination.ext_management_system.conversion_hosts.present?
+    end
+  end
+
+  def validate_vm(_vm_id)
+    # TODO: enhance the logic to determine whether this VM can be included in this request
+    true
+  end
+
+  def approve_vm(vm_id)
+    vm_resources.find_by(:resource_id => vm_id).update_attributes!(:status => ServiceResource::STATUS_APPROVED)
+  end
+
+  def cancel
+    update_attributes(:cancelation_status => MiqRequest::CANCEL_STATUS_REQUESTED)
+    miq_request_tasks.each(&:cancel)
+  end
+
+  def update_request_status
+    super
+    if request_state == 'finished' && status == 'Ok'
+      Notification.create(:type => "transformation_plan_request_succeeded", :options => {:plan_name => description})
+    elsif request_state == 'finished' && status != 'Ok'
+      Notification.create(:type => "transformation_plan_request_failed", :options => {:plan_name => description}, :subject => self)
+    end
+  end
+
+  def post_create_request_tasks
+    miq_request_tasks.each do |req_task|
+      job_options = {
+        :target_class => req_task.class.name,
+        :target_id    => req_task.id
+      }
+      job = InfraConversionJob.create_job(job_options)
+      req_task.options[:infra_conversion_job_id] = job.id
+      req_task.save!
+    end
+  end
+end

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -1,0 +1,352 @@
+class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
+  belongs_to :conversion_host
+  delegate :source_transport_method, :to => :conversion_host
+
+  def self.base_model
+    ServiceTemplateTransformationPlanTask
+  end
+
+  def self.get_description(req_obj)
+    source_name = req_obj.source.name
+    req_obj.kind_of?(ServiceTemplateTransformationPlanRequest) ? source_name : "Transforming VM [#{source_name}]"
+  end
+
+  def after_request_task_create
+    update_attributes(:description => get_description)
+  end
+
+  def resource_action
+    miq_request.source.resource_actions.detect { |ra| ra.action == 'Provision' }
+  end
+
+  def transformation_destination(source_obj)
+    miq_request.transformation_mapping.destination(source_obj)
+  end
+
+  def pre_ansible_playbook_service_template
+    ServiceTemplate.find_by(:id => vm_resource.options["pre_ansible_playbook_service_template_id"])
+  end
+
+  def post_ansible_playbook_service_template
+    ServiceTemplate.find_by(:id => vm_resource.options["post_ansible_playbook_service_template_id"])
+  end
+
+  def update_transformation_progress(progress)
+    update_options(:progress => (options[:progress] || {}).merge(progress))
+  end
+
+  def task_finished
+    # update the status of vm transformation status in the plan
+    vm_resource.update_attributes(:status => status == 'Ok' ? ServiceResource::STATUS_COMPLETED : ServiceResource::STATUS_FAILED)
+  end
+
+  def mark_vm_migrated
+    source.tag_with("migrated", :ns => "/managed", :cat => "transformation_status")
+  end
+
+  def task_active
+    vm_resource.update_attributes(:status => ServiceResource::STATUS_ACTIVE)
+  end
+
+  # This method returns true if all mappings are ok. It also preload
+  #  virtv2v_disks and network_mappings in task options
+  def preflight_check
+    raise 'OSP destination and source power_state is off' if destination_ems.emstype == 'openstack' && source.power_state == 'off'
+    update_options(:source_vm_power_state => source.power_state) # This will determine power_state of destination_vm
+    destination_cluster
+    virtv2v_disks
+    network_mappings
+    update_attributes(:state => 'migrate')
+  end
+
+  def source_cluster
+    source.ems_cluster
+  end
+
+  def destination_cluster
+    dst_cluster = transformation_destination(source_cluster)
+    raise "[#{source.name}] Cluster #{source_cluster} has no mapping." if dst_cluster.nil?
+    dst_cluster
+  end
+
+  def source_ems
+    source.ext_management_system
+  end
+
+  def destination_ems
+    destination_cluster.ext_management_system
+  end
+
+  def transformation_type
+    "#{source_ems.emstype}2#{destination_ems.emstype}"
+  end
+
+  def virtv2v_disks
+    return options[:virtv2v_disks] if options[:virtv2v_disks].present?
+    update_options(:virtv2v_disks => calculate_virtv2v_disks)
+    options[:virtv2v_disks]
+  end
+
+  def network_mappings
+    return options[:network_mappings] if options[:network_mappings].present?
+    update_options(:network_mappings => calculate_network_mappings)
+    options[:network_mappings]
+  end
+
+  def destination_network_ref(network)
+    send("destination_network_ref_#{destination_ems.emstype}", network)
+  end
+
+  def destination_network_ref_rhevm(network)
+    network.name
+  end
+
+  def destination_network_ref_openstack(network)
+    network.ems_ref
+  end
+
+  def destination_flavor
+    Flavor.find_by(:id => vm_resource.options["osp_flavor_id"])
+  end
+
+  def destination_security_group
+    SecurityGroup.find_by(:id => vm_resource.options["osp_security_group_id"])
+  end
+
+  def valid_transformation_log_types
+    %w(v2v wrapper)
+  end
+
+  def transformation_log(log_type = 'v2v')
+    if conversion_host.nil?
+      msg = "Conversion host was not found. Download of transformation log aborted."
+      _log.error(msg)
+      raise MiqException::Error, msg
+    end
+
+    logfile = options.fetch_path(:virtv2v_wrapper, "#{log_type}_log")
+    if logfile.blank?
+      msg = "The location of #{log_type} log was not set. Download of #{log_type} log aborted."
+      _log.error(msg)
+      raise MiqException::Error, msg
+    end
+
+    conversion_host.get_conversion_log(logfile)
+  end
+
+  # Intend to be called by UI to display transformation log. The log is stored in MiqTask#task_results
+  # Since the task_results may contain a large block of data, it is desired to remove the task upon receiving the data
+  def transformation_log_queue(userid = nil, log_type = 'v2v')
+    raise "Transformation log type '#{log_type}' not supported" unless valid_transformation_log_types.include?(log_type)
+    userid ||= User.current_userid || 'system'
+    if conversion_host.nil?
+      msg = "Conversion host was not found. Cannot queue the download of #{log_type} log."
+      return create_error_status_task(userid, msg).id
+    end
+
+    _log.info("Queuing the download of #{log_type} log for #{description} with ID [#{id}]")
+    task_options = {:userid => userid, :action => 'transformation_log'}
+    queue_options = {:class_name  => self.class,
+                     :method_name => 'transformation_log',
+                     :instance_id => id,
+                     :args        => [log_type],
+                     :zone        => conversion_host.resource.my_zone}
+    MiqTask.generic_action_with_callback(task_options, queue_options)
+  end
+
+  def infra_conversion_job
+    Job.find(options[:infra_conversion_job_id])
+  end
+
+  def cancel
+    update_attributes(:cancelation_status => MiqRequestTask::CANCEL_STATUS_REQUESTED)
+    infra_conversion_job.cancel
+  end
+
+  def canceling
+    update_attributes(:cancelation_status => MiqRequestTask::CANCEL_STATUS_PROCESSING)
+  end
+
+  def canceled
+    update_attributes(:cancelation_status => MiqRequestTask::CANCEL_STATUS_FINISHED)
+  end
+
+  def conversion_options
+    source_cluster = source.ems_cluster
+    source_storage = source.hardware.disks.select { |d| d.device_type == 'disk' }.first.storage
+    destination_cluster = transformation_destination(source_cluster)
+    destination_storage = transformation_destination(source_storage)
+
+    results = {
+      :source_disks     => virtv2v_disks.map { |disk| disk[:path] },
+      :network_mappings => network_mappings
+    }
+
+    results.merge!(send("conversion_options_source_provider_#{source_ems.emstype}_#{source_transport_method}", source_storage))
+    results.merge!(send("conversion_options_destination_provider_#{destination_ems.emstype}", destination_cluster, destination_storage))
+  end
+
+  def update_options(opts)
+    save if changed?
+    with_lock do
+      # Automate is updating this options hash (various keys) as well, using with_lock.
+      options.merge!(opts)
+      update_attributes(:options => options)
+    end
+    options
+  end
+
+  def run_conversion
+    start_timestamp = Time.now.utc.strftime('%Y-%m-%d %H:%M:%S')
+    updates = {}
+    updates[:virtv2v_wrapper] = conversion_host.run_conversion(conversion_options)
+    updates[:virtv2v_started_on] = start_timestamp
+    updates[:virtv2v_status] = 'active'
+    _log.info("InfraConversionJob run_conversion to update_options: #{updates}")
+    update_options(updates)
+  end
+
+  def get_conversion_state
+    updates = {}
+    virtv2v_state = conversion_host.get_conversion_state(options[:virtv2v_wrapper]['state_file'])
+    updated_disks = virtv2v_disks
+    updates[:virtv2v_message] = virtv2v_state['last_message']['message'] if virtv2v_state['last_message'].present?
+    if virtv2v_state['finished'].nil?
+      updated_disks.each do |disk|
+        matching_disks = virtv2v_state['disks'].select { |d| d['path'] == disk[:path] }
+        raise "No disk matches '#{disk[:path]}'. Aborting." if matching_disks.length.zero?
+        raise "More than one disk matches '#{disk[:path]}'. Aborting." if matching_disks.length > 1
+        disk[:percent] = matching_disks.first['progress']
+      end
+    else
+      updates[:virtv2v_finished_on] = Time.now.utc.strftime('%Y-%m-%d %H:%M:%S')
+      if virtv2v_state['failed']
+        updates[:virtv2v_status] = 'failed'
+        raise "Disks transformation failed."
+      else
+        updates[:virtv2v_status] = 'succeeded'
+        updated_disks.each { |d| d[:percent] = 100 }
+      end
+    end
+    updates[:virtv2v_disks] = updated_disks
+  ensure
+    _log.info("InfraConversionJob get_conversion_state to update_options: #{updates}")
+    update_options(updates)
+  end
+
+  def kill_virtv2v(signal = 'TERM')
+    return false if options[:virtv2v_started_on].blank? || options[:virtv2v_finished_on].present? || options[:virtv2v_wrapper].blank?
+    return false unless options[:virtv2v_wrapper]['pid']
+    conversion_host.kill_process(options[:virtv2v_wrapper]['pid'], signal)
+  end
+
+  private
+
+  def vm_resource
+    miq_request.vm_resources.find_by(:resource => source)
+  end
+
+  def create_error_status_task(userid, msg)
+    MiqTask.create(
+      :name    => "Download transformation log with ID: #{id}",
+      :userid  => userid,
+      :state   => MiqTask::STATE_FINISHED,
+      :status  => MiqTask::STATUS_ERROR,
+      :message => msg
+    )
+  end
+
+  def calculate_virtv2v_disks
+    source.hardware.disks.select { |d| d.device_type == 'disk' }.collect do |disk|
+      source_storage = disk.storage
+      destination_storage = transformation_destination(disk.storage)
+      raise "[#{source.name}] Disk #{disk.device_name} [#{source_storage.name}] has no mapping." if destination_storage.nil?
+      {
+        :path    => disk.filename,
+        :size    => disk.size,
+        :percent => 0,
+        :weight  => disk.size.to_f / source.allocated_disk_storage.to_f * 100
+      }
+    end
+  end
+
+  def calculate_network_mappings
+    source.hardware.nics.select { |n| n.device_type == 'ethernet' }.collect do |nic|
+      source_network = nic.lan
+      destination_network = transformation_destination(source_network)
+      raise "[#{source.name}] NIC #{nic.device_name} [#{source_network.name}] has no mapping." if destination_network.nil?
+      {
+        :source      => source_network.name,
+        :destination => destination_network_ref(destination_network),
+        :mac_address => nic.address,
+        :ip_address  => nic.network.try(:ipaddress)
+      }.compact
+    end
+  end
+
+  def conversion_options_source_provider_vmwarews_vddk(_storage)
+    {
+      :vm_name            => source.name,
+      :transport_method   => 'vddk',
+      :vmware_fingerprint => source.host.thumbprint_sha1,
+      :vmware_uri         => URI::Generic.build(
+        :scheme   => 'esx',
+        :userinfo => CGI.escape(source.host.authentication_userid),
+        :host     => source.host.ipaddress,
+        :path     => '/',
+        :query    => { :no_verify => 1 }.to_query
+      ).to_s,
+      :vmware_password    => source.host.authentication_password
+    }
+  end
+
+  def conversion_options_source_provider_vmwarews_ssh(storage)
+    {
+      :vm_name          => URI::Generic.build(
+        :scheme   => 'ssh',
+        :userinfo => 'root',
+        :host     => source.host.ipaddress,
+        :path     => "/vmfs/volumes/#{Addressable::URI.escape(storage.name)}/#{Addressable::URI.escape(source.location)}"
+      ).to_s,
+      :transport_method => 'ssh'
+    }
+  end
+
+  def conversion_options_destination_provider_rhevm(cluster, storage)
+    {
+      :rhv_url             => URI::Generic.build(:scheme => 'https', :host => destination_ems.hostname, :path => '/ovirt-engine/api').to_s,
+      :rhv_cluster         => cluster.name,
+      :rhv_storage         => storage.name,
+      :rhv_password        => destination_ems.authentication_password,
+      :install_drivers     => true,
+      :insecure_connection => true
+    }
+  end
+
+  def conversion_options_destination_provider_openstack(cluster, storage)
+    {
+      :osp_environment            => {
+        :os_auth_url             => URI::Generic.build(
+          :scheme => destination_ems.security_protocol == 'non-ssl' ? 'http' : 'https',
+          :host   => destination_ems.hostname,
+          :port   => destination_ems.port,
+          :path   => '/' + destination_ems.api_version
+        ).to_s,
+        :os_identity_api_version => '3',
+        :os_user_domain_name     => destination_ems.uid_ems,
+        :os_username             => destination_ems.authentication_userid,
+        :os_password             => destination_ems.authentication_password,
+        :os_project_name         => conversion_host.resource.cloud_tenant.name
+      },
+      :osp_server_id              => conversion_host.ems_ref,
+      :osp_destination_project_id => cluster.ems_ref,
+      :osp_volume_type_id         => storage.ems_ref,
+      :osp_flavor_id              => destination_flavor.ems_ref,
+      :osp_security_groups_ids    => [destination_security_group.ems_ref]
+    }
+  end
+
+  def valid_states
+    super << 'migrate'
+  end
+end

--- a/app/models/transformation_mapping.rb
+++ b/app/models/transformation_mapping.rb
@@ -1,0 +1,18 @@
+class TransformationMapping < ApplicationRecord
+  require_nested :VmMigrationValidator
+
+  has_many :transformation_mapping_items, :dependent => :destroy
+  has_many :service_resources, :as => :resource, :dependent => :nullify
+  has_many :service_templates, :through => :service_resources
+
+  validates :name, :presence => true, :uniqueness => true
+
+  def destination(source)
+    transformation_mapping_items.find_by(:source => source).try(:destination)
+  end
+
+  # vm_list: collection of hashes, each descriping a VM.
+  def search_vms_and_validate(vm_list = nil, service_template_id = nil)
+    VmMigrationValidator.new(self, vm_list, service_template_id).validate
+  end
+end

--- a/app/models/transformation_mapping/cloud_best_fit.rb
+++ b/app/models/transformation_mapping/cloud_best_fit.rb
@@ -1,0 +1,20 @@
+class TransformationMapping
+  class CloudBestFit
+    attr_reader :source_vm, :destination_manager
+    def initialize(source_vm, destination_manager)
+      @source_vm = source_vm
+      @destination_manager = destination_manager
+    end
+
+    def available_fit_flavors
+      @available_fit_flavors ||= destination_manager.flavors.where(
+        :cpus   => source_vm.cpu_total_cores..Float::INFINITY,
+        :memory => (source_vm.hardware.memory_mb * 1.megabyte)..Float::INFINITY
+      ).order(:cpus, :memory)
+    end
+
+    def best_fit_flavor
+      available_fit_flavors.first
+    end
+  end
+end

--- a/app/models/transformation_mapping/vm_migration_validator.rb
+++ b/app/models/transformation_mapping/vm_migration_validator.rb
@@ -1,0 +1,148 @@
+class TransformationMapping::VmMigrationValidator
+  require 'miq-hash_struct'
+
+  VM_CONFLICT = "conflict".freeze
+  VM_EMPTY_NAME = "empty_name".freeze
+  VM_IN_OTHER_PLAN = "in_other_plan".freeze
+  VM_INACTIVE = "inactive".freeze
+  VM_INVALID = "invalid".freeze
+  VM_MIGRATED = "migrated".freeze
+  VM_NOT_EXIST = "not_exist".freeze
+  VM_VALID = "ok".freeze
+
+  def initialize(mapping, vm_list = nil, service_template_id = nil)
+    @mapping = mapping
+    @vm_list = vm_list
+    @service_template_id = service_template_id.try(:to_i)
+  end
+
+  def validate
+    @vm_list.present? ? identify_vms : select_vms
+  end
+
+  def select_vms
+    valid_list = []
+
+    Vm.where(:ems_cluster => mapped_clusters).includes(:lans, :storages).each do |vm|
+      reason = validate_vm(vm, true)
+      valid_list << VmMigrateStruct.new(vm.name, vm, VM_VALID, reason) if reason == VM_VALID
+    end
+
+    {"valid" => valid_list}
+  end
+
+  def identify_vms
+    valid_list = []
+    invalid_list = []
+    conflict_list = []
+
+    vm_names = @vm_list.collect { |row| row['name'] }
+    vm_objects = Vm.where(:name => vm_names).includes(:ems_cluster, :lans, :storages, :host, :ext_management_system)
+
+    @vm_list.each do |row|
+      vm_name = row['name']
+
+      if vm_name.blank?
+        invalid_list << VmMigrateStruct.new('', nil, VM_INVALID, VM_EMPTY_NAME)
+        next
+      end
+
+      if vm_objects.select { |vm| vm.name == vm_name && !vm.active? }.any?
+        invalid_list << VmMigrateStruct.new(vm_name, nil, VM_INVALID, VM_INACTIVE)
+        next
+      end
+
+      vms = vm_objects.select { |vm| mapped_clusters.include?(vm.ems_cluster) }
+      vms = vms.select { |vm| vm.name == vm_name }
+      vms = vms.select { |vm| vm.uid_ems == row['uid_ems'] } if row['uid_ems'].present?
+      vms = vms.select { |vm| vm.host.name == row['host'] } if row['host'].present?
+      vms = vms.select { |vm| vm.ext_management_system.name == row['provider'] } if row['provider'].present?
+
+      if vms.empty?
+        invalid_list << VmMigrateStruct.new(vm_name, nil, VM_INVALID, VM_NOT_EXIST)
+      elsif vms.size == 1
+        vm = vms.first
+        reason = validate_vm(vm, false)
+        if reason == VM_VALID
+          valid_list << VmMigrateStruct.new(vm.name, vm, VM_VALID, reason)
+        else
+          invalid_list << VmMigrateStruct.new(vm.name, vm, VM_INVALID, reason)
+        end
+      else
+        vms.each { |v| conflict_list << VmMigrateStruct.new(v.name, v, VM_CONFLICT, VM_CONFLICT) }
+      end
+    end
+
+    {
+      "valid"      => valid_list,
+      "invalid"    => invalid_list,
+      "conflicted" => conflict_list
+    }
+  end
+
+  def validate_vm(vm, quick = true)
+    validate_result = vm_migration_status(vm)
+    return validate_result unless validate_result == VM_VALID
+
+    # a valid vm must find all resources in the mapping and has never been migrated
+    invalid_list = []
+    issue = no_mapping_list(invalid_list, "storages", vm.datastores - mapped_storages)
+    return no_mapping_msg(invalid_list) if issue && quick
+
+    no_mapping_list(invalid_list, "lans", vm.lans - mapped_lans)
+
+    invalid_list.present? ? no_mapping_msg(invalid_list) : VM_VALID
+  end
+
+  def vm_migration_status(vm)
+    vm_as_resources = ServiceResource.joins(:service_template).where(:resource => vm, :service_templates => {:type => 'ServiceTemplateTransformationPlan'})
+
+    # VM has not been migrated before
+    return VM_VALID if vm_as_resources.empty?
+
+    return VM_MIGRATED unless vm_as_resources.where(:status => ServiceResource::STATUS_COMPLETED).empty?
+
+    # VM failed in previous migration
+    vm_as_resources.all? { |rsc| rsc.status == ServiceResource::STATUS_FAILED || rsc.service_template_id == @service_template_id  } ? VM_VALID : VM_IN_OTHER_PLAN
+  end
+
+  def no_mapping_list(invalid_list, data_type, new_records)
+    return false if new_records.blank?
+    invalid_list << "#{data_type}: %{list}" % {:list => new_records.collect(&:name).join(", ")}
+    true
+  end
+
+  def no_mapping_msg(list)
+    "Mapping source not found - %{list}" % {:list => list.join('. ')}
+  end
+
+  def mapped_clusters
+    @mapped_clusters ||= EmsCluster.where(:id => @mapping.transformation_mapping_items.where(:source_type => 'EmsCluster').select(:source_id))
+  end
+
+  def mapped_storages
+    @mapped_storages ||= Storage.where(:id => @mapping.transformation_mapping_items.where(:source_type => 'Storage').select(:source_id))
+  end
+
+  def mapped_lans
+    @mapped_lans ||= Lan.where(:id => @mapping.transformation_mapping_items.where(:source_type => 'Lan').select(:source_id))
+  end
+
+  class VmMigrateStruct < MiqHashStruct
+    def initialize(vm_name, vm, status, reason)
+      options = {"name" => vm_name, "status" => status, "reason" => reason}
+
+      if vm.present?
+        options.merge!(
+          "cluster"        => vm.ems_cluster.try(:name) || '',
+          "path"           => vm.ext_management_system ? "#{vm.ext_management_system.name}/#{vm.v_parent_blue_folder_display_path}" : '',
+          "allocated_size" => vm.allocated_disk_storage,
+          "id"             => vm.id.to_s,
+          "ems_cluster_id" => vm.ems_cluster_id.to_s
+        )
+      end
+
+      super(options)
+    end
+  end
+end

--- a/app/models/transformation_mapping_item.rb
+++ b/app/models/transformation_mapping_item.rb
@@ -1,0 +1,7 @@
+class TransformationMappingItem < ApplicationRecord
+  belongs_to :transformation_mapping
+  belongs_to :source,      :polymorphic => true
+  belongs_to :destination, :polymorphic => true
+
+  validates :source_id, :uniqueness => {:scope => [:transformation_mapping_id, :source_type]}
+end

--- a/lib/infra_conversion_throttler.rb
+++ b/lib/infra_conversion_throttler.rb
@@ -1,0 +1,66 @@
+class InfraConversionThrottler
+  def self.start_conversions
+    pending_conversion_jobs.each do |ems, jobs|
+      running = ems.conversion_hosts.inject(0) { |sum, ch| sum + ch.active_tasks.size }
+      slots = (ems.miq_custom_get('Max Transformation Runners') || Settings.transformation.limits.max_concurrent_tasks_per_ems).to_i - running
+      jobs.each do |job|
+        eligible_hosts = ems.conversion_hosts.select(&:eligible?).sort_by { |ch| ch.active_tasks.size }
+        break if slots <= 0 || eligible_hosts.empty?
+        job.migration_task.update_attributes!(:conversion_host => eligible_hosts.first)
+        job.queue_signal(:start)
+        _log.info("Pending InfraConversionJob: id=#{job.id} signaled to start")
+        slots -= 1
+      end
+    end
+  end
+
+  def self.pending_conversion_jobs
+    pending = InfraConversionJob.where(:state => 'waiting_to_start')
+    _log.info("Pending InfraConversionJob: #{pending.count}")
+    pending.group_by { |job| job.migration_task.destination_ems }
+  end
+
+  # @return [Hash] the list of jobs in state 'running', grouped by conversion host
+  def self.running_conversion_jobs
+    running = InfraConversionJob.where(:state => 'running')
+    _log.info("Running InfraConversionJob: #{running.count}")
+    running.group_by { |job| job.migration_task.conversion_host }
+  end
+
+  # Calculate and apply the limits for all running jobs.
+  # The supported limits are:
+  #   - CPU per conversion host
+  #   - network per conversion host
+  #
+  # The limits can be retrieved per conversion host or from the default setting.
+  # When virt-v2v-wrapper starts the task stores the throttling file path in task.options[:virt-v2v-wrapper]['throttling_file'].
+  # There is no need to adjust limits if virt-v2v-wrapper has not been called by the task.
+  # The resources are evenly split between the jobs on a same conversion host.
+  # There is no need to adjust limits if they have not changed.
+  # Applying the limits is done via the conversion_host which handles the writing.
+  def self.apply_limits
+    running_conversion_jobs.each do |ch, jobs|
+      number_of_jobs = jobs.size
+
+      cpu_limit = ch.cpu_limit || Settings.transformation.limits.cpu_limit_per_host
+      cpu_limit = (cpu_limit.to_i / number_of_jobs).to_s unless cpu_limit == "unlimited"
+
+      network_limit = ch.network_limit || Settings.transformation.limits.network_limit_per_host
+      network_limit = (network_limit.to_i / number_of_jobs).to_s unless network_limit == "unlimited"
+
+      jobs.each do |job|
+        migration_task = job.migration_task
+        throttling_file_path = migration_task.options.fetch_path(:virtv2v_wrapper, 'throttling_file')
+        next unless throttling_file_path
+        limits = {
+          :cpu     => cpu_limit,
+          :network => network_limit
+        }
+        unless migration_task.options[:virtv2v_limits] == limits
+          ch.apply_task_limits(throttling_file_path, limits)
+          migration_task.update_options(:virtv2v_limits => limits)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/infra_conversion_throttler_spec.rb
+++ b/spec/lib/infra_conversion_throttler_spec.rb
@@ -1,0 +1,97 @@
+require 'infra_conversion_throttler'
+describe InfraConversionThrottler do
+  let(:ems) { FactoryBot.create(:ext_management_system, :zone => FactoryBot.create(:zone)) }
+  let(:host) { FactoryBot.create(:host, :ext_management_system => ems) }
+  let(:vm) { FactoryBot.create(:vm_or_template, :ext_management_system => ems) }
+  let(:task_waiting) { FactoryBot.create(:service_template_transformation_plan_task, :source => vm) }
+  let(:task_running_1) { FactoryBot.create(:service_template_transformation_plan_task, :source => vm) }
+  let(:task_running_2) { FactoryBot.create(:service_template_transformation_plan_task, :source => vm) }
+  let(:job_waiting) { FactoryBot.create(:infra_conversion_job, :state => 'waiting_to_start') }
+  let(:job_running_1) { FactoryBot.create(:infra_conversion_job, :state => 'running') }
+  let(:job_running_2) { FactoryBot.create(:infra_conversion_job, :state => 'running') }
+
+  before do
+    allow(host).to receive(:supports_conversion_host?).and_return(true)
+    allow(vm).to receive(:supports_conversion_host?).and_return(true)
+  end
+
+  context '.start_conversions' do
+    let(:conversion_host1) { FactoryBot.create(:conversion_host, :max_concurrent_tasks => 2, :vddk_transport_supported => true, :resource => host) }
+    let(:conversion_host2) { FactoryBot.create(:conversion_host, :max_concurrent_tasks => 2, :vddk_transport_supported => true, :resource => vm) }
+
+    before do
+      allow(task_waiting).to receive(:destination_ems).and_return(ems)
+      allow(job_waiting).to receive(:migration_task).and_return(task_waiting)
+      allow(described_class).to receive(:pending_conversion_jobs).and_return(ems => [job_waiting])
+      allow(ems).to receive(:conversion_hosts).and_return([conversion_host1, conversion_host2])
+      allow(conversion_host1).to receive(:check_ssh_connection).and_return(true)
+      allow(conversion_host2).to receive(:check_ssh_connection).and_return(true)
+    end
+
+    it 'will not start a job when ems limit hit' do
+      ems.miq_custom_set('Max Transformation Runners', 2)
+      allow(conversion_host1).to receive(:active_tasks).and_return([1])
+      allow(conversion_host2).to receive(:active_tasks).and_return([1])
+      expect(job_waiting).not_to receive(:queue_signal)
+      described_class.start_conversions
+    end
+
+    it 'will not start a job when conversion_host limit hit' do
+      ems.miq_custom_set('Max Transformation Runners', 100)
+      allow(conversion_host1).to receive(:active_tasks).and_return([1, 2])
+      allow(conversion_host2).to receive(:active_tasks).and_return([1, 2])
+      expect(job_waiting).not_to receive(:queue_signal)
+      described_class.start_conversions
+    end
+
+    it 'will start a job when limits are not hit' do
+      allow(conversion_host1).to receive(:active_tasks).and_return([1, 2])
+      allow(conversion_host2).to receive(:active_tasks).and_return([1])
+      expect(job_waiting).to receive(:queue_signal).with(:start)
+      described_class.start_conversions
+      expect(task_waiting.conversion_host.id).to eq(conversion_host2.id)
+    end
+  end
+
+  context '.apply_limits' do
+    let(:conversion_host) { FactoryBot.create(:conversion_host, :resource => vm, :cpu_limit => '50') }
+
+    before do
+      allow(described_class).to receive(:running_conversion_jobs).and_return(conversion_host => [job_running_1, job_running_2])
+      allow(conversion_host).to receive(:active_tasks).and_return([1, 2])
+      allow(job_running_1).to receive(:migration_task).and_return(task_running_1)
+      allow(job_running_2).to receive(:migration_task).and_return(task_running_2)
+    end
+
+    it 'does not set limit when virt-v2v-wrapper has not started' do
+      expect(conversion_host).not_to receive(:apply_task_limits)
+      described_class.apply_limits
+    end
+
+    it 'calls apply_task_limits with limits hash when virt-v2v-wrapper has started' do
+      path = '/tmp/fake_throttling_file'
+      limits = {
+        :cpu     => '25',
+        :network => 'unlimited'
+      }
+      task_running_1.options[:virtv2v_wrapper] = { 'throttling_file' => path }
+      task_running_2.options[:virtv2v_wrapper] = { 'throttling_file' => path }
+      expect(conversion_host).to receive(:apply_task_limits).twice.with(path, limits)
+      described_class.apply_limits
+      expect(task_running_1.reload.options[:virtv2v_limits]).to eq(limits)
+      expect(task_running_2.reload.options[:virtv2v_limits]).to eq(limits)
+    end
+
+    it 'does not call apply_task_limits when limits have not changed' do
+      path = '/tmp/fake_throttling_file'
+      limits = {
+        :cpu     => '25',
+        :network => 'unlimited'
+      }
+      task_running_1.update_options(:virtv2v_limits => limits)
+      task_running_2.update_options(:virtv2v_limits => limits)
+      expect(conversion_host).not_to receive(:apply_task_limits).with(path, limits)
+      described_class.apply_limits
+    end
+  end
+end

--- a/spec/models/conversion_host/configurations_spec.rb
+++ b/spec/models/conversion_host/configurations_spec.rb
@@ -1,0 +1,180 @@
+RSpec.describe ConversionHost, :v2v do
+  let(:conversion_host) { FactoryBot.create(:conversion_host, :resource => vm) }
+  let(:conversion_host_ssh) { FactoryBot.create(:conversion_host, :resource => vm, :ssh_transport_supported => true) }
+  let(:conversion_host_vddk) { FactoryBot.create(:conversion_host, :resource => vm, :vddk_transport_supported => true) }
+  let(:params) do
+    {
+      :name          => 'transformer',
+      :resource_type => vm.class.base_class.name,
+      :resource_id   => vm.id,
+      :resource      => vm
+    }
+  end
+
+  context "processing configuration requests" do
+    let(:vm) { FactoryBot.create(:vm_openstack) }
+
+    before(:each) do
+      allow(ConversionHost).to receive(:new).and_return(conversion_host)
+    end
+
+    context ".enable" do
+      let(:expected_notify) do
+        {
+          :type    => :conversion_host_config_success,
+          :options => {
+            :op_name => "enable",
+            :op_arg  => "type=#{params[:resource_type]} id=#{params[:resource_id]}"
+          }
+        }
+      end
+
+      it "to succeed and send notification" do
+        allow(conversion_host).to receive(:enable_conversion_host_role)
+        expect(Notification).to receive(:create).with(expected_notify)
+        expect(described_class.enable(params)).to be_a(described_class)
+      end
+
+      it "to fail and send notification" do
+        expected_notify[:type] = :conversion_host_config_failure
+        allow(conversion_host).to receive(:enable_conversion_host_role).and_raise
+        expect(Notification).to receive(:create).with(expected_notify)
+        expect { described_class.enable(params) }.to raise_error(StandardError)
+      end
+
+      context "transport method is SSH" do
+        let(:conversion_host) { conversion_host_ssh }
+
+        it "tags the associated resource as expected" do
+          allow(conversion_host).to receive(:enable_conversion_host_role)
+          taggings = conversion_host.resource.taggings
+          tag_names = taggings.map { |tagging| tagging.tag.name }
+
+          expect(tag_names).to contain_exactly(
+            '/user/v2v_transformation_host/true',
+            '/user/v2v_transformation_method/ssh'
+          )
+        end
+      end
+
+      context "transport method is VDDK" do
+        let(:conversion_host) { conversion_host_vddk }
+
+        it "tags the associated resource as expected" do
+          allow(conversion_host).to receive(:enable_conversion_host_role)
+          taggings = conversion_host.resource.taggings
+          tag_names = taggings.map { |tagging| tagging.tag.name }
+
+          expect(tag_names).to contain_exactly(
+            '/user/v2v_transformation_host/true',
+            '/user/v2v_transformation_method/vddk'
+          )
+        end
+      end
+    end
+
+    context "#disable" do
+      let(:expected_notify) do
+        {
+          :type    => :conversion_host_config_success,
+          :options => {
+            :op_name => "disable",
+            :op_arg  => "type=#{vm.class.name} id=#{vm.id}"
+          }
+        }
+      end
+
+      it "to succeed and send notification" do
+        allow(conversion_host).to receive(:disable_conversion_host_role)
+        expect(Notification).to receive(:create).with(expected_notify)
+        conversion_host.disable
+      end
+
+      it "to fail and send notification" do
+        expected_notify[:type] = :conversion_host_config_failure
+        allow(conversion_host).to receive(:disable_conversion_host_role).and_raise
+        expect(Notification).to receive(:create).with(expected_notify)
+        expect { conversion_host.disable }.to raise_error(StandardError)
+      end
+
+      it "tags the associated resource as expected" do
+        allow(conversion_host).to receive(:disable_conversion_host_role)
+        expect(Notification).to receive(:create).with(expected_notify)
+        conversion_host.disable
+        taggings = conversion_host.resource.taggings
+        tag_names = taggings.map { |tagging| tagging.tag.name }
+
+        expect(tag_names).to contain_exactly('/user/v2v_transformation_host/false')
+      end
+    end
+  end
+
+  context "queuing configuration requests" do
+    let(:ext_management_system) { FactoryBot.create(:ext_management_system) }
+    let(:vm) { FactoryBot.create(:vm_openstack, :ext_management_system => ext_management_system) }
+    let(:expected_task_action) { "Configuring a conversion_host: operation=#{op} resource=(name: #{vm.name} type: #{vm.class.name} id: #{vm.id})" }
+
+    context ".enable_queue" do
+      let(:op) { 'enable' }
+
+      it "to queue with a task" do
+        task_id = described_class.enable_queue(params)
+        expected_context_data = {:request_params => params.except(:resource)}
+
+        expect(MiqTask.find(task_id)).to have_attributes(:name => expected_task_action, :context_data => expected_context_data)
+        expect(MiqQueue.first).to have_attributes(
+          :args        => [params.merge(:task_id => task_id).except(:resource), nil],
+          :class_name  => described_class.name,
+          :method_name => "enable",
+          :priority    => MiqQueue::NORMAL_PRIORITY,
+          :role        => "ems_operations",
+          :zone        => vm.ext_management_system.my_zone
+        )
+      end
+
+      it "rejects ssh key information as context data" do
+        task_id = described_class.enable_queue(params.merge(:conversion_host_ssh_private_key => 'xxx', :vmware_ssh_private_key => 'yyy'))
+        expected_context_data = {:request_params => params.except(:resource)}
+
+        expect(MiqTask.find(task_id)).to have_attributes(:name => expected_task_action, :context_data => expected_context_data)
+      end
+    end
+
+    context "#disable_queue" do
+      let(:op) { 'disable' }
+
+      let(:expected_notify) do
+        {
+          :type    => :conversion_host_config_success,
+          :options => {
+            :op_name => "disable",
+            :op_arg  => "type=#{vm.class.name} id=#{vm.id}"
+          }
+        }
+      end
+
+      it "to queue with a task" do
+        task_id = conversion_host.disable_queue
+        expect(MiqTask.find(task_id)).to have_attributes(:name => expected_task_action)
+        expect(MiqQueue.first).to have_attributes(
+          :args        => [{:task_id => task_id}, nil],
+          :class_name  => described_class.name,
+          :instance_id => conversion_host.id,
+          :method_name => "disable",
+          :priority    => MiqQueue::NORMAL_PRIORITY,
+          :role        => "ems_operations",
+          :zone        => conversion_host.resource.ext_management_system.my_zone
+        )
+      end
+
+      it "calls the disable method if delivered" do
+        allow(conversion_host).to receive(:disable_conversion_host_role)
+        allow(ConversionHost).to receive(:find).with(conversion_host.id).and_return(conversion_host)
+
+        expect(Notification).to receive(:create).with(expected_notify)
+        conversion_host.disable_queue
+        expect(MiqQueue.first.deliver).to include("ok")
+      end
+    end
+  end
+end

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -1,0 +1,550 @@
+require "MiqSshUtil"
+
+RSpec.describe ConversionHost, :v2v do
+  let(:apst) { FactoryBot.create(:service_template_ansible_playbook) }
+
+  context "provider independent methods" do
+    let(:ems) { FactoryBot.create(:ems_redhat, :zone => FactoryBot.create(:zone), :api_version => '4.2.4') }
+    let(:host) { FactoryBot.create(:host_redhat, :ext_management_system => ems) }
+    let(:vm) { FactoryBot.create(:vm_openstack) }
+    let(:conversion_host_1) { FactoryBot.create(:conversion_host, :resource => host) }
+    let(:conversion_host_2) { FactoryBot.create(:conversion_host, :resource => vm) }
+    let(:task_1) { FactoryBot.create(:service_template_transformation_plan_task, :state => 'active', :conversion_host => conversion_host_1) }
+    let(:task_2) { FactoryBot.create(:service_template_transformation_plan_task, :conversion_host => conversion_host_1) }
+    let(:task_3) { FactoryBot.create(:service_template_transformation_plan_task, :state => 'migrate', :conversion_host => conversion_host_2) }
+
+    before do
+      allow(conversion_host_1).to receive(:active_tasks).and_return([task_1])
+      allow(conversion_host_2).to receive(:active_tasks).and_return([task_3])
+
+      allow(host).to receive(:ipaddresses).and_return(['10.0.0.1', 'FE80:0000:0000:0000:0202:B3FF:FE1E:8329', '192.168.0.1'])
+      allow(host).to receive(:ipaddress).and_return(nil)
+      allow(vm).to receive(:ipaddresses).and_return(['10.0.1.1', 'FE80::0202:B3FF:FE1E:3267', '192.168.1.1'])
+    end
+
+    context "#eligible?" do
+      it "fails when no source transport method is enabled" do
+        allow(conversion_host_1).to receive(:source_transport_method).and_return(nil)
+        allow(conversion_host_1).to receive(:verify_credentials).and_return(true)
+        allow(conversion_host_1).to receive(:check_concurrent_tasks).and_return(true)
+        expect(conversion_host_1.eligible?).to eq(false)
+      end
+
+      it "fails when no source transport method is enabled" do
+        allow(conversion_host_1).to receive(:source_transport_method).and_return('vddk')
+        allow(conversion_host_1).to receive(:verify_credentials).and_return(false)
+        allow(conversion_host_1).to receive(:check_concurrent_tasks).and_return(true)
+        expect(conversion_host_1.eligible?).to eq(false)
+      end
+
+      it "fails when no source transport method is enabled" do
+        allow(conversion_host_1).to receive(:source_transport_method).and_return('vddk')
+        allow(conversion_host_1).to receive(:verify_credentials).and_return(true)
+        allow(conversion_host_1).to receive(:check_concurrent_tasks).and_return(false)
+        expect(conversion_host_1.eligible?).to eq(false)
+      end
+
+      it "succeeds when all criteria are met" do
+        allow(conversion_host_1).to receive(:source_transport_method).and_return('vddk')
+        allow(conversion_host_1).to receive(:verify_credentials).and_return(true)
+        allow(conversion_host_1).to receive(:check_concurrent_tasks).and_return(true)
+        expect(conversion_host_1.eligible?).to eq(true)
+      end
+    end
+
+    context "#check_concurrent_tasks" do
+      context "default max concurrent tasks is equal to current active tasks" do
+        before { stub_settings_merge(:transformation => {:limits => {:max_concurrent_tasks_per_host => 1}}) }
+        it { expect(conversion_host_1.check_concurrent_tasks).to eq(false) }
+      end
+
+      context "default max concurrent tasks is greater than current active tasks" do
+        before { stub_settings_merge(:transformation => {:limits => {:max_concurrent_tasks_per_host => 10}}) }
+        it { expect(conversion_host_1.check_concurrent_tasks).to eq(true) }
+      end
+
+      context "host's max concurrent tasks is equal to current active tasks" do
+        before { conversion_host_1.max_concurrent_tasks = "1" }
+        it { expect(conversion_host_1.check_concurrent_tasks).to eq(false) }
+      end
+
+      context "host's max concurrent tasks greater than current active tasks" do
+        before { conversion_host_2.max_concurrent_tasks = "2" }
+        it { expect(conversion_host_2.check_concurrent_tasks).to eq(true) }
+      end
+    end
+
+    context "#source_transport_method" do
+      it { expect(conversion_host_2.source_transport_method).to be_nil }
+
+      context "ssh transport enabled" do
+        before { conversion_host_2.ssh_transport_supported = true }
+        it { expect(conversion_host_2.source_transport_method).to eq('ssh') }
+
+        context "vddk transport enabled" do
+          before { conversion_host_2.vddk_transport_supported = true }
+          it { expect(conversion_host_2.source_transport_method).to eq('vddk') }
+        end
+      end
+    end
+
+    context "#ipaddress" do
+      it "returns first IP address if 'address' is nil" do
+        expect(conversion_host_1.ipaddress).to eq('10.0.0.1')
+        expect(conversion_host_2.ipaddress).to eq('10.0.1.1')
+        expect(conversion_host_1.ipaddress('ipv4')).to eq('10.0.0.1')
+        expect(conversion_host_2.ipaddress('ipv4')).to eq('10.0.1.1')
+        expect(conversion_host_1.ipaddress('ipv6')).to eq('FE80:0000:0000:0000:0202:B3FF:FE1E:8329')
+        expect(conversion_host_2.ipaddress('ipv6')).to eq('FE80::0202:B3FF:FE1E:3267')
+      end
+
+      context "when address is set" do
+        before do
+          allow(conversion_host_1).to receive(:address).and_return('172.16.0.1')
+          allow(conversion_host_2).to receive(:address).and_return('2001:0DB8:85A3:0000:0000:8A2E:0370:7334')
+        end
+
+        it "returns 'address' if family matches, is invalid or is nil" do
+          expect(conversion_host_1.ipaddress).to eq('172.16.0.1')
+          expect(conversion_host_2.ipaddress).to eq('10.0.1.1')
+          expect(conversion_host_1.ipaddress('ipv4')).to eq('172.16.0.1')
+          expect(conversion_host_2.ipaddress('ipv4')).to eq('10.0.1.1')
+          expect(conversion_host_1.ipaddress('ipv6')).to eq('FE80:0000:0000:0000:0202:B3FF:FE1E:8329')
+          expect(conversion_host_2.ipaddress('ipv6')).to eq('2001:0DB8:85A3:0000:0000:8A2E:0370:7334')
+        end
+      end
+    end
+
+    context "#kill_process" do
+      it "returns false if if kill command failed" do
+        allow(conversion_host_1).to receive(:connect_ssh).and_raise('Unexpected failure')
+        expect(conversion_host_1.kill_process('1234', 'KILL')).to eq(false)
+      end
+
+      it "returns true if if kill command succeeded" do
+        allow(conversion_host_1).to receive(:connect_ssh)
+        expect(conversion_host_1.kill_process('1234', 'KILL')).to eq(true)
+      end
+    end
+  end
+
+  shared_examples_for "#check_ssh_connection" do
+    it "fails when SSH send an error" do
+      allow(conversion_host).to receive(:connect).and_raise('Unexpected failure')
+      expect(conversion_host.check_ssh_connection).to eq(false)
+    end
+
+    it "succeeds when SSH command succeeds" do
+      allow(conversion_host).to receive(:connect_ssh)
+      expect(conversion_host.check_ssh_connection).to eq(true)
+    end
+  end
+
+  context "resource provider is rhevm" do
+    let(:ems) { FactoryBot.create(:ems_redhat, :zone => FactoryBot.create(:zone), :api_version => '4.2.4') }
+    let(:host) { FactoryBot.create(:host_redhat, :ext_management_system => ems) }
+    let(:conversion_host) { FactoryBot.create(:conversion_host, :resource => host, :vddk_transport_supported => true) }
+
+    context "host userid is nil" do
+      before { allow(host).to receive(:authentication_userid).and_return(nil) }
+      it { expect(conversion_host.check_ssh_connection).to eq(false) }
+    end
+
+    context "host userid is set" do
+      before { allow(host).to receive(:authentication_userid).and_return('root') }
+
+      context "and host password is nil" do
+        before { allow(host).to receive(:authentication_password).and_return(nil) }
+        it { expect(conversion_host.check_ssh_connection).to eq(false) }
+      end
+
+      context "and host password is set" do
+        before { allow(host).to receive(:authentication_password).and_return('password') }
+        it_behaves_like "#check_ssh_connection"
+      end
+    end
+
+    context "#ansible_playbook" do
+      let(:auth_v2v) { FactoryBot.create(:authentication_v2v, :resource => conversion_host) }
+      let(:package_url) { 'http://file.example.com/vddk-stable.tar.gz' }
+      let(:enable_playbook) { '/usr/share/v2v-conversion-host-ansible/playbooks/conversion_host_enable.yml' }
+
+      it "check_conversion_host_role calls ansible_playbook with extra_vars" do
+        check_playbook = '/usr/share/v2v-conversion-host-ansible/playbooks/conversion_host_check.yml'
+        check_extra_vars = {
+          :v2v_host_type        => 'rhevm',
+          :v2v_transport_method => 'vddk'
+        }
+        expect(conversion_host).to receive(:ansible_playbook).with(check_playbook, check_extra_vars, 1)
+        conversion_host.check_conversion_host_role(1)
+      end
+
+      it "disable_conversion_host_role calls ansible_playbook with extra_vars" do
+        disable_playbook = '/usr/share/v2v-conversion-host-ansible/playbooks/conversion_host_disable.yml'
+        check_playbook = '/usr/share/v2v-conversion-host-ansible/playbooks/conversion_host_check.yml'
+        disable_extra_vars = {
+          :v2v_host_type        => 'rhevm',
+          :v2v_transport_method => 'vddk'
+        }
+        check_extra_vars = disable_extra_vars
+        expect(conversion_host).to receive(:ansible_playbook).once.ordered.with(disable_playbook, disable_extra_vars, 1)
+        expect(conversion_host).to receive(:ansible_playbook).once.ordered.with(check_playbook, check_extra_vars, 1)
+        conversion_host.disable_conversion_host_role(1)
+      end
+
+      it "enable_conversion_host_role raises if vmware_vddk_package_url is nil" do
+        expect { conversion_host.enable_conversion_host_role }.to raise_error("vmware_vddk_package_url is mandatory if transformation method is vddk")
+      end
+
+      it "enable_conversion_host_role calls ansible_playbook with extra_vars" do
+        check_playbook = '/usr/share/v2v-conversion-host-ansible/playbooks/conversion_host_check.yml'
+        enable_extra_vars = {
+          :v2v_host_type        => 'rhevm',
+          :v2v_transport_method => 'vddk',
+          :v2v_vddk_package_url => package_url
+        }
+        check_extra_vars = {
+          :v2v_host_type        => 'rhevm',
+          :v2v_transport_method => 'vddk'
+        }
+        expect(conversion_host).to receive(:ansible_playbook).once.ordered.with(enable_playbook, enable_extra_vars, nil)
+        expect(conversion_host).to receive(:ansible_playbook).once.ordered.with(check_playbook, check_extra_vars, nil)
+        conversion_host.enable_conversion_host_role('http://file.example.com/vddk-stable.tar.gz', nil)
+      end
+
+      it "logs an error message if the ansible_playbook command fails" do
+        command = "ansible_playbook #{enable_playbook}"
+        result = instance_double(AwesomeSpawn::CommandResult, :command_line => command, :failure? => true, :error => "oops")
+
+        allow(conversion_host).to receive(:check_conversion_host_role)
+        allow(conversion_host).to receive(:find_credentials).and_return(auth_v2v)
+        allow(AwesomeSpawn).to receive(:run).and_return(result)
+
+        expect($log).to receive(:error).with("MIQ(ConversionHost#ansible_playbook) #{command} ==> oops")
+        expect { conversion_host.enable_conversion_host_role(package_url, nil) }.to raise_error(RuntimeError)
+      end
+    end
+  end
+
+  context "resource provider is openstack" do
+    let(:ems) { FactoryBot.create(:ems_openstack, :zone => FactoryBot.create(:zone)) }
+    let(:vm) { FactoryBot.create(:vm_openstack, :ext_management_system => ems) }
+    let(:conversion_host) { FactoryBot.create(:conversion_host, :resource => vm, :ssh_transport_supported => true) }
+
+    context "ems authentications is empty" do
+      it { expect(conversion_host.check_ssh_connection).to be(false) }
+    end
+
+    context "ems authentications contains ssh_auth" do
+      let(:ssh_auth) { FactoryBot.create(:authentication_ssh_keypair, :resource => ems) }
+
+      before do
+        allow(ems).to receive(:authentications).and_return(ssh_auth)
+        allow(ssh_auth).to receive(:where).with(:authype => 'ssh_keypair').and_return(ssh_auth)
+        allow(ssh_auth).to receive(:where).and_return(ssh_auth)
+        allow(ssh_auth).to receive(:not).with(:userid => nil, :auth_key => nil).and_return([ssh_auth])
+      end
+
+      it_behaves_like "#check_ssh_connection"
+    end
+
+    context "#ansible_playbook" do
+      it "check_conversion_host_role calls ansible_playbook with extra_vars" do
+        check_playbook = '/usr/share/v2v-conversion-host-ansible/playbooks/conversion_host_check.yml'
+        check_extra_vars = {
+          :v2v_host_type        => 'openstack',
+          :v2v_transport_method => 'ssh'
+        }
+        expect(conversion_host).to receive(:ansible_playbook).with(check_playbook, check_extra_vars, 1)
+        conversion_host.check_conversion_host_role(1)
+      end
+
+      it "disable_conversion_host_role calls ansible_playbook with extra_vars" do
+        disable_playbook = '/usr/share/v2v-conversion-host-ansible/playbooks/conversion_host_disable.yml'
+        check_playbook = '/usr/share/v2v-conversion-host-ansible/playbooks/conversion_host_check.yml'
+        disable_extra_vars = {
+          :v2v_host_type        => 'openstack',
+          :v2v_transport_method => 'ssh'
+        }
+        check_extra_vars = disable_extra_vars
+        expect(conversion_host).to receive(:ansible_playbook).once.ordered.with(disable_playbook, disable_extra_vars, 1)
+        expect(conversion_host).to receive(:ansible_playbook).once.ordered.with(check_playbook, check_extra_vars, 1)
+        conversion_host.disable_conversion_host_role(1)
+      end
+
+      it "enable_conversion_host_role raises if vmware_ssh_private_key is nil" do
+        expect { conversion_host.enable_conversion_host_role }.to raise_error("vmware_ssh_private_key is mandatory if transformation_method is ssh")
+      end
+
+      it "enable_conversion_host_role calls ansible_playbook with extra_vars" do
+        enable_playbook = '/usr/share/v2v-conversion-host-ansible/playbooks/conversion_host_enable.yml'
+        check_playbook = '/usr/share/v2v-conversion-host-ansible/playbooks/conversion_host_check.yml'
+        enable_extra_vars = {
+          :v2v_host_type        => 'openstack',
+          :v2v_transport_method => 'ssh',
+          :v2v_ssh_private_key  => 'fake ssh private key',
+          :v2v_ca_bundle        => 'fake CA bundle'
+        }
+        check_extra_vars = {
+          :v2v_host_type        => 'openstack',
+          :v2v_transport_method => 'ssh'
+        }
+        expect(conversion_host).to receive(:ansible_playbook).once.ordered.with(enable_playbook, enable_extra_vars, nil)
+        expect(conversion_host).to receive(:ansible_playbook).once.ordered.with(check_playbook, check_extra_vars, nil)
+        conversion_host.enable_conversion_host_role(nil, 'fake ssh private key', 'fake CA bundle')
+      end
+    end
+  end
+
+  context "address validation" do
+    let(:vm) { FactoryBot.create(:vm_openstack) }
+
+    it "is invalid if the address is not a valid IP address" do
+      allow(vm).to receive(:ipaddresses).and_return(['127.0.0.1'])
+      conversion_host = ConversionHost.new(:name => "test", :resource => vm, :address => "xxx")
+      expect(conversion_host.valid?).to be(false)
+      expect(conversion_host.errors[:address]).to include("is invalid")
+    end
+
+    it "is invalid if the address is present but not included in the resource addresses" do
+      allow(vm).to receive(:ipaddresses).and_return(['127.0.0.1'])
+      conversion_host = ConversionHost.new(:name => "test", :resource => vm, :address => "127.0.0.2")
+      expect(conversion_host.valid?).to be(false)
+      expect(conversion_host.errors[:address]).to include("is not included in the list")
+    end
+
+    it "is valid if the address is included within the list of available resource addresses" do
+      allow(vm).to receive(:ipaddresses).and_return(['127.0.0.1'])
+      conversion_host = ConversionHost.new(:name => "test", :resource => vm, :address => "127.0.0.1")
+      expect(conversion_host.valid?).to be(true)
+    end
+
+    it "is ignored if the resource does not have any ipaddresses" do
+      conversion_host = ConversionHost.new(:name => "test", :resource => vm, :address => "127.0.0.2")
+      expect(conversion_host.valid?).to be(true)
+    end
+
+    it "is valid if an address is not provided" do
+      allow(vm).to receive(:ipaddresses).and_return(['127.0.0.1'])
+      conversion_host = ConversionHost.new(:name => "test", :resource => vm)
+      expect(conversion_host.valid?).to be(true)
+    end
+  end
+
+  context "resource validation" do
+    let(:ems) { FactoryBot.create(:ems_redhat, :zone => FactoryBot.create(:zone), :api_version => '4.2.4') }
+    let(:redhat_host) { FactoryBot.create(:host_redhat, :ext_management_system => ems) }
+    let(:azure_vm) { FactoryBot.create(:vm_azure) }
+
+    it "is valid if the associated resource supports conversion hosts" do
+      conversion_host = ConversionHost.new(:name => "test", :resource => redhat_host)
+      expect(conversion_host.valid?).to be(true)
+    end
+
+    it "is invalid if the associated resource does not support conversion hosts" do
+      conversion_host = ConversionHost.new(:name => "test", :resource => azure_vm)
+      expect(conversion_host.valid?).to be(false)
+      expect(conversion_host.errors.messages[:resource].first).to eql("Feature not available/supported")
+    end
+
+    it "is invalid if there is no associated resource" do
+      conversion_host = ConversionHost.new(:name => "test2")
+      expect(conversion_host.valid?).to be(false)
+      expect(conversion_host.errors[:resource].first).to eql("can't be blank")
+    end
+  end
+
+  context "name validation" do
+    let(:ems) { FactoryBot.create(:ems_redhat, :zone => FactoryBot.create(:zone), :api_version => '4.2.4') }
+    let(:redhat_host) { FactoryBot.create(:host_redhat, :name => 'foo', :ext_management_system => ems) }
+
+    it "defaults to the associated resource name if no name is explicitly provided" do
+      conversion_host = ConversionHost.new(:resource => redhat_host)
+      expect(conversion_host.valid?).to be(true)
+      expect(conversion_host.name).to eql(redhat_host.name)
+    end
+  end
+
+  context "authentication associations" do
+    let(:vm) { FactoryBot.create(:vm_openstack) }
+    let(:ems) { FactoryBot.create(:ems_redhat, :zone => FactoryBot.create(:zone), :api_version => '4.2.4') }
+    let(:host) { FactoryBot.create(:host_redhat, :ext_management_system => ems) }
+
+    let(:conversion_host_vm) { FactoryBot.create(:conversion_host, :resource => vm) }
+    let(:conversion_host_host) { FactoryBot.create(:conversion_host, :resource => host) }
+
+    let(:auth_keypair) { FactoryBot.create(:authentication_ssh_keypair, :resource => conversion_host_vm) }
+    let(:auth_v2v) { FactoryBot.create(:authentication_v2v, :resource => conversion_host_host) }
+
+    it "finds associated ssh_keypair authentications" do
+      expect(conversion_host_vm.authentications).to contain_exactly(auth_keypair)
+    end
+
+    it "finds associated v2v authentications" do
+      expect(conversion_host_host.authentications).to contain_exactly(auth_v2v)
+    end
+
+    it "allows a resource to add an authentication" do
+      auth_keypair2 = FactoryBot.create(:authentication_ssh_keypair)
+      conversion_host_vm.authentications << auth_keypair2
+      expect(conversion_host_vm.authentications).to contain_exactly(auth_keypair, auth_keypair2)
+    end
+  end
+
+  context "find_credentials" do
+    let(:auth_v2v) { FactoryBot.create(:authentication_v2v, :resource => conversion_host_vm) }
+    let(:ems_redhat) { FactoryBot.create(:ems_redhat, :zone => FactoryBot.create(:zone), :api_version => '4.2.4') }
+    let(:ems_openstack) { FactoryBot.create(:ems_openstack, :zone => FactoryBot.create(:zone)) }
+    let(:auth_default) { FactoryBot.create(:authentication) }
+
+    let(:host) { FactoryBot.create(:host_redhat, :ext_management_system => ems_redhat) }
+    let(:vm) { FactoryBot.create(:vm_openstack, :ext_management_system => ems_openstack) }
+
+    let(:conversion_host_vm) { FactoryBot.create(:conversion_host, :resource => vm) }
+    let(:conversion_host_host) { FactoryBot.create(:conversion_host, :resource => host) }
+
+    it "finds the v2v credentials as expected when associated directly with the conversion host" do
+      conversion_host_vm.authentications << auth_v2v
+      expect(conversion_host_vm.send(:find_credentials)).to eq(auth_v2v)
+    end
+
+    it "finds the credentials associated with the resource if credentials cannot be found for the conversion host" do
+      vm.ext_management_system.authentications << auth_default
+      host.authentications << auth_default
+      expect(conversion_host_vm.send(:find_credentials)).to eq(auth_default)
+      expect(conversion_host_host.send(:find_credentials)).to eq(auth_default)
+    end
+  end
+
+  context "verify credentials" do
+    let(:vm) { FactoryBot.create(:vm_openstack) }
+    let(:conversion_host_vm) { FactoryBot.create(:conversion_host, :resource => vm) }
+
+    it "works with no associated authentications" do
+      allow(conversion_host_vm).to receive(:connect_ssh).and_return(true)
+      expect(conversion_host_vm.verify_credentials).to be_truthy
+    end
+
+    it "works as expected with no associated authentications if the connect_ssh method fails" do
+      allow(conversion_host_vm).to receive(:connect_ssh).and_raise(Exception.new)
+      expect { conversion_host_vm.verify_credentials }.to raise_error(RuntimeError)
+    end
+
+    it "works if there is an associated validation" do
+      authentication = FactoryBot.create(:authentication_ssh_keypair)
+      conversion_host_vm.authentications << authentication
+      allow(Net::SSH).to receive(:start).and_return(true)
+      expect(conversion_host_vm.verify_credentials).to be_truthy
+    end
+
+    it "works as expected if there is an associated validation that is invalid" do
+      authentication = FactoryBot.create(:authentication_ssh_keypair)
+      conversion_host_vm.authentications << authentication
+      allow(Net::SSH).to receive(:start).and_raise(Net::SSH::AuthenticationFailed.new)
+      expect { conversion_host_vm.verify_credentials }.to raise_error(MiqException::MiqInvalidCredentialsError)
+    end
+
+    it "works if there are multiple associated validations" do
+      authentications = [FactoryBot.create(:authentication_ssh_keypair)] * 2
+      conversion_host_vm.authentications << authentications
+      allow(Net::SSH).to receive(:start).and_return(true)
+      expect(conversion_host_vm.verify_credentials).to be_truthy
+    end
+
+    it "works if an auth_type is explicitly specified" do
+      authentication = FactoryBot.create(:authentication_ssh_keypair)
+      conversion_host_vm.authentications << authentication
+      allow(Net::SSH).to receive(:start).and_return(true)
+      expect(conversion_host_vm.verify_credentials('v2v')).to be_truthy
+    end
+  end
+
+  context "#run_conversion" do
+    let(:vm) { FactoryBot.create(:vm_openstack) }
+    let(:conversion_host) { FactoryBot.create(:conversion_host, :resource => vm) }
+    let(:conversion_options) { {:foo => 1, :bar => 'hello' } }
+
+    it "works as expected if the connection is successful and the JSON is valid" do
+      allow(conversion_host).to receive(:connect_ssh).and_return({:alpha => {:beta => 'hello'}}.to_json)
+      expect(conversion_host.run_conversion(conversion_options)).to eql('alpha' => {'beta' => 'hello'})
+    end
+
+    it "works as expected if the connection is successful but the JSON is invalid" do
+      allow(conversion_host).to receive(:connect_ssh).and_return('bogus')
+      expected_message = "Could not parse result data after running virt-v2v-wrapper.py using "\
+        "options: #{conversion_options}. Result was: bogus."
+      expect { conversion_host.run_conversion(conversion_options) }.to raise_error(expected_message)
+    end
+
+    it "works as expected if the connection is unsuccessful" do
+      allow(conversion_host).to receive(:connect_ssh).and_raise(MiqException::MiqInvalidCredentialsError)
+      expected_message = "Failed to connect and run conversion using options #{conversion_options}"
+      expect { conversion_host.run_conversion(conversion_options) }.to raise_error(/#{expected_message}/)
+    end
+
+    it "works as expected if an unknown error occurs" do
+      allow(conversion_host).to receive(:connect_ssh).and_raise(StandardError)
+      expected_message = "Starting conversion failed on '#{vm.name}'"
+      expect { conversion_host.run_conversion(conversion_options) }.to raise_error(/#{expected_message}/)
+    end
+  end
+
+  context "#get_conversion_state" do
+    let(:vm) { FactoryBot.create(:vm_openstack) }
+    let(:conversion_host) { FactoryBot.create(:conversion_host, :resource => vm) }
+    let(:path) { 'some_path' }
+
+    it "works as expected if the connection is successful and the JSON is valid" do
+      allow(conversion_host).to receive(:connect_ssh).and_return({:alpha => {:beta => 'hello'}}.to_json)
+      expect(conversion_host.get_conversion_state(path)).to eql('alpha' => {'beta' => 'hello'})
+    end
+
+    it "works as expected if the connection is successful but the JSON is invalid" do
+      allow(conversion_host).to receive(:connect_ssh).and_return('bogus')
+      expected_message = "Could not parse conversion state data from file '#{path}': bogus"
+      expect { conversion_host.get_conversion_state(path) }.to raise_error(expected_message)
+    end
+
+    it "works as expected if the connection is unsuccessful" do
+      allow(conversion_host).to receive(:connect_ssh).and_raise(MiqException::MiqInvalidCredentialsError)
+      expected_message = "Failed to connect and retrieve conversion state data from file '#{path}'"
+      expect { conversion_host.get_conversion_state(path) }.to raise_error(/#{expected_message}/)
+    end
+
+    it "works as expected if an unknown error occurs" do
+      allow(conversion_host).to receive(:connect_ssh).and_raise(StandardError)
+      expected_message = "Error retrieving and parsing conversion state file '#{path}' from '#{vm.name}'"
+      expect { conversion_host.get_conversion_state(path) }.to raise_error(/#{expected_message}/)
+    end
+  end
+
+  context "#apply_task_limits" do
+    let(:vm) { FactoryBot.create(:vm_openstack) }
+    let(:conversion_host) { FactoryBot.create(:conversion_host, :resource => vm) }
+    let(:path) { 'some_path' }
+    let(:limits) { { :cpu => '50', :network => '10' } }
+
+    it "works as expected if the connection is successful and the JSON is generated" do
+      allow(conversion_host).to receive(:connect_ssh).and_return(true)
+      expect(conversion_host.apply_task_limits(path, limits)).to be_truthy
+    end
+
+    it "works as expected if the connection is successful but the JSON is invalid" do
+      allow(conversion_host).to receive(:connect_ssh).and_raise(JSON::GeneratorError, 'fake unparser error')
+      expected_message = "Could not generate JSON from limits '#{limits}' with [JSON::GeneratorError: fake unparser error]"
+      expect { conversion_host.apply_task_limits(path, limits) }.to raise_error(expected_message)
+    end
+
+    it "works as expected if the connection is unsuccessful" do
+      allow(conversion_host).to receive(:connect_ssh).and_raise(MiqException::MiqInvalidCredentialsError)
+      expected_message = "Failed to connect and apply limits in file '#{path}'"
+      expect { conversion_host.apply_task_limits(path, limits) }.to raise_error(/#{expected_message}/)
+    end
+
+    it "works as expected if an unknown error occurs" do
+      allow(conversion_host).to receive(:connect_ssh).and_raise(StandardError, 'fake error')
+      expected_message = "Could not apply the limits in '#{path}' on '#{vm.name}' with [StandardError: fake error]"
+      expect { conversion_host.apply_task_limits(path, limits) }.to raise_error(expected_message)
+    end
+  end
+end

--- a/spec/models/infra_conversion_job_spec.rb
+++ b/spec/models/infra_conversion_job_spec.rb
@@ -1,0 +1,209 @@
+RSpec.describe InfraConversionJob, :v2v do
+  let(:vm)      { FactoryBot.create(:vm_or_template) }
+  let(:request) { FactoryBot.create(:service_template_transformation_plan_request) }
+  let(:task)    { FactoryBot.create(:service_template_transformation_plan_task, :miq_request => request, :source => vm) }
+  let(:options) { {:target_class => task.class.name, :target_id => task.id} }
+  let(:job)     { described_class.create_job(options) }
+
+  context '.create_job' do
+    it 'leaves job waiting to start' do
+      job = described_class.create_job(options)
+      expect(job.state).to eq('waiting_to_start')
+    end
+  end
+
+  context 'state transitions' do
+    %w(start poll_conversion start_post_stage poll_post_stage finish abort_job cancel error).each do |signal|
+      shared_examples_for "allows #{signal} signal" do
+        it signal.to_s do
+          expect(job).to receive(signal.to_sym)
+          job.signal(signal.to_sym)
+        end
+      end
+    end
+
+    %w(start poll_conversion start_post_stage poll_post_stage).each do |signal|
+      shared_examples_for "doesn't allow #{signal} signal" do
+        it signal.to_s do
+          expect { job.signal(signal.to_sym) }.to raise_error(RuntimeError, /#{signal} is not permitted at state #{job.state}/)
+        end
+      end
+    end
+
+    context 'waiting_to_start' do
+      before do
+        job.state = 'waiting_to_start'
+      end
+      it_behaves_like 'allows start signal'
+      it_behaves_like 'allows finish signal'
+      it_behaves_like 'allows abort_job signal'
+      it_behaves_like 'allows cancel signal'
+      it_behaves_like 'allows error signal'
+
+      it_behaves_like 'doesn\'t allow poll_conversion signal'
+      it_behaves_like 'doesn\'t allow start_post_stage signal'
+      it_behaves_like 'doesn\'t allow poll_post_stage signal'
+    end
+
+    context 'running' do
+      before do
+        job.state = 'running'
+      end
+
+      it_behaves_like 'allows poll_conversion signal'
+      it_behaves_like 'allows start_post_stage signal'
+      it_behaves_like 'allows finish signal'
+      it_behaves_like 'allows abort_job signal'
+      it_behaves_like 'allows cancel signal'
+      it_behaves_like 'allows error signal'
+
+      it_behaves_like 'doesn\'t allow start signal'
+      it_behaves_like 'doesn\'t allow poll_post_stage signal'
+    end
+
+    context 'post_conversion' do
+      before do
+        job.state = 'post_conversion'
+      end
+
+      it_behaves_like 'allows poll_post_stage signal'
+      it_behaves_like 'allows finish signal'
+      it_behaves_like 'allows abort_job signal'
+      it_behaves_like 'allows cancel signal'
+      it_behaves_like 'allows error signal'
+
+      it_behaves_like 'doesn\'t allow start signal'
+      it_behaves_like 'doesn\'t allow poll_conversion signal'
+      it_behaves_like 'doesn\'t allow start_post_stage signal'
+    end
+  end
+
+  context 'operations' do
+    let(:poll_interval) { Settings.transformation.limits.conversion_polling_interval }
+
+    before do
+      allow(job).to receive(:migration_task).and_return(task)
+    end
+
+    context '#start' do
+      it 'to poll_conversion when preflight_check passes' do
+        expect(task).to receive(:preflight_check)
+        expect(job).to receive(:queue_signal).with(:poll_conversion)
+        job.signal(:start)
+      end
+
+      it 'to abort_conversion when preflight_check failed' do
+        expect(task).to receive(:preflight_check).and_raise
+        expect(job).to receive(:abort_conversion)
+        job.signal(:start)
+      end
+    end
+
+    context '#poll_conversion' do
+      before do
+        job.state = 'running'
+        task.options[:virtv2v_wrapper] = {'state_file' => 'something'}
+      end
+
+      it 'to poll_conversion when migration_task.options[:virtv2v_wrapper] is nil' do
+        task.options[:virtv2v_wrapper] = nil
+        Timecop.freeze(2019, 2, 6) do
+          expect(job).to receive(:queue_signal).with(:poll_conversion, :deliver_on => Time.now.utc + poll_interval)
+          job.signal(:poll_conversion)
+        end
+      end
+
+      it 'to poll_conversion when migration_task.options[:virtv2v_wrapper][:state_file] is nil' do
+        task.options[:virtv2v_wrapper] = {'state_file' => nil}
+        Timecop.freeze(2019, 2, 6) do
+          expect(job).to receive(:queue_signal).with(:poll_conversion, :deliver_on => Time.now.utc + poll_interval)
+          job.signal(:poll_conversion)
+        end
+      end
+
+      it 'abort_conversion when get_conversion_state fails' do
+        expect(task).to receive(:get_conversion_state).and_raise
+        expect(job).to receive(:abort_conversion)
+        job.signal(:poll_conversion)
+      end
+
+      it 'to poll_conversion when migration_task.options[:virtv2v_status] is active' do
+        task.options[:virtv2v_status] = 'active'
+        Timecop.freeze(2019, 2, 6) do
+          expect(task).to receive(:get_conversion_state)
+          expect(job).to receive(:queue_signal).with(:poll_conversion, :deliver_on => Time.now.utc + poll_interval)
+          job.signal(:poll_conversion)
+        end
+      end
+
+      it 'abort_conversion when migration_task.options[:virtv2v_status] is failed' do
+        task.options[:virtv2v_status] = 'failed'
+        expect(task).to receive(:get_conversion_state)
+        expect(job).to receive(:abort_conversion)
+        job.signal(:poll_conversion)
+      end
+
+      it 'to start_post_stage when migration_task.options[:virtv2v_status] is succeeded' do
+        task.options[:virtv2v_status] = 'succeeded'
+        expect(task).to receive(:get_conversion_state)
+        expect(job).to receive(:queue_signal).with(:start_post_stage)
+        job.signal(:poll_conversion)
+      end
+
+      it 'abort_conversion when migration_task.options[:virtv2v_status] is unknown' do
+        task.options[:virtv2v_status] = '_'
+        expect(task).to receive(:get_conversion_state)
+        expect(job).to receive(:abort_conversion)
+        job.signal(:poll_conversion)
+      end
+
+      it 'abort_conversion when poll_conversion times out' do
+        job.options[:poll_conversion_max] = 24 * 60
+        job.context[:poll_conversion_count] = 24 * 60
+        expect(job).to receive(:abort_conversion)
+        job.signal(:poll_conversion)
+      end
+    end
+
+    context '#start_post_stage' do
+      it 'to poll_post_stage when signaled :start_post_stage' do
+        job.state = 'running'
+        Timecop.freeze(2019, 2, 6) do
+          expect(job).to receive(:queue_signal).with(:poll_post_stage, :deliver_on => Time.now.utc + poll_interval)
+          job.signal(:start_post_stage)
+        end
+      end
+    end
+
+    context '#poll_post_stage' do
+      before do
+        job.state = 'post_conversion'
+      end
+
+      it 'to poll_post_stage when migration_task.state is not finished' do
+        task.state = 'not-finished'
+        Timecop.freeze(2019, 2, 6) do
+          expect(job).to receive(:queue_signal).with(:poll_post_stage, :deliver_on => Time.now.utc + poll_interval)
+          job.signal(:poll_post_stage)
+        end
+      end
+
+      it 'to finish when migration_task.state is finished' do
+        task.state = 'finished'
+        task.status = 'whatever'
+        Timecop.freeze(2019, 2, 6) do
+          expect(job).to receive(:queue_signal).with(:finish)
+          job.signal(:poll_post_stage)
+          expect(job.status).to eq(task.status)
+        end
+      end
+
+      it 'abort_conversion when poll_post_stage times out' do
+        job.options[:poll_post_stage_max] = 30
+        job.context[:poll_post_stage_count] = 30
+        expect(job).to receive(:abort_conversion)
+        job.signal(:poll_post_stage)
+      end
+    end
+  end
+end

--- a/spec/models/service_template_transformation_plan_request_spec.rb
+++ b/spec/models/service_template_transformation_plan_request_spec.rb
@@ -1,0 +1,171 @@
+RSpec.describe ServiceTemplateTransformationPlanRequest, :v2v do
+  let(:vms) { Array.new(3) { FactoryBot.create(:vm_or_template) } }
+  let(:vm_requests) do
+    [ServiceResource::STATUS_QUEUED, ServiceResource::STATUS_FAILED, ServiceResource::STATUS_APPROVED].zip(vms).collect do |status, vm|
+      ServiceResource.new(:resource => vm, :status => status)
+    end
+  end
+
+  let(:plan) { FactoryBot.create(:service_template_transformation_plan, :service_resources => vm_requests) }
+  let(:request) { FactoryBot.create(:service_template_transformation_plan_request, :source => plan) }
+
+  describe '#requested_task_idx' do
+    it 'selects approved vm requests' do
+      expect(request.requested_task_idx.first).to have_attributes(:resource => vms[2], :status => ServiceResource::STATUS_APPROVED)
+    end
+  end
+
+  describe 'customize_request_task_attributes' do
+    it 'sets the source option to be the vm in the vm_request' do
+      req_task_attrs = {}
+      request.customize_request_task_attributes(req_task_attrs, vm_requests[0])
+      expect(req_task_attrs[:source]).to eq(vms[0])
+    end
+  end
+
+  describe '#source_vms' do
+    it 'selects queued and failed vm in the request' do
+      expect(request.source_vms).to match_array([vms[0].id, vms[1].id])
+    end
+  end
+
+  describe '#validate_conversion_hosts' do
+    context 'no conversion host exists in EMS' do
+      let(:dst_ems) { FactoryBot.create(:ext_management_system) }
+      let(:src_cluster) { FactoryBot.create(:ems_cluster) }
+      let(:dst_cluster) { FactoryBot.create(:ems_cluster, :ext_management_system => dst_ems) }
+
+      let(:mapping) do
+        FactoryBot.create(
+          :transformation_mapping,
+          :transformation_mapping_items => [TransformationMappingItem.new(:source => src_cluster, :destination => dst_cluster)]
+        )
+      end
+
+      let(:catalog_item_options) do
+        {
+          :name        => 'Transformation Plan',
+          :description => 'a description',
+          :config_info => {
+            :transformation_mapping_id => mapping.id,
+            :actions                   => [
+              {:vm_id => vms.first.id.to_s, :pre_service => false, :post_service => false},
+              {:vm_id => vms.last.id.to_s, :pre_service => false, :post_service => false},
+            ],
+          }
+        }
+      end
+
+      let(:plan) { ServiceTemplateTransformationPlan.create_catalog_item(catalog_item_options) }
+      let(:request) { FactoryBot.create(:service_template_transformation_plan_request, :source => plan) }
+
+      it 'returns false' do
+        host = FactoryBot.create(:host_redhat, :ext_management_system => FactoryBot.create(:ext_management_system, :zone => FactoryBot.create(:zone), :api_version => '4.2.4'))
+        conversion_host = FactoryBot.create(:conversion_host, :resource => host)
+        expect(request.validate_conversion_hosts).to be false
+      end
+    end
+
+    context 'conversion host exists in EMS and resource is a Host' do
+      let(:dst_ems) { FactoryBot.create(:ems_redhat, :api_version => '4.2.4') }
+      let(:src_cluster) { FactoryBot.create(:ems_cluster) }
+      let(:dst_cluster) { FactoryBot.create(:ems_cluster, :ext_management_system => dst_ems) }
+
+      let(:mapping) do
+        FactoryBot.create(
+          :transformation_mapping,
+          :transformation_mapping_items => [TransformationMappingItem.new(:source => src_cluster, :destination => dst_cluster)]
+        )
+      end
+
+      let(:catalog_item_options) do
+        {
+          :name        => 'Transformation Plan',
+          :description => 'a description',
+          :config_info => {
+            :transformation_mapping_id => mapping.id,
+            :actions                   => [
+              {:vm_id => vms.first.id.to_s, :pre_service => false, :post_service => false},
+              {:vm_id => vms.last.id.to_s, :pre_service => false, :post_service => false},
+            ],
+          }
+        }
+      end
+
+      let(:plan) { ServiceTemplateTransformationPlan.create_catalog_item(catalog_item_options) }
+      let(:request) { FactoryBot.create(:service_template_transformation_plan_request, :source => plan) }
+
+      it 'returns true' do
+        host = FactoryBot.create(:host_redhat, :ext_management_system => dst_ems, :ems_cluster => dst_cluster)
+        conversion_host = FactoryBot.create(:conversion_host, :resource => host)
+        expect(request.validate_conversion_hosts).to be true
+      end
+    end
+
+    context 'conversion host exists in EMS and resource is a Vm' do
+      let(:dst_ems) { FactoryBot.create(:ems_openstack) }
+      let(:src_cluster) { FactoryBot.create(:ems_cluster) }
+      let(:dst_cloud_tenant) { FactoryBot.create(:cloud_tenant, :ext_management_system => dst_ems) }
+
+      let(:mapping) do
+        FactoryBot.create(
+          :transformation_mapping,
+          :transformation_mapping_items => [TransformationMappingItem.new(:source => src_cluster, :destination => dst_cloud_tenant)]
+        )
+      end
+
+      let(:catalog_item_options) do
+        {
+          :name        => 'Transformation Plan',
+          :description => 'a description',
+          :config_info => {
+            :transformation_mapping_id => mapping.id,
+            :actions                   => [
+              {:vm_id => vms.first.id.to_s, :pre_service => false, :post_service => false},
+              {:vm_id => vms.last.id.to_s, :pre_service => false, :post_service => false},
+            ],
+          }
+        }
+      end
+
+      let(:plan) { ServiceTemplateTransformationPlan.create_catalog_item(catalog_item_options) }
+      let(:request) { FactoryBot.create(:service_template_transformation_plan_request, :source => plan) }
+
+      it 'returns true' do
+        vm = FactoryBot.create(:vm_openstack, :ext_management_system => dst_ems, :cloud_tenant => dst_cloud_tenant)
+        conversion_host = FactoryBot.create(:conversion_host, :resource => vm)
+        expect(request.validate_conversion_hosts).to be true
+      end
+    end
+  end
+
+  describe '#validate_vm' do
+    it { expect(request.validate_vm(vms[0].id)).to be_truthy }
+  end
+
+  describe '#approve_vm' do
+    it 'turns the status to Approved' do
+      request.approve_vm(vms[0].id)
+      expect(ServiceResource.find_by(:resource => vms[0]).status).to eq(ServiceResource::STATUS_APPROVED)
+    end
+  end
+
+  context "when request gets canceled" do
+    before { request.cancel }
+
+    it "cancelation_status is set to requested" do
+      expect(request.cancelation_status).to eq(MiqRequest::CANCEL_STATUS_REQUESTED)
+      expect(request.cancel_requested?).to be_truthy
+      expect(request.canceling?).to be_falsey
+      expect(request.canceled?).to be_falsey
+    end
+
+    it "marks request as finished in error" do
+      request.send(:do_cancel)
+      expect(request.cancelation_status).to eq(MiqRequest::CANCEL_STATUS_FINISHED)
+      expect(request.request_state).to eq('finished')
+      expect(request.status).to eq('Error')
+      expect(request.message).to eq('Request is canceled by user.')
+    end
+  end
+end

--- a/spec/models/service_template_transformation_plan_spec.rb
+++ b/spec/models/service_template_transformation_plan_spec.rb
@@ -1,0 +1,305 @@
+RSpec.describe ServiceTemplateTransformationPlan, :v2v do
+  subject { FactoryBot.create(:service_template_transformation_plan) }
+
+  describe '#request_class' do
+    it { expect(subject.request_class).to eq(ServiceTemplateTransformationPlanRequest) }
+  end
+
+  describe '#request_type' do
+    it { expect(subject.request_type).to eq("transformation_plan") }
+  end
+
+  describe '#validate_order' do
+    it 'always allows a plan to be ordered' do
+      expect(subject.validate_order).to be_truthy
+      expect(subject.orderable?).to be_truthy # alias
+    end
+  end
+
+  let(:transformation_mapping) { FactoryBot.create(:transformation_mapping) }
+  let(:transformation_mapping2) { FactoryBot.create(:transformation_mapping) }
+  let(:apst) { FactoryBot.create(:service_template_ansible_playbook) }
+  let(:vm1) { FactoryBot.create(:vm_or_template) }
+  let(:vm2) { FactoryBot.create(:vm_or_template) }
+  let(:vm3) { FactoryBot.create(:vm_or_template) }
+  let(:security_group1) { FactoryBot.create(:security_group, :name => "default") }
+  let(:flavor1) { FactoryBot.create(:flavor, :name => "large") }
+  let(:security_group2) { FactoryBot.create(:security_group, :name => "default") }
+  let(:flavor2) { FactoryBot.create(:flavor, :name => "medium") }
+
+  let(:catalog_item_options) do
+    {
+      :name        => 'Transformation Plan',
+      :description => 'a description',
+      :config_info => {
+        :transformation_mapping_id => transformation_mapping.id,
+        :pre_service_id            => apst.id,
+        :post_service_id           => apst.id,
+        :actions                   => [
+          {:vm_id => vm1.id.to_s, :pre_service => true, :post_service => false, :osp_security_group_id => security_group1.id, :osp_flavor_id => flavor1.id},
+          {:vm_id => vm2.id.to_s, :pre_service => true, :post_service => true, :osp_security_group_id => security_group1.id, :osp_flavor_id => flavor1.id}
+        ],
+      }
+    }
+  end
+
+  let(:updated_catalog_item_options_with_vms_added) do
+    {
+      :name        => 'Transformation Plan Updated',
+      :description => 'an updated description',
+      :config_info => {
+        :transformation_mapping_id => transformation_mapping.id,
+        :pre_service_id            => apst.id,
+        :post_service_id           => apst.id,
+        :actions                   => [
+          {:vm_id => vm1.id.to_s, :pre_service => true, :post_service => false, :osp_security_group_id => security_group1.id, :osp_flavor_id => flavor1.id},
+          {:vm_id => vm2.id.to_s, :pre_service => true, :post_service => true, :osp_security_group_id => security_group1.id, :osp_flavor_id => flavor1.id},
+          {:vm_id => vm3.id.to_s, :pre_service => true, :post_service => true, :osp_security_group_id => security_group2.id, :osp_flavor_id => flavor2.id}
+        ],
+      }
+    }
+  end
+
+  let(:updated_catalog_item_options_with_vms_removed) do
+    {
+      :name        => 'Transformation Plan Updated',
+      :description => 'an updated description',
+      :config_info => {
+        :transformation_mapping_id => transformation_mapping.id,
+        :pre_service_id            => apst.id,
+        :post_service_id           => apst.id,
+        :actions                   => [
+          {:vm_id => vm1.id.to_s, :pre_service => true, :post_service => false}
+        ],
+      }
+    }
+  end
+
+  let(:updated_catalog_item_options_with_vms_added_and_removed) do
+    {
+      :name        => 'Transformation Plan Updated',
+      :description => 'an updated description',
+      :config_info => {
+        :transformation_mapping_id => transformation_mapping.id,
+        :pre_service_id            => apst.id,
+        :post_service_id           => apst.id,
+        :actions                   => [
+          {:vm_id => vm1.id.to_s, :pre_service => true, :post_service => false},
+          {:vm_id => vm3.id.to_s, :pre_service => true, :post_service => true}
+        ],
+      }
+    }
+  end
+
+  let(:updated_options_with_updated_transformation_mapping) do
+    {
+      :name        => 'Transformation Plan Updated',
+      :description => 'an updated description',
+      :config_info => {
+        :transformation_mapping_id => transformation_mapping2.id,
+        :pre_service_id            => apst.id,
+        :post_service_id           => apst.id,
+        :actions                   => [
+          {:vm_id => vm1.id.to_s, :pre_service => true, :post_service => false},
+          {:vm_id => vm2.id.to_s, :pre_service => true, :post_service => true}
+        ],
+      }
+    }
+  end
+
+  let(:miq_requests) { [FactoryBot.create(:service_template_transformation_plan_request, :request_state => "finished")] }
+  let(:miq_requests_with_in_progress_request) { [FactoryBot.create(:service_template_transformation_plan_request, :request_state => "active")] }
+
+  describe '.public_service_templates' do
+    it 'display public service templates' do
+      st1 = FactoryBot.create(:service_template_transformation_plan)
+      st2 = FactoryBot.create(:service_template)
+
+      expect(st1.internal?).to be_truthy
+      expect(st2.internal?).to be_falsey
+      expect(ServiceTemplate.public_service_templates).to match_array([st2])
+    end
+  end
+
+  describe '.create_catalog_item' do
+    it 'creates and returns a transformation plan' do
+      service_template = described_class.create_catalog_item(catalog_item_options)
+
+      expect(service_template.name).to eq('Transformation Plan')
+      expect(service_template.transformation_mapping).to eq(transformation_mapping)
+      expect(service_template.vm_resources.collect(&:resource)).to match_array([vm1, vm2])
+      expect(service_template.vm_resources.collect(&:status)).to eq([ServiceResource::STATUS_QUEUED, ServiceResource::STATUS_QUEUED])
+      expect(service_template.vm_resources.find_by(:resource_id => vm1.id).options)
+        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id)
+      expect(service_template.vm_resources.find_by(:resource_id => vm2.id).options)
+        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "post_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id)
+      expect(service_template.config_info).to eq(catalog_item_options[:config_info])
+      expect(service_template.resource_actions.first).to have_attributes(
+        :action => 'Provision',
+        :fqname => described_class.default_provisioning_entry_point(nil)
+      )
+    end
+
+    it 'requires a transformation mapping' do
+      catalog_item_options[:config_info].delete(:transformation_mapping_id)
+
+      expect do
+        described_class.create_catalog_item(catalog_item_options)
+      end.to raise_error(StandardError, 'Must provide an existing transformation mapping')
+    end
+
+    it 'requires selected vms' do
+      catalog_item_options[:config_info].delete(:actions)
+
+      expect do
+        described_class.create_catalog_item(catalog_item_options)
+      end.to raise_error(StandardError, 'Must select a list of valid vms')
+    end
+
+    it 'validates unique name' do
+      described_class.create_catalog_item(catalog_item_options)
+      expect { described_class.create_catalog_item(catalog_item_options) }.to raise_error(
+        ActiveRecord::RecordInvalid, 'Validation failed: ServiceTemplateTransformationPlan: Name has already been taken'
+      )
+    end
+  end
+
+  describe '#update_catalog_item' do
+    it 'updates the associated transformation mapping' do
+      service_template = described_class.create_catalog_item(catalog_item_options)
+      service_template.miq_requests = []
+      service_template.update_catalog_item(updated_options_with_updated_transformation_mapping)
+      expect(service_template.name).to eq('Transformation Plan Updated')
+      expect(service_template.transformation_mapping).to eq(transformation_mapping2)
+    end
+
+    it 'updates by adding new VMs to existing VMs and returns a transformation plan' do
+      service_template = described_class.create_catalog_item(catalog_item_options)
+      service_template.miq_requests = []
+      service_template.update_catalog_item(updated_catalog_item_options_with_vms_added)
+
+      expect(service_template.name).to eq('Transformation Plan Updated')
+      expect(service_template.transformation_mapping).to eq(transformation_mapping)
+      expect(service_template.vm_resources.collect(&:resource)).to match_array([vm1, vm2, vm3])
+      expect(service_template.vm_resources.collect(&:status)).to eq([ServiceResource::STATUS_QUEUED, ServiceResource::STATUS_QUEUED, ServiceResource::STATUS_QUEUED])
+      expect(service_template.vm_resources.find_by(:resource_id => vm1.id).options)
+        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id)
+      expect(service_template.vm_resources.find_by(:resource_id => vm2.id).options)
+        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "post_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id)
+      expect(service_template.vm_resources.find_by(:resource_id => vm3.id).options)
+        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "post_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group2.id, "osp_flavor_id" => flavor2.id)
+      expect(service_template.config_info).to eq(updated_catalog_item_options_with_vms_added[:config_info])
+      expect(service_template.resource_actions.first).to have_attributes(
+        :action => 'Provision',
+        :fqname => described_class.default_provisioning_entry_point(nil)
+      )
+    end
+
+    it 'updates by removing some VMs from the existing VMs and returns a transformation plan' do
+      service_template = described_class.create_catalog_item(catalog_item_options)
+      service_template.miq_requests = []
+      service_template.update_catalog_item(updated_catalog_item_options_with_vms_removed)
+
+      expect(service_template.name).to eq('Transformation Plan Updated')
+      expect(service_template.transformation_mapping).to eq(transformation_mapping)
+      expect(service_template.vm_resources.collect(&:resource)).to match_array([vm1])
+      expect(service_template.vm_resources.collect(&:status)).to eq([ServiceResource::STATUS_QUEUED])
+      expect(service_template.vm_resources.find_by(:resource_id => vm1.id).options)
+        .to eq("pre_ansible_playbook_service_template_id" => apst.id)
+      expect(service_template.config_info).to eq(updated_catalog_item_options_with_vms_removed[:config_info])
+      expect(service_template.resource_actions.first).to have_attributes(
+        :action => 'Provision',
+        :fqname => described_class.default_provisioning_entry_point(nil)
+      )
+    end
+
+    it 'updates by adding new VMs to the existing VMs and removing some VMs from the existing VMs and returns a transformation plan' do
+      service_template = described_class.create_catalog_item(catalog_item_options)
+      service_template.miq_requests = []
+      service_template.update_catalog_item(updated_catalog_item_options_with_vms_added_and_removed)
+
+      expect(service_template.name).to eq('Transformation Plan Updated')
+      expect(service_template.transformation_mapping).to eq(transformation_mapping)
+      expect(service_template.vm_resources.collect(&:resource)).to match_array([vm1, vm3])
+      expect(service_template.vm_resources.collect(&:status)).to eq([ServiceResource::STATUS_QUEUED, ServiceResource::STATUS_QUEUED])
+      expect(service_template.vm_resources.find_by(:resource_id => vm1.id).options)
+        .to eq("pre_ansible_playbook_service_template_id" => apst.id)
+      expect(service_template.vm_resources.find_by(:resource_id => vm3.id).options)
+        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "post_ansible_playbook_service_template_id" => apst.id)
+      expect(service_template.config_info).to eq(updated_catalog_item_options_with_vms_added_and_removed[:config_info])
+      expect(service_template.resource_actions.first).to have_attributes(
+        :action => 'Provision',
+        :fqname => described_class.default_provisioning_entry_point(nil)
+      )
+    end
+
+    it 'updates only the basic attributes' do
+      service_template = described_class.create_catalog_item(catalog_item_options)
+      service_template.miq_requests = []
+      service_template.update_catalog_item(:name => "Name updated", :description => "description updated")
+
+      expect(service_template.name).to eq('Name updated')
+      expect(service_template.description).to eq('description updated')
+      expect(service_template.transformation_mapping).to eq(transformation_mapping)
+      expect(service_template.vm_resources.collect(&:resource)).to match_array([vm1, vm2])
+      expect(service_template.vm_resources.collect(&:status)).to eq([ServiceResource::STATUS_QUEUED, ServiceResource::STATUS_QUEUED])
+      expect(service_template.vm_resources.find_by(:resource_id => vm1.id).options)
+        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id)
+      expect(service_template.vm_resources.find_by(:resource_id => vm2.id).options)
+        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "post_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id)
+      expect(service_template.config_info).to eq(catalog_item_options[:config_info])
+      expect(service_template.resource_actions.first).to have_attributes(
+        :action => 'Provision',
+        :fqname => described_class.default_provisioning_entry_point(nil)
+      )
+    end
+
+    it 'updates only the basic attributes when completed miq_requests are present' do
+      service_template = described_class.create_catalog_item(catalog_item_options)
+      service_template.miq_requests = miq_requests
+      service_template.update_catalog_item(updated_catalog_item_options_with_vms_added)
+
+      expect(service_template.name).to eq('Transformation Plan Updated')
+      expect(service_template.description).to eq('an updated description')
+      expect(service_template.transformation_mapping).to eq(transformation_mapping)
+      expect(service_template.vm_resources.collect(&:resource)).to match_array([vm1, vm2])
+      expect(service_template.vm_resources.find_by(:resource_id => vm1.id).options)
+        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id)
+      expect(service_template.vm_resources.find_by(:resource_id => vm2.id).options)
+        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "post_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id)
+      expect(service_template.config_info).to eq(catalog_item_options[:config_info])
+      expect(service_template.resource_actions.first).to have_attributes(
+        :action => 'Provision',
+        :fqname => described_class.default_provisioning_entry_point(nil)
+      )
+    end
+
+    it 'raises an exception when miq_request is in progress' do
+      service_template = described_class.create_catalog_item(catalog_item_options)
+      service_template.miq_requests = miq_requests_with_in_progress_request
+      expect do
+        service_template.update_catalog_item(updated_catalog_item_options_with_vms_added)
+      end.to raise_error(StandardError, 'Editing a plan in progress is prohibited')
+    end
+
+    it 'requires a transformation mapping' do
+      updated_catalog_item_options_with_vms_added[:config_info].delete(:transformation_mapping_id)
+
+      service_template = described_class.create_catalog_item(catalog_item_options)
+
+      expect do
+        service_template.update_catalog_item(updated_catalog_item_options_with_vms_added)
+      end.to raise_error(StandardError, 'Must provide an existing transformation mapping')
+    end
+
+    it 'requires selected vms' do
+      updated_catalog_item_options_with_vms_added[:config_info].delete(:actions)
+
+      service_template = described_class.create_catalog_item(catalog_item_options)
+
+      expect do
+        service_template.update_catalog_item(updated_catalog_item_options_with_vms_added)
+      end.to raise_error(StandardError, 'Must select a list of valid vms')
+    end
+  end
+end

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -1,0 +1,683 @@
+RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
+  let(:infra_conversion_job) { FactoryBot.create(:infra_conversion_job) }
+
+  describe '.base_model' do
+    it { expect(described_class.base_model).to eq(ServiceTemplateTransformationPlanTask) }
+  end
+
+  describe '#after_request_task_create' do
+    it 'does not create child tasks' do
+      allow(subject).to receive(:source).and_return(double('vm', :name => 'any'))
+      expect(subject).not_to receive(:create_child_tasks)
+      expect(subject).to receive(:update_attributes).with(hash_including(:description))
+      subject.after_request_task_create
+    end
+  end
+
+  context 'independent of provider' do
+    let(:src) { FactoryBot.create(:ems_cluster) }
+    let(:dst) { FactoryBot.create(:ems_cluster) }
+    let(:host) { FactoryBot.create(:host, :ext_management_system => FactoryBot.create(:ext_management_system, :zone => FactoryBot.create(:zone))) }
+    let(:vm)  { FactoryBot.create(:vm_or_template) }
+    let(:vm2)  { FactoryBot.create(:vm_or_template) }
+    let(:apst) { FactoryBot.create(:service_template_ansible_playbook) }
+    let(:conversion_host) { FactoryBot.create(:conversion_host, :skip_validate, :resource => host) }
+
+    let(:mapping) do
+      FactoryBot.create(
+        :transformation_mapping,
+        :transformation_mapping_items => [TransformationMappingItem.new(:source => src, :destination => dst)]
+      )
+    end
+
+    let(:catalog_item_options) do
+      {
+        :name        => 'Transformation Plan',
+        :description => 'a description',
+        :config_info => {
+          :transformation_mapping_id => mapping.id,
+          :pre_service_id            => apst.id,
+          :post_service_id           => apst.id,
+          :actions                   => [
+            {:vm_id => vm.id.to_s, :pre_service => true, :post_service => true},
+            {:vm_id => vm2.id.to_s, :pre_service => false, :post_service => false},
+          ],
+        }
+      }
+    end
+
+    let(:plan) { ServiceTemplateTransformationPlan.create_catalog_item(catalog_item_options) }
+
+    let(:request) { FactoryBot.create(:service_template_transformation_plan_request, :source => plan) }
+    let(:task) { FactoryBot.create(:service_template_transformation_plan_task, :miq_request => request, :request_type => 'transformation_plan', :source => vm) }
+    let(:task2) { FactoryBot.create(:service_template_transformation_plan_task, :miq_request => request, :request_type => 'transformation_plan', :source => vm2) }
+
+    describe '#resource_action' do
+      it 'has a resource action points to the entry point for transformation' do
+        expect(task.resource_action).to have_attributes(
+          :action => 'Provision',
+          :fqname => ServiceTemplateTransformationPlan.default_provisioning_entry_point(nil)
+        )
+      end
+    end
+
+    describe '#transformation_destination' do
+      it { expect(task.transformation_destination(src)).to eq(dst) }
+    end
+
+    describe '#pre_ansible_playbook_service_template' do
+      it { expect(task.pre_ansible_playbook_service_template).to eq(apst) }
+      it { expect(task2.pre_ansible_playbook_service_template).to be_nil }
+    end
+
+    describe '#post_ansible_playbook_service_template' do
+      it { expect(task.post_ansible_playbook_service_template).to eq(apst) }
+      it { expect(task2.post_ansible_playbook_service_template).to be_nil }
+    end
+
+    describe '#update_transformation_progress' do
+      it 'saves the progress in options' do
+        task.update_transformation_progress(:vm_percent => '80')
+        expect(task.options[:progress]).to eq(:vm_percent => '80')
+      end
+    end
+
+    describe 'task_active' do
+      it 'sets vm_request status to Started' do
+        task.task_active
+        expect(plan.vm_resources.find_by(:resource => task.source).status).to eq(ServiceResource::STATUS_ACTIVE)
+      end
+    end
+
+    describe 'task_finished' do
+      it 'sets vm_request status to Completed' do
+        task.task_finished
+        expect(plan.vm_resources.find_by(:resource => task.source).status).to eq(ServiceResource::STATUS_COMPLETED)
+      end
+    end
+
+    describe '.get_description' do
+      it 'describes a task' do
+        expect(described_class.get_description(task)).to include("Transforming VM")
+      end
+
+      it 'describes a request' do
+        expect(described_class.get_description(request)).to eq(plan.name)
+      end
+    end
+
+    describe '#transformation_log_queue' do
+      context 'when conversion host exists' do
+        before do
+          task.conversion_host = conversion_host
+
+          allow(described_class).to receive(:find).and_return(task)
+
+          allow(MiqTask).to receive(:wait_for_taskid) do
+            request = MiqQueue.find_by(:class_name => described_class.name)
+            request.update_attributes(:state => MiqQueue::STATE_DEQUEUE)
+            request.delivered(*request.deliver)
+          end
+        end
+
+        it 'raises when log type is invalid' do
+          msg = "Transformation log type 'invalid' not supported"
+          expect { task.transformation_log_queue('user', 'invalid') }.to raise_error(msg)
+        end
+
+        it 'gets the transformation log from conversion host' do
+          expect(task).to receive(:transformation_log).and_return('transformation migration log content')
+          taskid = task.transformation_log_queue('user')
+          MiqTask.wait_for_taskid(taskid)
+          expect(MiqTask.find(taskid)).to have_attributes(
+            :task_results => 'transformation migration log content',
+            :status       => 'Ok'
+          )
+        end
+
+        it 'returns the error message' do
+          msg = 'Failed to get transformation migration log for some reason'
+          expect(task).to receive(:transformation_log).and_raise(msg)
+          taskid = task.transformation_log_queue('user')
+          MiqTask.wait_for_taskid(taskid)
+          expect(MiqTask.find(taskid).message).to include(msg)
+          expect(MiqTask.find(taskid).status).to eq('Error')
+        end
+      end
+
+      context 'when conversion host does not exist' do
+        it 'returns an error message' do
+          taskid = task.transformation_log_queue('user')
+          expect(MiqTask.find(taskid)).to have_attributes(
+            :message => "Conversion host was not found. Cannot queue the download of v2v log.",
+            :status  => 'Error'
+          )
+        end
+      end
+    end
+
+    describe '#transformation_log' do
+      before do
+        task.conversion_host = conversion_host
+        task.options.store_path(:virtv2v_wrapper, "v2v_log", "/path/to/log.file")
+        task.save!
+      end
+
+      it 'requires transformation log location in options' do
+        task.options.store_path(:virtv2v_wrapper, "v2v_log", "")
+        expect { task.transformation_log("v2v") }.to raise_error(MiqException::Error)
+      end
+
+      it 'gets the transformation log content' do
+        msg = 'my transformation migration log'
+        allow(conversion_host).to receive(:get_conversion_log).with(task.options[:virtv2v_wrapper]['v2v_log']).and_return(msg)
+        expect(task.transformation_log("v2v")).to eq(msg)
+      end
+    end
+
+    describe '#mark_vm_migrated' do
+      it 'should tag VM as migrated' do
+        task.mark_vm_migrated
+        expect(vm).to be_is_tagged_with("migrated", :ns => "/managed", :cat => "transformation_status")
+      end
+    end
+
+    describe '#cancel' do
+      it 'catches cancel state' do
+        task.options[:infra_conversion_job_id] = infra_conversion_job.id
+        expect(task).to receive(:infra_conversion_job).and_return(infra_conversion_job)
+        expect(infra_conversion_job).to receive(:cancel)
+        task.cancel
+        expect(task.cancelation_status).to eq(MiqRequestTask::CANCEL_STATUS_REQUESTED)
+        expect(task.cancel_requested?).to be_truthy
+      end
+    end
+
+    describe '#kill_virtv2v' do
+      before do
+        task.options = {
+          :virtv2v_wrapper    => { 'state_file' => '/tmp/v2v.state', 'pid' => '1234' },
+          :virtv2v_started_on => 1
+        }
+        task.conversion_host = conversion_host
+        allow(conversion_host).to receive(:get_conversion_state).with(task.options[:virtv2v_wrapper]['state_file']).and_return({})
+      end
+
+      it "returns false if not started" do
+        task.options[:virtv2v_started_on] = nil
+        expect(conversion_host).not_to receive(:kill_process)
+        expect(task.kill_virtv2v('KILL')).to eq(false)
+      end
+
+      it "returns false if finished" do
+        task.options[:virtv2v_finished_on] = 1
+        expect(conversion_host).not_to receive(:kill_process)
+        expect(task.kill_virtv2v('KILL')).to eq(false)
+      end
+
+      it "returns false if virtv2v_wrapper is absent" do
+        task.options[:virtv2v_wrapper] = nil
+        expect(conversion_host).not_to receive(:kill_process)
+        expect(task.kill_virtv2v('KILL')).to eq(false)
+      end
+
+      it "returns false if virtv2v_wrapper.pid is absent" do
+        task.options[:virtv2v_wrapper]['pid'] = nil
+        expect(conversion_host).not_to receive(:kill_process)
+        expect(task.kill_virtv2v('KILL')).to eq(false)
+      end
+
+      it "returns false if if kill command failed" do
+        expect(conversion_host).to receive(:kill_process).with('1234', 'KILL').and_return(false)
+        expect(task.kill_virtv2v('KILL')).to eq(false)
+      end
+
+      it "returns true if if kill command succeeded" do
+        expect(conversion_host).to receive(:kill_process).with('1234', 'KILL').and_return(true)
+        expect(task.kill_virtv2v('KILL')).to eq(true)
+      end
+    end
+  end
+
+  context 'populated request and task' do
+    let(:src_ems) { FactoryBot.create(:ext_management_system, :zone => FactoryBot.create(:zone)) }
+    let(:src_cluster) { FactoryBot.create(:ems_cluster, :ext_management_system => src_ems) }
+    let(:dst_ems) { FactoryBot.create(:ext_management_system, :zone => FactoryBot.create(:zone)) }
+    let(:dst_cluster) { FactoryBot.create(:ems_cluster, :ext_management_system => dst_ems) }
+
+    let(:src_vm_1)  { FactoryBot.create(:vm_or_template, :ext_management_system => src_ems, :ems_cluster => src_cluster) }
+    let(:src_vm_2)  { FactoryBot.create(:vm_or_template, :ext_management_system => src_ems, :ems_cluster => src_cluster) }
+    let(:apst) { FactoryBot.create(:service_template_ansible_playbook) }
+
+    let(:dst_flavor) { FactoryBot.create(:flavor) }
+    let(:dst_security_group) { FactoryBot.create(:security_group) }
+
+    let(:mapping) do
+      FactoryBot.create(
+        :transformation_mapping,
+        :transformation_mapping_items => [TransformationMappingItem.new(:source => src_cluster, :destination => dst_cluster)]
+      )
+    end
+
+    let(:catalog_item_options) do
+      {
+        :name        => 'Transformation Plan',
+        :description => 'a description',
+        :config_info => {
+          :transformation_mapping_id => mapping.id,
+          :pre_service_id            => apst.id,
+          :post_service_id           => apst.id,
+          :actions                   => [
+            {:vm_id => src_vm_1.id.to_s, :pre_service => true, :post_service => true, :osp_flavor_id => dst_flavor.id, :osp_security_group_id => dst_security_group.id},
+            {:vm_id => src_vm_2.id.to_s, :pre_service => false, :post_service => false},
+          ],
+        }
+      }
+    end
+
+    let(:plan) { ServiceTemplateTransformationPlan.create_catalog_item(catalog_item_options) }
+    let(:request) { FactoryBot.create(:service_template_transformation_plan_request, :source => plan) }
+    let(:task_1) { FactoryBot.create(:service_template_transformation_plan_task, :miq_request => request, :request_type => 'transformation_plan', :source => src_vm_1) }
+    let(:task_2) { FactoryBot.create(:service_template_transformation_plan_task, :miq_request => request, :request_type => 'transformation_plan', :source => src_vm_2) }
+
+    let(:conversion_host) { FactoryBot.create(:conversion_host, :resource => src_vm_1) }
+
+    describe "#valid_states" do
+      it "contains 'migrate'" do
+        expect(task_1.send(:valid_states)).to include('migrate')
+      end
+    end
+
+    describe '#transformation_destination' do
+      it { expect(task_1.transformation_destination(src_cluster)).to eq(dst_cluster) }
+    end
+
+    describe '#pre_ansible_playbook_service_template' do
+      it { expect(task_1.pre_ansible_playbook_service_template).to eq(apst) }
+      it { expect(task_2.pre_ansible_playbook_service_template).to be_nil }
+    end
+
+    describe '#post_ansible_playbook_service_template' do
+      it { expect(task_1.post_ansible_playbook_service_template).to eq(apst) }
+      it { expect(task_2.post_ansible_playbook_service_template).to be_nil }
+    end
+
+    shared_examples_for "#run_conversion" do
+      let(:time_now) { Time.now.utc }
+      before do
+        allow(Time).to receive(:now).and_return(time_now)
+        allow(conversion_host).to receive(:run_conversion).with(task_1.conversion_options).and_return(
+          {
+            "wrapper_log" => "/tmp/wrapper.log",
+            "v2v_log"     => "/tmp/v2v.log",
+            "state_file"  => "/tmp/v2v.state"
+          }
+        )
+      end
+
+      it "collects the wrapper state hash" do
+        task_1.run_conversion
+        expect(task_1.options[:virtv2v_wrapper]).to eq(
+          {
+            "wrapper_log" => "/tmp/wrapper.log",
+            "v2v_log"     => "/tmp/v2v.log",
+            "state_file"  => "/tmp/v2v.state"
+          }
+        )
+       expect(task_1.options[:virtv2v_started_on]).to eq(time_now.strftime('%Y-%m-%d %H:%M:%S'))
+       expect(task_1.options[:virtv2v_status]).to eq('active')
+      end
+    end
+
+    context 'source is vmwarews' do
+      let(:src_ems) { FactoryBot.create(:ems_vmware, :zone => FactoryBot.create(:zone)) }
+      let(:src_host) { FactoryBot.create(:host_vmware_esx, :ext_management_system => src_ems, :ipaddress => '10.0.0.1') }
+      let(:src_storage) { FactoryBot.create(:storage, :ext_management_system => src_ems, :name => 'stockage récent') }
+
+      let(:src_lan_1) { FactoryBot.create(:lan) }
+      let(:src_lan_2) { FactoryBot.create(:lan) }
+      let(:src_nic_1) { FactoryBot.create(:guest_device_nic, :lan => src_lan_1) }
+      let(:src_nic_2) { FactoryBot.create(:guest_device_nic, :lan => src_lan_2) }
+
+      let(:src_disk_1) { instance_double("disk", :device_name => "Hard disk 1", :device_type => "disk", :filename => "[datastore12] test_vm/test_vm.vmdk", :size => 17_179_869_184) }
+      let(:src_disk_2) { instance_double("disk", :device_name => "Hard disk 2", :device_type => "disk", :filename => "[datastore12] test_vm/test_vm-2.vmdk", :size => 17_179_869_184) }
+
+      let(:src_hardware) { FactoryBot.create(:hardware, :nics => [src_nic_1, src_nic_2]) }
+
+      let(:src_vm_1) { FactoryBot.create(:vm_openstack, :ext_management_system => src_ems, :ems_cluster => src_cluster, :host => src_host, :hardware => src_hardware) }
+      let(:src_vm_2) { FactoryBot.create(:vm_openstack, :ext_management_system => src_ems, :ems_cluster => src_cluster, :host => src_host) }
+
+      let(:src_network_1) { FactoryBot.create(:network, :ipaddress => '10.0.1.1') }
+      let(:src_network_2) { FactoryBot.create(:network, :ipaddress => nil) }
+
+      # Disks have to be stubbed because there's no factory for Disk class
+      before do
+        allow(src_hardware).to receive(:disks).and_return([src_disk_1, src_disk_2])
+        allow(src_disk_1).to receive(:storage).and_return(src_storage)
+        allow(src_disk_2).to receive(:storage).and_return(src_storage)
+        allow(src_vm_1).to receive(:allocated_disk_storage).and_return(34_359_738_368)
+        allow(src_nic_1).to receive(:network).and_return(src_network_1)
+        allow(src_nic_2).to receive(:network).and_return(src_network_2)
+        allow(src_host).to receive(:thumbprint_sha1).and_return('01:23:45:67:89:ab:cd:ef:01:23:45:67:89:ab:cd:ef:01:23:45:67')
+        allow(src_host).to receive(:authentication_userid).and_return('esx_user')
+        allow(src_host).to receive(:authentication_password).and_return('esx_passwd')
+        task_1.options[:transformation_host_id] = conversion_host.id
+        allow(task_1).to receive(:with_lock).and_yield
+      end
+
+      it "fails when cluster is not mapped" do
+        allow(task_1).to receive(:transformation_destination).with(src_cluster).and_return(nil)
+        expect { task_1.destination_cluster }.to raise_error("[#{src_vm_1.name}] Cluster #{src_cluster} has no mapping.")
+      end
+
+      it "finds the source ems based on source vm" do
+        expect(task_1.source_ems).to eq(src_ems)
+      end
+
+      it 'find the destination ems based on mapping' do
+        expect(task_1.destination_ems).to eq(dst_ems)
+      end
+
+      shared_examples_for "get_conversion_state" do
+        let(:time_now) { Time.now.utc }
+        before do
+          allow(Time).to receive(:now).and_return(time_now)
+        end
+
+        it "raises when conversion is failed" do
+          allow(conversion_host).to receive(:get_conversion_state).with(task.options[:virtv2v_wrapper]['state_file']).and_return(
+            {
+              "failed"       => true,
+              "finished"     => true,
+              "started"      => true,
+              "disks"        => [
+                { "path" => src_disk_1.filename, "progress" => 23.0 },
+                { "path" => src_disk_1.filename, "progress" => 0.0 }
+              ],
+              "pid"          => 5855,
+              "return_code"  => 1,
+              "disk_count"   => 2,
+              "last_message" => {
+                "message" => "virt-v2v failed somehow",
+                "type"    => "error"
+              }
+            }
+          )
+          expect { task_1.get_conversion_state }.to raise_error("Disks transformation failed.")
+          expect(task_1.options[:virtv2v_status]).to eq('failed')
+          expect(task_1.options[:virtv2v_finished_on]).to eq(time_now.strftime('%Y-%m-%d %H:%M:%S'))
+          expect(task_1.options[:virtv2v_message]).to eq('virt-v2v failed somehow')
+        end
+
+        it "updates disks progress" do
+          allow(conversion_host).to receive(:get_conversion_state).with(task.options[:virtv2v_wrapper]['state_file']).and_return(
+            {
+              "started"     => true,
+              "disks"       => [
+                { "path" => src_disk_1.filename, "progress" => 100.0 },
+                { "path" => src_disk_1.filename, "progress" => 50.0 }
+              ],
+              "pid"         => 5855,
+              "disk_count"  => 2
+            }
+          )
+          task_1.get_conversion_state
+          expect(task_1.options[:virtv2v_disks]).to eq(
+            [
+              { :path => src_disk_1.filename, :size => disk.size, :percent => 100, :weight  => 50 },
+              { :path => src_disk_2.filename, :size => disk.size, :percent => 50, :weight  => 50 }
+            ]
+          )
+          expect(task_1.options[:virtv2v_status]).to eq('active')
+        end
+
+        it "sets disks progress to 100% when conversion is finished and successful" do
+          allow(conversion_host).to receive(:get_conversion_state).with(task.options[:virtv2v_wrapper]['state_file']).and_return(
+            {
+              "finished"    => true,
+              "started"     => true,
+              "disks"       => [
+                { "path" => src_disk_1.filename, "progress" => 100.0},
+                { "path" => src_disk_1.filename, "progress" => 100.0}
+              ],
+              "pid"         => 5855,
+              "return_code" => 0,
+              "disk_count"  => 1
+            }
+          )
+          task_1.get_conversion_state
+          expect(task.options[:virtv2v_disks]).to eq(
+            [
+              { :path => src_disk_1.filename, :size => disk.size, :percent => 100, :weight  => 50 },
+              { :path => src_disk_2.filename, :size => disk.size, :percent => 100, :weight  => 50 }
+            ]
+          )
+          expect(task_1.options[:virtv2v_status]).to eq('finished')
+          epxect(task_1.options[:virtv2v_finished_on]).to eq(time)
+          expect(task_1.options[:virtv2v_message]).to be_nil
+        end
+      end
+
+      shared_examples_for "#virtv2v_disks" do
+        it "checks mapping and generates virtv2v_disks hash" do
+          expect(task_1.virtv2v_disks).to eq(
+            [
+              { :path => src_disk_1.filename, :size => src_disk_1.size, :percent => 0, :weight  => 50.0 },
+              { :path => src_disk_2.filename, :size => src_disk_2.size, :percent => 0, :weight  => 50.0 }
+            ]
+          )
+        end
+      end
+
+      context 'destination is rhevm' do
+        let(:dst_ems) { FactoryBot.create(:ems_redhat, :zone => FactoryBot.create(:zone), :api_version => '4.2.4') }
+        let(:dst_storage) { FactoryBot.create(:storage) }
+        let(:dst_lan_1) { FactoryBot.create(:lan) }
+        let(:dst_lan_2) { FactoryBot.create(:lan) }
+        let(:conversion_host) { FactoryBot.create(:conversion_host, :resource => FactoryBot.create(:host_redhat, :ext_management_system => dst_ems)) }
+
+        let(:mapping) do
+          FactoryBot.create(
+            :transformation_mapping,
+            :transformation_mapping_items => [
+              TransformationMappingItem.new(:source => src_cluster, :destination => dst_cluster),
+              TransformationMappingItem.new(:source => src_storage, :destination => dst_storage),
+              TransformationMappingItem.new(:source => src_lan_1, :destination => dst_lan_1),
+              TransformationMappingItem.new(:source => src_lan_2, :destination => dst_lan_2)
+            ]
+          )
+        end
+
+        before do
+          task_1.conversion_host = conversion_host
+        end
+
+        it { expect(task_1.destination_cluster).to eq(dst_cluster) }
+
+        it_behaves_like "#virtv2v_disks"
+
+        context "#network_mappings" do
+          it "generates network_mappings hash" do
+            expect(task_1.network_mappings).to eq(
+              [
+                { :source => src_lan_1.name, :destination => dst_lan_1.name, :mac_address => src_nic_1.address, :ip_address => '10.0.1.1' },
+                { :source => src_lan_2.name, :destination => dst_lan_2.name, :mac_address => src_nic_2.address }
+              ]
+            )
+          end
+        end
+
+        it "passes preflight check regardless of power_state" do
+          src_vm_1.send(:power_state=, 'anything')
+          expect { task_1.preflight_check }.not_to raise_error
+        end
+
+        context "transport method is vddk" do
+          before do
+            conversion_host.vddk_transport_supported = true
+          end
+
+          it "generates conversion options hash" do
+            expect(task_1.conversion_options).to eq(
+              :vm_name             => src_vm_1.name,
+              :transport_method    => 'vddk',
+              :vmware_fingerprint  => '01:23:45:67:89:ab:cd:ef:01:23:45:67:89:ab:cd:ef:01:23:45:67',
+              :vmware_uri          => "esx://esx_user@10.0.0.1/?no_verify=1",
+              :vmware_password     => 'esx_passwd',
+              :rhv_url             => "https://#{dst_ems.hostname}/ovirt-engine/api",
+              :rhv_cluster         => dst_cluster.name,
+              :rhv_storage         => dst_storage.name,
+              :rhv_password        => dst_ems.authentication_password,
+              :source_disks        => [src_disk_1.filename, src_disk_2.filename],
+              :network_mappings    => task_1.network_mappings,
+              :install_drivers     => true,
+              :insecure_connection => true
+            )
+          end
+
+          it_behaves_like "#run_conversion"
+        end
+
+        context "transport method is ssh" do
+          before do
+            conversion_host.vddk_transport_supported = false
+            conversion_host.ssh_transport_supported = true
+          end
+
+          it "generates conversion options hash" do
+            expect(task_1.conversion_options).to eq(
+              :vm_name             => "ssh://root@10.0.0.1/vmfs/volumes/stockage%20r%C3%A9cent/#{src_vm_1.location}",
+              :transport_method    => 'ssh',
+              :rhv_url             => "https://#{dst_ems.hostname}/ovirt-engine/api",
+              :rhv_cluster         => dst_cluster.name,
+              :rhv_storage         => dst_storage.name,
+              :rhv_password        => dst_ems.authentication_password,
+              :source_disks        => [src_disk_1.filename, src_disk_2.filename],
+              :network_mappings    => task_1.network_mappings,
+              :install_drivers     => true,
+              :insecure_connection => true
+            )
+          end
+        end
+      end
+
+      context 'destination is openstack' do
+        let(:dst_ems) { FactoryBot.create(:ems_openstack, :api_version => 'v3', :zone => FactoryBot.create(:zone)) }
+        let(:dst_cloud_tenant) { FactoryBot.create(:cloud_tenant, :name => 'fake tenant', :ext_management_system => dst_ems) }
+        let(:dst_cloud_volume_type) { FactoryBot.create(:cloud_volume_type) }
+        let(:dst_cloud_network_1) { FactoryBot.create(:cloud_network) }
+        let(:dst_cloud_network_2) { FactoryBot.create(:cloud_network) }
+        let(:dst_flavor) { FactoryBot.create(:flavor) }
+        let(:dst_security_group) { FactoryBot.create(:security_group) }
+        let(:conversion_host_vm) { FactoryBot.create(:vm_openstack, :ext_management_system => dst_ems, :cloud_tenant => dst_cloud_tenant) }
+        let(:conversion_host) { FactoryBot.create(:conversion_host, :resource => conversion_host_vm) }
+
+        let(:mapping) do
+          FactoryBot.create(
+            :transformation_mapping,
+            :transformation_mapping_items => [
+              TransformationMappingItem.new(:source => src_cluster, :destination => dst_cloud_tenant),
+              TransformationMappingItem.new(:source => src_storage, :destination => dst_cloud_volume_type),
+              TransformationMappingItem.new(:source => src_lan_1, :destination => dst_cloud_network_1),
+              TransformationMappingItem.new(:source => src_lan_2, :destination => dst_cloud_network_2)
+            ]
+          )
+        end
+
+        before do
+          task_1.conversion_host = conversion_host
+        end
+
+        it { expect(task_1.destination_cluster).to eq(dst_cloud_tenant) }
+
+        it_behaves_like "#virtv2v_disks"
+
+        context "#network_mappings" do
+          it "generates network_mappings hash" do
+            expect(task_1.network_mappings).to eq(
+              [
+                { :source => src_lan_1.name, :destination => dst_cloud_network_1.ems_ref, :mac_address => src_nic_1.address, :ip_address => '10.0.1.1' },
+                { :source => src_lan_2.name, :destination => dst_cloud_network_2.ems_ref, :mac_address => src_nic_2.address }
+              ]
+            )
+          end
+        end
+
+        it "fails preflight check if src is power off" do
+          src_vm_1.send(:power_state=, 'off')
+          expect { task_1.preflight_check }.to raise_error('OSP destination and source power_state is off')
+        end
+
+        context "transport method is vddk" do
+          before do
+            conversion_host.vddk_transport_supported = true
+          end
+
+          it "generates conversion options hash" do
+            expect(task_1.conversion_options).to eq(
+              :vm_name                    => src_vm_1.name,
+              :transport_method           => 'vddk',
+              :vmware_fingerprint         => '01:23:45:67:89:ab:cd:ef:01:23:45:67:89:ab:cd:ef:01:23:45:67',
+              :vmware_uri                 => "esx://esx_user@10.0.0.1/?no_verify=1",
+              :vmware_password            => 'esx_passwd',
+              :osp_environment            => {
+                :os_auth_url             => URI::Generic.build(
+                  :scheme => dst_ems.security_protocol == 'non-ssl' ? 'http' : 'https',
+                  :host   => dst_ems.hostname,
+                  :port   => dst_ems.port,
+                  :path   => '/v3'
+                ).to_s,
+                :os_identity_api_version => '3',
+                :os_user_domain_name     => dst_ems.uid_ems,
+                :os_username             => dst_ems.authentication_userid,
+                :os_password             => dst_ems.authentication_password,
+                :os_project_name         => dst_cloud_tenant.name
+              },
+              :osp_server_id              => conversion_host_vm.ems_ref,
+              :osp_destination_project_id => dst_cloud_tenant.ems_ref,
+              :osp_volume_type_id         => dst_cloud_volume_type.ems_ref,
+              :osp_flavor_id              => dst_flavor.ems_ref,
+              :osp_security_groups_ids    => [dst_security_group.ems_ref],
+              :source_disks               => [src_disk_1.filename, src_disk_2.filename],
+              :network_mappings           => task_1.network_mappings
+            )
+          end
+        end
+
+        context "transport method is ssh" do
+          before do
+            conversion_host.vddk_transport_supported = false
+            conversion_host.ssh_transport_supported = true
+          end
+
+          it "generates conversion options hash" do
+            expect(task_1.conversion_options).to eq(
+              :vm_name                    => "ssh://root@10.0.0.1/vmfs/volumes/stockage%20r%C3%A9cent/#{src_vm_1.location}",
+              :transport_method           => 'ssh',
+              :osp_environment            => {
+                :os_auth_url             => URI::Generic.build(
+                  :scheme => dst_ems.security_protocol == 'non-ssl' ? 'http' : 'https',
+                  :host   => dst_ems.hostname,
+                  :port   => dst_ems.port,
+                  :path   => '/v3'
+                ).to_s,
+                :os_identity_api_version => '3',
+                :os_user_domain_name     => dst_ems.uid_ems,
+                :os_username             => dst_ems.authentication_userid,
+                :os_password             => dst_ems.authentication_password,
+                :os_project_name         => dst_cloud_tenant.name
+              },
+              :osp_server_id              => conversion_host_vm.ems_ref,
+              :osp_destination_project_id => dst_cloud_tenant.ems_ref,
+              :osp_volume_type_id         => dst_cloud_volume_type.ems_ref,
+              :osp_flavor_id              => dst_flavor.ems_ref,
+              :osp_security_groups_ids    => [dst_security_group.ems_ref],
+              :source_disks               => [src_disk_1.filename, src_disk_2.filename],
+              :network_mappings           => task_1.network_mappings
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/models/transformation_mapping/cloud_best_fit_spec.rb
+++ b/spec/models/transformation_mapping/cloud_best_fit_spec.rb
@@ -1,0 +1,37 @@
+describe TransformationMapping::CloudBestFit do
+  let(:ems)         { FactoryBot.create(:ems_openstack) }
+  let(:vm)          { FactoryBot.create(:vm_vmware, :hardware => vm_hardware) }
+  let(:vm_hardware) { FactoryBot.create(:hardware, :cpu1x2, :ram1GB) }
+
+  subject { described_class.new(vm, ems) }
+
+  it "no flavors on the provider" do
+    expect(subject.available_fit_flavors).to match_array([])
+    expect(subject.best_fit_flavor).to be_nil
+  end
+
+  it "no flavors match" do
+    ems.flavors.create!(:cpus => 1, :memory => 512.megabytes)
+
+    expect(subject.available_fit_flavors).to match_array([])
+    expect(subject.best_fit_flavor).to be_nil
+  end
+
+  it "one flavor matches" do
+    ems.flavors.create!(:cpus => 2, :memory => 512.megabytes)
+    flavor = ems.flavors.create!(:cpus => 2, :memory => 1.gigabyte)
+
+    expect(subject.available_fit_flavors).to match_array([flavor])
+    expect(subject.best_fit_flavor).to eq(flavor)
+  end
+
+  it "multiple flavors match" do
+    ems.flavors.create!(:cpus => 2, :memory => 512.megabytes)
+    flavor1 = ems.flavors.create!(:cpus => 2, :memory => 1.gigabyte)
+    flavor2 = ems.flavors.create!(:cpus => 2, :memory => 2.gigabytes)
+    flavor3 = ems.flavors.create!(:cpus => 4, :memory => 1.gigabyte)
+
+    expect(subject.available_fit_flavors).to match_array([flavor1, flavor2, flavor3])
+    expect(subject.best_fit_flavor).to eq(flavor1)
+  end
+end

--- a/spec/models/transformation_mapping_spec.rb
+++ b/spec/models/transformation_mapping_spec.rb
@@ -1,0 +1,177 @@
+RSpec.describe TransformationMapping, :v2v do
+  let(:src) { FactoryBot.create(:ems_cluster) }
+  let(:dst) { FactoryBot.create(:ems_cluster) }
+  let(:vm)  { FactoryBot.create(:vm_vmware, :ems_cluster => src) }
+
+  let(:mapping) do
+    FactoryBot.create(
+      :transformation_mapping,
+      :transformation_mapping_items => [TransformationMappingItem.new(:source => src, :destination => dst)]
+    )
+  end
+
+  describe '#destination' do
+    it "finds the destination" do
+      expect(mapping.destination(src)).to eq(dst)
+    end
+
+    it "returns nil for unmapped source" do
+      expect(mapping.destination(FactoryBot.create(:ems_cluster))).to be_nil
+    end
+  end
+
+  describe '#service_templates' do
+    let(:plan) { FactoryBot.create(:service_template_transformation_plan) }
+    before { FactoryBot.create(:service_resource, :resource => mapping, :service_template => plan) }
+
+    it 'finds the transformation plans' do
+      expect(mapping.service_templates).to match([plan])
+    end
+  end
+
+  describe '#search_vms_and_validate' do
+    let(:vm) { FactoryBot.create(:vm_vmware, :name => 'test_vm', :ems_cluster => src, :ext_management_system => FactoryBot.create(:ext_management_system)) }
+    let(:vm2) { FactoryBot.create(:vm_vmware, :ems_cluster => src, :ext_management_system => FactoryBot.create(:ext_management_system)) }
+    let(:inactive_vm) { FactoryBot.create(:vm_vmware, :name => 'test_vm_inactive', :ems_cluster => src, :ext_management_system => nil) }
+    let(:storage) { FactoryBot.create(:storage) }
+    let(:lan) { FactoryBot.create(:lan) }
+    let(:nic) { FactoryBot.create(:guest_device_nic, :lan => lan) }
+
+    before do
+      mapping.transformation_mapping_items << TransformationMappingItem.new(:source => storage, :destination => storage)
+      mapping.transformation_mapping_items << TransformationMappingItem.new(:source => lan, :destination => lan)
+      vm.storages << storage
+      vm.hardware = FactoryBot.create(:hardware, :guest_devices => [nic])
+    end
+
+    context 'with VM list' do
+      context 'returns invalid vms' do
+        it 'if VM does not exist' do
+          result = mapping.search_vms_and_validate(['name' => 'vm1'])
+          expect(result['invalid'].first.reason).to eq(TransformationMapping::VmMigrationValidator::VM_NOT_EXIST)
+        end
+
+        it 'if VM is inactive' do
+          inactive_vm.storages << FactoryBot.create(:storage, :name => 'storage_for_inactive_vm')
+          result = mapping.search_vms_and_validate(['name' => 'test_vm_inactive'])
+          expect(result['invalid'].first.reason).to eq(TransformationMapping::VmMigrationValidator::VM_INACTIVE)
+        end
+
+        it "if VM's cluster is not in the mapping" do
+          FactoryBot.create(
+            :vm_vmware,
+            :name                  => 'vm2',
+            :ems_cluster           => FactoryBot.create(:ems_cluster, :name => 'cluster1'),
+            :ext_management_system => FactoryBot.create(:ext_management_system)
+          )
+          result = mapping.search_vms_and_validate(['name' => 'vm2'])
+          expect(result['invalid'].first.reason).to match(/not_exist/)
+        end
+
+        it "if VM's storages are not all in the mapping" do
+          vm.storages << FactoryBot.create(:storage, :name => 'storage2')
+          result = mapping.search_vms_and_validate(['name' => vm.name])
+          expect(result['invalid'].first.reason).to match(/Mapping source not found - storages: storage2/)
+        end
+
+        it "if VM's lans are not all in the mapping" do
+          vm.hardware.guest_devices << FactoryBot.create(:guest_device_nic, :lan =>FactoryBot.create(:lan, :name => 'lan2'))
+          result = mapping.search_vms_and_validate(['name' => vm.name])
+          expect(result['invalid'].first.reason).to match(/Mapping source not found - lans: lan2/)
+        end
+
+        it "if any source is invalid" do
+          vm.storages << FactoryBot.create(:storage, :name => 'storage2')
+          vm.hardware.guest_devices << FactoryBot.create(:guest_device_nic, :lan =>FactoryBot.create(:lan, :name => 'lan2'))
+          result = mapping.search_vms_and_validate(['name' => vm.name])
+          expect(result['invalid'].first.reason).to match(/Mapping source not found - storages: storage2. lans: lan2/)
+        end
+
+        it 'if VM is in another migration plan' do
+          %w(Queued Approved Active).each do |status|
+            FactoryBot.create(
+              :service_resource,
+              :resource         => vm,
+              :service_template => FactoryBot.create(:service_template_transformation_plan),
+              :status           => status
+            )
+
+            result = mapping.search_vms_and_validate(['name' => vm.name])
+            expect(result['invalid'].first.reason).to match(/in_other_plan/)
+          end
+        end
+
+        it 'if VM has been migrated' do
+          FactoryBot.create(
+            :service_resource,
+            :resource         => vm,
+            :service_template => FactoryBot.create(:service_template_transformation_plan),
+            :status           => 'Completed'
+          )
+
+          result = mapping.search_vms_and_validate(['name' => vm.name])
+          expect(result['invalid'].first.reason).to match(/migrated/)
+        end
+      end
+
+      it 'returns valid vms' do
+        result = mapping.search_vms_and_validate(['name' => vm.name])
+        expect(result['valid'].first.reason).to eq(TransformationMapping::VmMigrationValidator::VM_VALID)
+        expect(result['valid'].first.ems_cluster_id).to eq(vm.ems_cluster_id.to_s)
+      end
+
+      it 'returns conflict vms' do
+        FactoryBot.create(:vm_vmware, :name => 'test_vm', :ems_cluster => src, :ext_management_system => FactoryBot.create(:ext_management_system))
+        result = mapping.search_vms_and_validate(['name' => vm.name])
+        expect(result['conflicted'].first.reason).to eq(TransformationMapping::VmMigrationValidator::VM_CONFLICT)
+      end
+    end
+
+    context 'with VM list and service_template_id' do
+      it 'returns valid vms when a ServiceTemplate record is edited with CSV containing the same VM already included in the ServiceTemplate record' do
+        service_template = FactoryBot.create(:service_template_transformation_plan)
+
+        FactoryBot.create(
+          :service_resource,
+          :resource         => vm2,
+          :service_template => service_template,
+          :status           => "Active"
+        )
+        result = mapping.search_vms_and_validate(['name' => vm2.name], service_template.id.to_s)
+        expect(result['valid'].first.reason).to match(/ok/)
+      end
+
+      it 'returns invalid vms when the Service Template record is edited with CSV containing a different VM that belongs to a different ServiceTemplate record' do
+        service_template = FactoryBot.create(:service_template_transformation_plan)
+        service_template2 = FactoryBot.create(:service_template_transformation_plan)
+
+        FactoryBot.create(
+          :service_resource,
+          :resource         => vm2,
+          :service_template => service_template,
+          :status           => "Active"
+        )
+        result = mapping.search_vms_and_validate(['name' => vm2.name], service_template2.id.to_s)
+        expect(result['invalid'].first.reason).to match(/in_other_plan/)
+      end
+    end
+
+    context 'without VM list' do
+      it 'returns valid vms' do
+        result = mapping.search_vms_and_validate
+        expect(result['valid'].count).to eq(1)
+      end
+
+      it 'skips invalid vms' do
+        FactoryBot.create(
+          :vm_vmware,
+          :name                  => 'vm2',
+          :ems_cluster           => FactoryBot.create(:ems_cluster, :name => 'cluster1'),
+          :ext_management_system => FactoryBot.create(:ext_management_system)
+        )
+        result = mapping.search_vms_and_validate
+        expect(result['valid'].count).to eq(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Move all V2V-related model code from the ManageIQ/manageiq (core) repo to manageiq-v2v.

In order to keep all V2V code in a common repo, the model code (and related spec tests) are being moved to this repo. A separate PR will remove this set of code from the core repo.

A second PR will move API code from the manageiq-api repo to this repo as well as another to remove that code from the api repo.

This PR has no dependencies.

@djberg96 @agrare @roliveri please review.
