### PR TITLE
[#875] Replace Configure Providers button with distinct links to infra and cloud providers

### DIFF
--- a/app/javascript/react/screens/App/Mappings/Mappings.js
+++ b/app/javascript/react/screens/App/Mappings/Mappings.js
@@ -8,8 +8,8 @@ import InfrastructureMappingsList from './components/InfrastructureMappingsList/
 import { FETCH_TRANSFORMATION_PLANS_URL, FETCH_ARCHIVED_TRANSFORMATION_PLANS_URL } from '../Overview/OverviewConstants';
 import { FETCH_TRANSFORMATION_MAPPINGS_URL, FETCH_CLOUD_TENANTS_URL } from './MappingsConstants';
 import { FETCH_V2V_PROVIDERS_URL } from '../../../../redux/common/providers/providersConstants';
-import ShowWizardEmptyState from '../common/ShowWizardEmptyState/ShowWizardEmptyState';
 import BreadcrumbPageSwitcher from '../common/BreadcrumbPageSwitcher';
+import NoProvidersEmptyState from '../common/NoProvidersEmptyState';
 
 class Mappings extends Component {
   constructor(props) {
@@ -228,14 +228,7 @@ class Mappings extends Component {
               showMappingWizardEditModeAction={showMappingWizardEditModeAction}
             />
           ) : (
-            <ShowWizardEmptyState
-              description={
-                __('The source and target providers must be configured before attempting a migration') // prettier-ignore
-              }
-              buttonText={__('Configure Providers')}
-              buttonHref="/ems_infra/show_list"
-              className="white-bg"
-            />
+            <NoProvidersEmptyState className="white-bg" />
           )}
         </Spinner>
         {mappingWizardVisible && this.mappingWizard}

--- a/app/javascript/react/screens/App/Overview/Overview.js
+++ b/app/javascript/react/screens/App/Overview/Overview.js
@@ -17,6 +17,7 @@ import {
 import { FETCH_TRANSFORMATION_MAPPINGS_URL, FETCH_CLOUD_TENANTS_URL } from '../Mappings/MappingsConstants';
 import { FETCH_V2V_PROVIDERS_URL } from '../../../../redux/common/providers/providersConstants';
 import BreadcrumbPageSwitcher from '../common/BreadcrumbPageSwitcher';
+import NoProvidersEmptyState from '../common/NoProvidersEmptyState';
 
 class Overview extends React.Component {
   constructor(props) {
@@ -359,14 +360,7 @@ class Overview extends React.Component {
               />
             )
           ) : (
-            <ShowWizardEmptyState
-              description={
-                __('The source and target providers must be configured before attempting a migration') // prettier-ignore
-              }
-              buttonText={__('Configure Providers')}
-              buttonHref="/ems_infra/show_list"
-              className="full-page-empty"
-            />
+            <NoProvidersEmptyState className="full-page-empty" />
           )}
         </Spinner>
         <ConfirmModal show={confirmModalVisible} onCancel={hideConfirmModalAction} {...confirmModalOptions} />

--- a/app/javascript/react/screens/App/Overview/__test__/Overview.test.js
+++ b/app/javascript/react/screens/App/Overview/__test__/Overview.test.js
@@ -49,7 +49,7 @@ describe('Overview component', () => {
     test('and displays empty state if insufficient', () => {
       const props = getBaseProps();
       const wrapper = shallow(<Overview {...props} hasSufficientProviders={false} />); // eslint-disable-line no-unused-vars
-      expect(wrapper.find('ShowWizardEmptyState')).toMatchSnapshot();
+      expect(wrapper.find('NoProvidersEmptyState')).toMatchSnapshot();
     });
   });
 });

--- a/app/javascript/react/screens/App/Overview/__test__/__snapshots__/Overview.test.js.snap
+++ b/app/javascript/react/screens/App/Overview/__test__/__snapshots__/Overview.test.js.snap
@@ -1,14 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Overview component checks for necessary providers and displays empty state if insufficient 1`] = `
-<ShowWizardEmptyState
-  buttonHref="/ems_infra/show_list"
-  buttonText="Configure Providers"
+<NoProvidersEmptyState
   className="full-page-empty"
-  description="The source and target providers must be configured before attempting a migration"
-  iconName="add-circle-o"
-  iconType="pf"
-  showWizardAction={null}
-  title=" "
 />
 `;

--- a/app/javascript/react/screens/App/common/NoProvidersEmptyState.js
+++ b/app/javascript/react/screens/App/common/NoProvidersEmptyState.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ShowWizardEmptyState from './ShowWizardEmptyState/ShowWizardEmptyState';
+
+const NoProvidersEmptyState = ({ className }) => (
+  <ShowWizardEmptyState
+    className={className}
+    description={
+      __('Before attempting a migration, you must have at least one VMware and one Red Hat Virtualization or Red Hat OpenStack Platform provider configured.') // prettier-ignore
+    }
+    action={
+      <React.Fragment>
+        <a href="/ems_infra/show_list">{__('View VMware and Red Hat Virtualization providers')}</a>
+        <br />
+        <a href="/ems_cloud/show_list">{__('View Red Hat OpenStack Platform providers')}</a>
+      </React.Fragment>
+    }
+  />
+);
+
+NoProvidersEmptyState.propTypes = {
+  className: PropTypes.string
+};
+
+export default NoProvidersEmptyState;

--- a/app/javascript/react/screens/App/common/ShowWizardEmptyState/ShowWizardEmptyState.js
+++ b/app/javascript/react/screens/App/common/ShowWizardEmptyState/ShowWizardEmptyState.js
@@ -7,6 +7,7 @@ const ShowWizardEmptyState = ({
   buttonHref,
   description,
   buttonText,
+  action,
   title,
   iconType,
   iconName,
@@ -16,11 +17,14 @@ const ShowWizardEmptyState = ({
     <EmptyState.Icon type={iconType} name={iconName} />
     <EmptyState.Title>{title}</EmptyState.Title>
     <EmptyState.Info>{description}</EmptyState.Info>
-    {buttonText && (
+    {(buttonText || action) && (
       <EmptyState.Action>
-        <Button bsStyle="primary" bsSize="large" onClick={showWizardAction} href={buttonHref}>
-          {sprintf(__('%s'), buttonText)}
-        </Button>
+        {action}
+        {buttonText && (
+          <Button bsStyle="primary" bsSize="large" onClick={showWizardAction} href={buttonHref}>
+            {sprintf(__('%s'), buttonText)}
+          </Button>
+        )}
       </EmptyState.Action>
     )}
   </EmptyState>
@@ -31,6 +35,7 @@ ShowWizardEmptyState.propTypes = {
   buttonHref: PropTypes.string,
   description: PropTypes.node,
   buttonText: PropTypes.string,
+  action: PropTypes.node,
   title: PropTypes.string,
   iconType: PropTypes.string,
   iconName: PropTypes.string


### PR DESCRIPTION
Fixes #875.

This PR affects the empty state view that is shown when the user has no providers configured. To test it, you can modify the Overview/index.js file and/or the Mappings/index.js file so that the `hasSufficientProviders` prop is false.

Instead of the single "Configure Providers" button that we had before, which linked to `Compute > Infrastructure > Providers`, (which was not helpful for OpenStack providers) we now have distinct links to both that page and `Compute > Cloud > Providers`.

To reduce code duplication I consolidated these two identical empty state views into a new component called `NoProvidersEmptyState`.

As seen in the Plans view:

<img width="1438" alt="Screenshot 2019-06-10 16 08 39" src="https://user-images.githubusercontent.com/811963/59223779-ce11ac80-8b9a-11e9-9637-0955568ea48f.png">

As seen in the Mappings view:

<img width="1440" alt="Screenshot 2019-06-10 16 08 45" src="https://user-images.githubusercontent.com/811963/59223794-d4a02400-8b9a-11e9-94b9-7f4de601e1a4.png">
