### PR TITLE
Move v2v product features to plugin repo

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -1,0 +1,45 @@
+# V2V
+- :name: Migration Overview
+  :description: Migration Overview
+  :feature_type: node
+  :identifier: migration
+  :children:
+  - :name: Conversion Hosts
+    :description: Conversion Hosts
+    :feature_type: node
+    :identifier: conversion_host
+    :children:
+    - :name: View
+      :description: View Conversion Hosts
+      :feature_type: view
+      :identifier: conversion_host_view
+      :children:
+      - :name: List
+        :description: Display Lists of Conversion Hosts
+        :feature_type: view
+        :identifier: conversion_host_show_list
+      - :name: Show
+        :description: Display Individual Conversion Hosts
+        :feature_type: view
+        :identifier: conversion_host_show
+    - :name: Operate
+      :description: Perform Operations on Conversion Hosts
+      :feature_type: control
+      :identifier: conversion_host_control
+      :children:
+      - :name: Edit Tags
+        :description: Edit Tags of Conversion Hosts
+        :feature_type: control
+        :identifier: conversion_host_tag
+
+# V2V
+- :name: Infrastructure Mappings
+  :description: Infrastructure Mappings
+  :feature_type: node
+  :identifier: mappings
+
+# V2V
+- :name: Migration Settings
+  :description: Migration Settings
+  :feature_type: node
+  :identifier: migration_settings

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -1,8 +1,17 @@
-# V2V
 - :name: Migration Overview
   :description: Migration Overview
   :feature_type: node
   :identifier: migration
+
+- :name: Infrastructure Mappings
+  :description: Infrastructure Mappings
+  :feature_type: node
+  :identifier: mappings
+
+- :name: Migration Settings
+  :description: Migration Settings
+  :feature_type: node
+  :identifier: migration_settings
   :children:
   - :name: Conversion Hosts
     :description: Conversion Hosts
@@ -31,15 +40,3 @@
         :description: Edit Tags of Conversion Hosts
         :feature_type: control
         :identifier: conversion_host_tag
-
-# V2V
-- :name: Infrastructure Mappings
-  :description: Infrastructure Mappings
-  :feature_type: node
-  :identifier: mappings
-
-# V2V
-- :name: Migration Settings
-  :description: Migration Settings
-  :feature_type: node
-  :identifier: migration_settings


### PR DESCRIPTION
1. v2v product features can live in the plugin repo (remove from core in https://github.com/ManageIQ/manageiq/pull/18884)
2. fix for product features structure to mimic ui / menu structure

Before
![roles-before](https://user-images.githubusercontent.com/6648365/59667301-c4013680-91b6-11e9-9526-f6c249b0e3d6.png)


After
![roles-after](https://user-images.githubusercontent.com/6648365/59667313-c82d5400-91b6-11e9-8b13-f056af069e81.png)
