### PR TITLE
Add 'Missing Providers' title to empty state, update empty state on conversion host settings page

### DIFF
--- a/app/javascript/react/screens/App/Overview/__test__/__snapshots__/Overview.test.js.snap
+++ b/app/javascript/react/screens/App/Overview/__test__/__snapshots__/Overview.test.js.snap
@@ -3,5 +3,6 @@
 exports[`Overview component checks for necessary providers and displays empty state if insufficient 1`] = `
 <NoProvidersEmptyState
   className="full-page-empty"
+  description="Before attempting a migration, you must have at least one VMware and one Red Hat Virtualization or Red Hat OpenStack Platform provider configured."
 />
 `;

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/ConversionHostsSettings.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/ConversionHostsSettings.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Spinner, Icon } from 'patternfly-react';
-import ShowWizardEmptyState from '../../../common/ShowWizardEmptyState/ShowWizardEmptyState';
 import ConversionHostsEmptyState from './components/ConversionHostsEmptyState';
 import ConversionHostsList from './components/ConversionHostsList';
 import ConversionHostWizard from './components/ConversionHostWizard';
 import { FETCH_V2V_PROVIDERS_URL } from '../../../../../../redux/common/providers/providersConstants';
+import NoProvidersEmptyState from '../../../common/NoProvidersEmptyState';
 
 class ConversionHostsSettings extends React.Component {
   pollingInterval = null;
@@ -90,13 +90,11 @@ class ConversionHostsSettings extends React.Component {
     return (
       <Spinner loading={isFetchingProviders || !hasMadeInitialFetch} style={{ marginTop: 15 }}>
         {!hasSufficientProviders ? (
-          <ShowWizardEmptyState
+          <NoProvidersEmptyState
+            className="full-page-empty"
             description={
               __('There are no providers available from which to configure a conversion host. You must configure a target provider before configuring conversion hosts.') // prettier-ignore
             }
-            buttonText={__('Configure Providers')}
-            buttonHref="/ems_infra/show_list"
-            className="full-page-empty"
           />
         ) : (
           <React.Fragment>

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/__tests__/ConversionHostsSettings.test.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/__tests__/ConversionHostsSettings.test.js
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 import { Spinner } from 'patternfly-react';
 import ConversionHostsSettings from '../ConversionHostsSettings';
 import ConversionHostsEmptyState from '../components/ConversionHostsEmptyState';
-import ShowWizardEmptyState from '../../../../common/ShowWizardEmptyState/ShowWizardEmptyState';
+import NoProvidersEmptyState from '../../../../common/NoProvidersEmptyState';
 import ConversionHostsList from '../components/ConversionHostsList';
 import ConversionHostWizard from '../components/ConversionHostWizard';
 
@@ -38,7 +38,7 @@ describe('ConversionHostsSettings component', () => {
 
   it('renders an empty state when insufficient providers are present', () => {
     const component = shallow(<ConversionHostsSettings {...getBaseProps()} hasSufficientProviders={false} />);
-    expect(component.find(ShowWizardEmptyState)).toHaveLength(1);
+    expect(component.find(NoProvidersEmptyState)).toHaveLength(1);
     expect(component.find(ConversionHostsEmptyState)).toHaveLength(0);
     expect(component.find(ConversionHostsList)).toHaveLength(0);
     expect(component.find(ConversionHostWizard)).toHaveLength(0);
@@ -47,7 +47,7 @@ describe('ConversionHostsSettings component', () => {
   it('renders an empty state when no conversion hosts are present', () => {
     const component = shallow(<ConversionHostsSettings {...getBaseProps()} />);
     expect(component.find(ConversionHostsEmptyState)).toHaveLength(1);
-    expect(component.find(ShowWizardEmptyState)).toHaveLength(0);
+    expect(component.find(NoProvidersEmptyState)).toHaveLength(0);
     expect(component.find(ConversionHostsList)).toHaveLength(0);
     expect(component.find(ConversionHostWizard)).toHaveLength(0);
   });
@@ -55,7 +55,7 @@ describe('ConversionHostsSettings component', () => {
   it('renders the list view when conversion hosts are present', () => {
     const component = shallow(<ConversionHostsSettings {...getBaseProps()} combinedListItems={[{ foo: 'bar' }]} />);
     expect(component.find(ConversionHostsList)).toHaveLength(1);
-    expect(component.find(ShowWizardEmptyState)).toHaveLength(0);
+    expect(component.find(NoProvidersEmptyState)).toHaveLength(0);
     expect(component.find(ConversionHostsEmptyState)).toHaveLength(0);
     expect(component.find(ConversionHostWizard)).toHaveLength(0);
   });

--- a/app/javascript/react/screens/App/common/NoProvidersEmptyState.js
+++ b/app/javascript/react/screens/App/common/NoProvidersEmptyState.js
@@ -2,12 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ShowWizardEmptyState from './ShowWizardEmptyState/ShowWizardEmptyState';
 
-const NoProvidersEmptyState = ({ className }) => (
+const NoProvidersEmptyState = ({ className, description }) => (
   <ShowWizardEmptyState
     className={className}
-    description={
-      __('Before attempting a migration, you must have at least one VMware and one Red Hat Virtualization or Red Hat OpenStack Platform provider configured.') // prettier-ignore
-    }
+    title={__('Missing Providers')}
+    description={description}
     action={
       <React.Fragment>
         <a href="/ems_infra/show_list">{__('View VMware and Red Hat Virtualization providers')}</a>
@@ -19,7 +18,12 @@ const NoProvidersEmptyState = ({ className }) => (
 );
 
 NoProvidersEmptyState.propTypes = {
-  className: PropTypes.string
+  className: PropTypes.string,
+  description: PropTypes.string
+};
+
+NoProvidersEmptyState.defaultProps = {
+  description: __('Before attempting a migration, you must have at least one VMware and one Red Hat Virtualization or Red Hat OpenStack Platform provider configured.') // prettier-ignore
 };
 
 export default NoProvidersEmptyState;


### PR DESCRIPTION
In #980 I forgot to update the similar empty state on the Conversion Hosts settings page. This corrects that, while also adding a "Missing Providers" title to these empty states as suggested by @vconzola [here](https://github.com/ManageIQ/manageiq-v2v/pull/980#issuecomment-501422019).

As seen in the Plans view:

![Screenshot 2019-06-12 15 46 07](https://user-images.githubusercontent.com/811963/59381721-232ff880-8d2a-11e9-9379-93c1a56f6698.png)

As seen in the Mappings view:

![Screenshot 2019-06-12 15 45 35](https://user-images.githubusercontent.com/811963/59381738-2aef9d00-8d2a-11e9-8312-bf9fc4262d49.png)

As seen in the Settings view (I kept the original description text):

![Screenshot 2019-06-12 15 45 07](https://user-images.githubusercontent.com/811963/59381745-30e57e00-8d2a-11e9-811f-e380993aa774.png)
