### PR TITLE
[#865][BZ#1670703] Add BreadcrumbPageSwitcher for Plans, Mappings and Settings pages

### DIFF
--- a/app/assets/stylesheets/manageiq-v2v/base.scss
+++ b/app/assets/stylesheets/manageiq-v2v/base.scss
@@ -1,5 +1,6 @@
 @import '../../../javascript/react/app.scss';
 @import './type-ahead-select.scss';
+@import './breadcrumbswitcher-popover.scss';
 
 .react-wrapper {
   height: 100%;

--- a/app/assets/stylesheets/manageiq-v2v/breadcrumbswitcher-popover.scss
+++ b/app/assets/stylesheets/manageiq-v2v/breadcrumbswitcher-popover.scss
@@ -1,0 +1,98 @@
+/*
+  Until we can properly import patternfly-react CSS extensions, we need to include the styles for breadcrumbswitcher manually.
+  This can be replaced with a proper import after https://github.com/patternfly/patternfly-react/issues/673 is fixed.
+  This is a copy of https://github.com/patternfly/patternfly-react/blob/master/packages/patternfly-3/patternfly-react/sass/patternfly-react/_breadcrumbswitcher-popover.scss
+*/
+
+$switcher-max-height: 400px;
+$switcher-max-width: 200px;
+$switcher-min-width: 200px;
+
+#breadcrumb-switcher-popover {
+  z-index: 1000 !important;
+
+  .popover-content {
+    display: flex;
+    flex-direction: column;
+    padding-left: 0;
+    padding-right: 0;
+    max-height: $switcher-max-height;
+    overflow: hidden;
+    max-width: $switcher-max-width;
+    min-width: $switcher-max-width;
+
+    .input-search {
+      position: relative;
+      left: 0;
+      margin-left: auto;
+      margin-right: auto;
+
+      input {
+        padding: 0 25px 0 25px;
+        width: 180px;
+      }
+
+      .fa-search {
+        color: $color-pf-blue-400;
+        position: absolute;
+        top: 7px;
+        left: 8px;
+        z-index: 99;
+      }
+
+      .fa-close {
+        cursor: pointer;
+        position: absolute;
+        top: 7px;
+        right: 10px;
+        z-index: 99;
+      }
+    }
+
+    .breadcrumb-switcher-popover-error {
+      text-indent: 10px;
+      color: $color-pf-red-100;
+    }
+
+    .list-group-item {
+      padding: 5px 10px 5px 10px;
+
+      &:hover {
+        background-color: $color-pf-blue-25;
+      }
+
+      &.active {
+        background-color: $color-pf-blue-400;
+      }
+    }
+
+    .no-border {
+      border: none;
+    }
+
+    .pager {
+      margin: 0 10px;
+
+      a {
+        width: 22px;
+      }
+
+      .fa {
+        margin-left: -2px;
+      }
+    }
+
+    .scrollable-list {
+      margin-top: 5px;
+      margin-bottom: 10px;
+
+      &.list-group {
+        border-top: 0;
+      }
+    }
+  }
+
+  .breadcrumb-switcher-popover-loading {
+    margin-top: 10px;
+  }
+}

--- a/app/javascript/react/screens/App/Mappings/Mappings.js
+++ b/app/javascript/react/screens/App/Mappings/Mappings.js
@@ -9,6 +9,7 @@ import { FETCH_TRANSFORMATION_PLANS_URL, FETCH_ARCHIVED_TRANSFORMATION_PLANS_URL
 import { FETCH_TRANSFORMATION_MAPPINGS_URL, FETCH_CLOUD_TENANTS_URL } from './MappingsConstants';
 import { FETCH_V2V_PROVIDERS_URL } from '../../../../redux/common/providers/providersConstants';
 import ShowWizardEmptyState from '../common/ShowWizardEmptyState/ShowWizardEmptyState';
+import BreadcrumbPageSwitcher from '../common/BreadcrumbPageSwitcher';
 
 class Mappings extends Component {
   constructor(props) {
@@ -179,6 +180,7 @@ class Mappings extends Component {
           <Breadcrumb.Item active>
             <strong>{__('Infrastructure Mappings')}</strong>
           </Breadcrumb.Item>
+          <BreadcrumbPageSwitcher activeHref="#/mappings" />
         </Toolbar>
         <Spinner
           loading={

--- a/app/javascript/react/screens/App/Overview/Overview.js
+++ b/app/javascript/react/screens/App/Overview/Overview.js
@@ -16,6 +16,7 @@ import {
 } from './OverviewConstants';
 import { FETCH_TRANSFORMATION_MAPPINGS_URL, FETCH_CLOUD_TENANTS_URL } from '../Mappings/MappingsConstants';
 import { FETCH_V2V_PROVIDERS_URL } from '../../../../redux/common/providers/providersConstants';
+import BreadcrumbPageSwitcher from '../common/BreadcrumbPageSwitcher';
 
 class Overview extends React.Component {
   constructor(props) {
@@ -418,6 +419,7 @@ class Overview extends React.Component {
         <Breadcrumb.Item active>
           <strong>{__('Migration Plans')}</strong>
         </Breadcrumb.Item>
+        <BreadcrumbPageSwitcher activeHref="#/plans" />
       </Toolbar>
     );
 

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
@@ -223,7 +223,7 @@ const MigrationsCompletedList = ({
                           ),
                           !isMissingMapping && (
                             <ListView.InfoItem key={`${plan.id}-infraMappingName`}>
-                              <a href="/migration#/mappings">{plan.infraMappingName}</a>
+                              {plan.infraMappingName}
                             </ListView.InfoItem>
                           ),
                           !denied ? (

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
@@ -160,7 +160,7 @@ const MigrationsNotStartedList = ({
                           ),
                           !isMissingMapping && (
                             <ListView.InfoItem key={`${plan.id}-infraMappingName`}>
-                              <a href="/migration#/mappings">{plan.infraMappingName}</a>
+                              {plan.infraMappingName}
                             </ListView.InfoItem>
                           ),
                           migrationScheduled && !migrationStarting ? (

--- a/app/javascript/react/screens/App/Settings/Settings.js
+++ b/app/javascript/react/screens/App/Settings/Settings.js
@@ -4,6 +4,7 @@ import { Breadcrumb, Tabs, Tab } from 'patternfly-react';
 import Toolbar from '../../../config/Toolbar';
 import GeneralSettings from './screens/GeneralSettings';
 import ConversionHostsSettings from './screens/ConversionHostsSettings';
+import BreadcrumbPageSwitcher from '../common/BreadcrumbPageSwitcher';
 
 const Settings = props => {
   const { match, redirectTo } = props;
@@ -16,6 +17,7 @@ const Settings = props => {
         <Breadcrumb.Item active>
           <strong>{__('Migration Settings')}</strong>
         </Breadcrumb.Item>
+        <BreadcrumbPageSwitcher activeHref="#/settings" />
       </Toolbar>
       <div style={{ marginTop: 10 }}>
         <Tabs id="settings-tabs" activeKey={match.path} onSelect={key => redirectTo(key)} unmountOnExit>

--- a/app/javascript/react/screens/App/Settings/__tests__/__snapshots__/Settings.test.js.snap
+++ b/app/javascript/react/screens/App/Settings/__tests__/__snapshots__/Settings.test.js.snap
@@ -20,6 +20,9 @@ exports[`Settings component renders correctly 1`] = `
         Migration Settings
       </strong>
     </BreadcrumbItem>
+    <BreadcrumbPageSwitcher
+      activeHref="#/settings"
+    />
   </Toolbar>
   <div
     style={

--- a/app/javascript/react/screens/App/common/BreadcrumbPageSwitcher.js
+++ b/app/javascript/react/screens/App/common/BreadcrumbPageSwitcher.js
@@ -11,7 +11,7 @@ const BreadcrumbPageSwitcher = ({ activeHref }) => {
   );
 
   const popoverContent = (
-    <ListGroup style={{ marginBottom: 0 }}>
+    <ListGroup style={{ marginBottom: 0, borderTop: 0 }}>
       <SwitcherItem name={__('Migration Plans')} href="#/plans" />
       <SwitcherItem name={__('Infrastructure Mappings')} href="#/mappings" />
       <SwitcherItem name={__('Migration Settings')} href="#/settings" />

--- a/app/javascript/react/screens/App/common/BreadcrumbPageSwitcher.js
+++ b/app/javascript/react/screens/App/common/BreadcrumbPageSwitcher.js
@@ -9,6 +9,10 @@ const BreadcrumbPageSwitcher = ({ activeHref }) => {
       {name}
     </ListGroupItem>
   );
+  SwitcherItem.propTypes = {
+    name: PropTypes.string,
+    href: PropTypes.string
+  };
 
   const popoverContent = (
     <ListGroup style={{ marginBottom: 0, borderTop: 0 }}>

--- a/app/javascript/react/screens/App/common/BreadcrumbPageSwitcher.js
+++ b/app/javascript/react/screens/App/common/BreadcrumbPageSwitcher.js
@@ -25,7 +25,16 @@ const BreadcrumbPageSwitcher = ({ activeHref }) => {
       placement="bottom"
       overlay={<Popover id="breadcrumb-switcher-popover">{popoverContent}</Popover>}
     >
-      <Button style={{ marginTop: '-2px', marginBottom: '-4px', marginLeft: '15px' }}>
+      <Button
+        style={{
+          marginTop: '-2px',
+          marginBottom: '-4px',
+          marginLeft: '15px',
+          height: '22px',
+          width: '32px',
+          lineHeight: '14px'
+        }}
+      >
         <Icon type="fa" name="exchange" />
       </Button>
     </OverlayTrigger>

--- a/app/javascript/react/screens/App/common/BreadcrumbPageSwitcher.js
+++ b/app/javascript/react/screens/App/common/BreadcrumbPageSwitcher.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { OverlayTrigger, Popover, Button, Icon, ListGroup, ListGroupItem } from 'patternfly-react';
+
+const BreadcrumbPageSwitcher = ({ activeHref }) => {
+  const SwitcherItem = ({ name, href }) => (
+    <ListGroupItem className={classNames('no-border', { active: href === activeHref })} href={href}>
+      {name}
+    </ListGroupItem>
+  );
+
+  const popoverContent = (
+    <ListGroup style={{ marginBottom: 0 }}>
+      <SwitcherItem name={__('Migration Plans')} href="#/plans" />
+      <SwitcherItem name={__('Infrastructure Mappings')} href="#/mappings" />
+      <SwitcherItem name={__('Migration Settings')} href="#/settings" />
+    </ListGroup>
+  );
+
+  return (
+    <OverlayTrigger
+      rootClose
+      trigger="click"
+      placement="bottom"
+      overlay={<Popover id="breadcrumb-switcher-popover">{popoverContent}</Popover>}
+    >
+      <Button style={{ marginTop: '-2px', marginBottom: '-4px', marginLeft: '15px' }}>
+        <Icon type="fa" name="exchange" />
+      </Button>
+    </OverlayTrigger>
+  );
+};
+
+BreadcrumbPageSwitcher.propTypes = {
+  activeHref: PropTypes.string
+};
+
+export default BreadcrumbPageSwitcher;


### PR DESCRIPTION
Closes #865.
https://bugzilla.redhat.com/show_bug.cgi?id=1670703

I didn't use the `BreadcrumbSwitcher` available in patternfly-react because of some issues with its `active` prop on resources being set by `window.location.pathname`, which doesn't work for our client-side routing. Also, that component has no way to disable its search bar without a CSS override.

This small component seemed like a much simpler solution.

![vUZWJKL2hZ](https://user-images.githubusercontent.com/811963/58513924-9c4a2000-816e-11e9-91d6-1904e7c65c0d.gif)

