### PR TITLE
[#957] [BZ#1712873] Prevent migration task info popovers with long error messages from being pushed off the screen

### DIFF
--- a/app/javascript/react/screens/App/Plan/Plan.scss
+++ b/app/javascript/react/screens/App/Plan/Plan.scss
@@ -27,10 +27,10 @@
   margin-bottom: 0px;
 }
 
-.task-info-popover .popover-title {
-  text-transform: capitalize;
+.task-info-popover {
+  max-width: 450px;
 }
 
-.no-max-width {
-  max-width: none;
+.task-info-popover .popover-title {
+  text-transform: capitalize;
 }

--- a/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
+++ b/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
@@ -282,7 +282,7 @@ class PlanRequestDetailList extends React.Component {
                 <Popover
                   id={`popover${task.id}${n}`}
                   title={V2V_MIGRATION_STATUS_MESSAGES[task.message]}
-                  className="task-info-popover no-max-width"
+                  className="task-info-popover"
                 >
                   <div>
                     <div>


### PR DESCRIPTION
Fixes #957.
https://bugzilla.redhat.com/show_bug.cgi?id=1712873

The history of `.popover` `max-width` continues...

* In core bootstrap, popover max-width is set to 220px.
* This caused long errors to run over the borders of the popover box, so we fixed that by setting max-width to `none` in https://github.com/ManageIQ/manageiq-v2v/pull/580.
* I went to remove our max-width: none and found that around the same time, manageiq-ui-classic added the same `max-width: none` for all popovers to fix a similar issue: https://github.com/ManageIQ/manageiq-ui-classic/pull/2978, so that was still taking effect even without our override.
* Of course, now we find `max-width: none` here causes *longer* errors to run off the screen.

I set the max-width of these specific task info popovers to a sensible 450px in this PR, which should be wide enough to prevent the first issue and narrow enough to prevent the second one.

Maybe we're done now?

This fix can be tested with the database called `long-task-error` from [my collection](https://drive.google.com/drive/u/1/folders/1psxWLopcPUFeJCoHcnMiOgF40x2V0h3Q), which has a plan "rhv-vddk" containing the long error shown in the screenshots below.

# Screens

Popover with the original `max-width: 220px` from bootstrap:
![Screenshot 2019-05-23 17 58 05](https://user-images.githubusercontent.com/811963/58290898-5f0a1a80-7d89-11e9-83ab-44ebf14e9b23.png)

Popover with `max-width: none`:
![Screenshot 2019-05-23 17 57 32](https://user-images.githubusercontent.com/811963/58290921-70532700-7d89-11e9-99dd-f41d46c0cb72.png)

Popover with `max-width: 450px`:
![Screenshot 2019-05-23 17 57 46](https://user-images.githubusercontent.com/811963/58290935-7cd77f80-7d89-11e9-8a98-6b41feaf60a6.png)