### PR TITLE
[#958] [BZ#1712806] Conversion Host Wizard: Auth Step - Force validation to re-run when verifyOpenstackCerts is toggled

### DIFF
--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/ConversionHostWizardAuthenticationStep.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/ConversionHostWizardAuthenticationStep.js
@@ -88,6 +88,7 @@ const ConversionHostWizardAuthenticationStep = ({
             component={FormField}
             controlId="verify-openstack-certs"
             style={{ marginTop: 25 }}
+            validate={() => undefined} // Force redux-form to re-run validation when this field changes, since it can unmount openstackCaCerts
           >
             {({ input: { value, onChange } }) => (
               <Switch


### PR DESCRIPTION
Fixes #958 
https://bugzilla.redhat.com/show_bug.cgi?id=1712806

See the BZ for a screen recording of the issue being demonstrated.

When the openstackCaCerts field is mounted, since it has a validation function (defined in `<TextFileField />`), when it is blank it blocks the wizard from proceeding. The problem here is that when the switch is toggled and openstackCaCerts is unmounted, nothing with a validation function in the form has changed, so redux-form doesn't know it needs to run validation again. With this validate function in place (that will always return undefined, indicating that the field passes validation), redux-form will run its validation again when the switch is toggled, and it will not include openstackCaCerts because that field has been unmounted, so the wizard will be unblocked.

I ran into this same issue with the VMware SSH key and VDDK library path fields, which are mounted/unmounted by the Transformation Method option. That time, the solution was to force fields to unregister when they are unmounted by adding this redux-form option: https://github.com/ManageIQ/manageiq-v2v/commit/6cf1e82e0f6aa9045956423a9c4bc1a0cc8b5e55#diff-ba605d048e49232c350841e6d0802a97R128

However, even though the fields have been unregistered on unmount, the validation does not run again until a field with a validator has changed (which I honestly feel is a bug in redux-form). The issue didn't come up with the Transformation Method option because it always had a validator.

Here's a recording of the same interaction with the issue fixed:

![gemtbz0fjH](https://user-images.githubusercontent.com/811963/58281699-bef4c700-7d71-11e9-8bed-0791660b7e5e.gif)
