### PR TITLE
Move the Migration menu section to the top level, placed before Configuration (after Compute)

### DIFF
--- a/app/javascript/react/screens/App/Mappings/Mappings.js
+++ b/app/javascript/react/screens/App/Mappings/Mappings.js
@@ -1,14 +1,13 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Breadcrumb, Spinner } from 'patternfly-react';
+import { Spinner } from 'patternfly-react';
 
-import Toolbar from '../../../config/Toolbar';
 import componentRegistry from '../../../../components/componentRegistry';
 import InfrastructureMappingsList from './components/InfrastructureMappingsList/InfrastructureMappingsList';
 import { FETCH_TRANSFORMATION_PLANS_URL, FETCH_ARCHIVED_TRANSFORMATION_PLANS_URL } from '../Overview/OverviewConstants';
 import { FETCH_TRANSFORMATION_MAPPINGS_URL, FETCH_CLOUD_TENANTS_URL } from './MappingsConstants';
 import { FETCH_V2V_PROVIDERS_URL } from '../../../../redux/common/providers/providersConstants';
-import BreadcrumbPageSwitcher from '../common/BreadcrumbPageSwitcher';
+import MigrationBreadcrumbBar from '../common/MigrationBreadcrumbBar';
 import NoProvidersEmptyState from '../common/NoProvidersEmptyState';
 
 class Mappings extends Component {
@@ -174,13 +173,7 @@ class Mappings extends Component {
 
     return (
       <React.Fragment>
-        <Toolbar>
-          <Breadcrumb.Item active>{__('Migration')}</Breadcrumb.Item>
-          <Breadcrumb.Item active>
-            <strong>{__('Infrastructure Mappings')}</strong>
-          </Breadcrumb.Item>
-          <BreadcrumbPageSwitcher activeHref="#/mappings" />
-        </Toolbar>
+        <MigrationBreadcrumbBar activeHref="#/mappings" />
         <Spinner
           loading={
             isFetchingCloudNetworks ||

--- a/app/javascript/react/screens/App/Mappings/Mappings.js
+++ b/app/javascript/react/screens/App/Mappings/Mappings.js
@@ -175,7 +175,6 @@ class Mappings extends Component {
     return (
       <React.Fragment>
         <Toolbar>
-          <Breadcrumb.Item active>{__('Compute')}</Breadcrumb.Item>
           <Breadcrumb.Item active>{__('Migration')}</Breadcrumb.Item>
           <Breadcrumb.Item active>
             <strong>{__('Infrastructure Mappings')}</strong>

--- a/app/javascript/react/screens/App/Overview/Overview.js
+++ b/app/javascript/react/screens/App/Overview/Overview.js
@@ -408,7 +408,6 @@ class Overview extends React.Component {
 
     const toolbarContent = (
       <Toolbar>
-        <Breadcrumb.Item active>{__('Compute')}</Breadcrumb.Item>
         <Breadcrumb.Item active>{__('Migration')}</Breadcrumb.Item>
         <Breadcrumb.Item active>
           <strong>{__('Migration Plans')}</strong>

--- a/app/javascript/react/screens/App/Overview/Overview.js
+++ b/app/javascript/react/screens/App/Overview/Overview.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Card, Breadcrumb, CardGrid, Spinner, Icon } from 'patternfly-react';
+import { Card, CardGrid, Spinner, Icon } from 'patternfly-react';
 
-import Toolbar from '../../../config/Toolbar';
 import * as AggregateCards from './components/AggregateCards';
 import Migrations from './components/Migrations/Migrations';
 import ShowWizardEmptyState from '../common/ShowWizardEmptyState/ShowWizardEmptyState';
@@ -16,7 +15,7 @@ import {
 } from './OverviewConstants';
 import { FETCH_TRANSFORMATION_MAPPINGS_URL, FETCH_CLOUD_TENANTS_URL } from '../Mappings/MappingsConstants';
 import { FETCH_V2V_PROVIDERS_URL } from '../../../../redux/common/providers/providersConstants';
-import BreadcrumbPageSwitcher from '../common/BreadcrumbPageSwitcher';
+import MigrationBreadcrumbBar from '../common/MigrationBreadcrumbBar';
 import NoProvidersEmptyState from '../common/NoProvidersEmptyState';
 
 class Overview extends React.Component {
@@ -406,19 +405,9 @@ class Overview extends React.Component {
         </div>
       );
 
-    const toolbarContent = (
-      <Toolbar>
-        <Breadcrumb.Item active>{__('Migration')}</Breadcrumb.Item>
-        <Breadcrumb.Item active>
-          <strong>{__('Migration Plans')}</strong>
-        </Breadcrumb.Item>
-        <BreadcrumbPageSwitcher activeHref="#/plans" />
-      </Toolbar>
-    );
-
     return (
       <React.Fragment>
-        {toolbarContent}
+        <MigrationBreadcrumbBar activeHref="#/plans" />
         {overviewContent}
         {mappingWizardVisible && this.mappingWizard}
         {planWizardVisible && this.planWizard}

--- a/app/javascript/react/screens/App/Plan/Plan.js
+++ b/app/javascript/react/screens/App/Plan/Plan.js
@@ -165,7 +165,6 @@ class Plan extends React.Component {
     return (
       <React.Fragment>
         <Toolbar>
-          <Breadcrumb.Item active>{__('Compute')}</Breadcrumb.Item>
           <Breadcrumb.Item active>{__('Migration')}</Breadcrumb.Item>
           <Breadcrumb.Item href="#/plans">{__('Migration Plans')}</Breadcrumb.Item>
           {!isRejectedPlan &&

--- a/app/javascript/react/screens/App/Settings/Settings.js
+++ b/app/javascript/react/screens/App/Settings/Settings.js
@@ -12,7 +12,6 @@ const Settings = props => {
   return (
     <React.Fragment>
       <Toolbar>
-        <Breadcrumb.Item active>{__('Compute')}</Breadcrumb.Item>
         <Breadcrumb.Item active>{__('Migration')}</Breadcrumb.Item>
         <Breadcrumb.Item active>
           <strong>{__('Migration Settings')}</strong>

--- a/app/javascript/react/screens/App/Settings/Settings.js
+++ b/app/javascript/react/screens/App/Settings/Settings.js
@@ -1,23 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Breadcrumb, Tabs, Tab } from 'patternfly-react';
-import Toolbar from '../../../config/Toolbar';
+import { Tabs, Tab } from 'patternfly-react';
 import GeneralSettings from './screens/GeneralSettings';
 import ConversionHostsSettings from './screens/ConversionHostsSettings';
-import BreadcrumbPageSwitcher from '../common/BreadcrumbPageSwitcher';
+import MigrationBreadcrumbBar from '../common/MigrationBreadcrumbBar';
 
 const Settings = props => {
   const { match, redirectTo } = props;
 
   return (
     <React.Fragment>
-      <Toolbar>
-        <Breadcrumb.Item active>{__('Migration')}</Breadcrumb.Item>
-        <Breadcrumb.Item active>
-          <strong>{__('Migration Settings')}</strong>
-        </Breadcrumb.Item>
-        <BreadcrumbPageSwitcher activeHref="#/settings" />
-      </Toolbar>
+      <MigrationBreadcrumbBar activeHref="#/settings" />
       <div style={{ marginTop: 10 }}>
         <Tabs id="settings-tabs" activeKey={match.path} onSelect={key => redirectTo(key)} unmountOnExit>
           <Tab eventKey="/settings" title={__('Migration Throttling')}>

--- a/app/javascript/react/screens/App/Settings/__tests__/__snapshots__/Settings.test.js.snap
+++ b/app/javascript/react/screens/App/Settings/__tests__/__snapshots__/Settings.test.js.snap
@@ -2,23 +2,9 @@
 
 exports[`Settings component renders correctly 1`] = `
 <React.Fragment>
-  <Toolbar>
-    <BreadcrumbItem
-      active={true}
-    >
-      Migration
-    </BreadcrumbItem>
-    <BreadcrumbItem
-      active={true}
-    >
-      <strong>
-        Migration Settings
-      </strong>
-    </BreadcrumbItem>
-    <BreadcrumbPageSwitcher
-      activeHref="#/settings"
-    />
-  </Toolbar>
+  <MigrationBreadcrumbBar
+    activeHref="#/settings"
+  />
   <div
     style={
       Object {

--- a/app/javascript/react/screens/App/Settings/__tests__/__snapshots__/Settings.test.js.snap
+++ b/app/javascript/react/screens/App/Settings/__tests__/__snapshots__/Settings.test.js.snap
@@ -6,11 +6,6 @@ exports[`Settings component renders correctly 1`] = `
     <BreadcrumbItem
       active={true}
     >
-      Compute
-    </BreadcrumbItem>
-    <BreadcrumbItem
-      active={true}
-    >
       Migration
     </BreadcrumbItem>
     <BreadcrumbItem

--- a/app/javascript/react/screens/App/common/BreadcrumbPageSwitcher.js
+++ b/app/javascript/react/screens/App/common/BreadcrumbPageSwitcher.js
@@ -3,32 +3,21 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { OverlayTrigger, Popover, Button, Icon, ListGroup, ListGroupItem } from 'patternfly-react';
 
-const BreadcrumbPageSwitcher = ({ activeHref }) => {
-  const SwitcherItem = ({ name, href }) => (
-    <ListGroupItem className={classNames('no-border', { active: href === activeHref })} href={href}>
-      {name}
-    </ListGroupItem>
-  );
-  SwitcherItem.propTypes = {
-    name: PropTypes.string,
-    href: PropTypes.string
-  };
-
-  const popoverContent = (
-    <ListGroup style={{ marginBottom: 0, borderTop: 0 }}>
-      <SwitcherItem name={__('Migration Plans')} href="#/plans" />
-      <SwitcherItem name={__('Infrastructure Mappings')} href="#/mappings" />
-      <SwitcherItem name={__('Migration Settings')} href="#/settings" />
-    </ListGroup>
+const BreadcrumbPageSwitcher = ({ items, activeHref }) => {
+  const popover = (
+    <Popover id="breadcrumb-switcher-popover">
+      <ListGroup style={{ marginBottom: 0, borderTop: 0 }}>
+        {items.map(({ name, href }) => (
+          <ListGroupItem className={classNames('no-border', { active: href === activeHref })} href={href} key={href}>
+            {name}
+          </ListGroupItem>
+        ))}
+      </ListGroup>
+    </Popover>
   );
 
   return (
-    <OverlayTrigger
-      rootClose
-      trigger="click"
-      placement="bottom"
-      overlay={<Popover id="breadcrumb-switcher-popover">{popoverContent}</Popover>}
-    >
+    <OverlayTrigger rootClose trigger="click" placement="bottom" overlay={popover}>
       <Button
         style={{
           marginTop: '-2px',
@@ -46,7 +35,8 @@ const BreadcrumbPageSwitcher = ({ activeHref }) => {
 };
 
 BreadcrumbPageSwitcher.propTypes = {
-  activeHref: PropTypes.string
+  activeHref: PropTypes.string.isRequired,
+  items: PropTypes.arrayOf(PropTypes.shape({ name: PropTypes.string, href: PropTypes.string })).isRequired
 };
 
 export default BreadcrumbPageSwitcher;

--- a/app/javascript/react/screens/App/common/MigrationBreadcrumbBar.js
+++ b/app/javascript/react/screens/App/common/MigrationBreadcrumbBar.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Breadcrumb } from 'patternfly-react';
+import Toolbar from '../../../config/Toolbar';
+import BreadcrumbPageSwitcher from './BreadcrumbPageSwitcher';
+
+const items = [
+  { name: __('Migration Plans'), href: '#/plans' },
+  { name: __('Infrastructure Mappings'), href: '#/mappings' },
+  { name: __('Migration Settings'), href: '#/settings' }
+];
+
+const MigrationBreadcrumbBar = ({ activeHref }) => {
+  const activeItem = items.find(item => item.href === activeHref);
+  return (
+    <Toolbar>
+      <Breadcrumb.Item active>{__('Migration')}</Breadcrumb.Item>
+      <Breadcrumb.Item active>
+        <strong>{activeItem.name}</strong>
+      </Breadcrumb.Item>
+      <BreadcrumbPageSwitcher items={items} activeHref={activeHref} />
+    </Toolbar>
+  );
+};
+
+MigrationBreadcrumbBar.propTypes = {
+  activeHref: PropTypes.string.isRequired
+};
+
+export default MigrationBreadcrumbBar;

--- a/lib/manageiq/v2v/engine.rb
+++ b/lib/manageiq/v2v/engine.rb
@@ -12,11 +12,11 @@ module ManageIQ::V2V
 
     initializer 'plugin' do
       Menu::CustomLoader.register(
-        Menu::Section.new(:migration, N_("Migration"), 'fa fa-plus', [
+        Menu::Section.new(:migration, N_("Migration"), 'pficon pficon-migration', [
           Menu::Item.new('plans', N_("Migration Plans"), 'migration', {:feature => 'migration', :any => true}, '/migration#/plans'),
           Menu::Item.new('mappings', N_("Infrastructure Mappings"), 'mappings', {:feature => 'mappings', :any => true}, '/migration#/mappings'),
           Menu::Item.new('settings', N_("Migration Settings"), 'migration_settings', {:feature => 'migration_settings', :any => true}, '/migration#/settings')
-        ], nil, nil, nil, nil, :compute)
+        ], nil, :conf) # Place Migration before Configuration (after Compute)
       )
     end
 


### PR DESCRIPTION
Closes #994.

In anticipation of adding the new Migration Analytics page (which will now be in a separate plugin), we decided Migration should be promoted to its own top-level menu section within ManageIQ/CloudForms. This PR simply moves the menu and updates the breadcrumb bars of each page to remove the Compute piece.

![Screenshot 2019-06-20 17 29 19](https://user-images.githubusercontent.com/811963/59883737-13e12880-9384-11e9-8f90-01c46986d492.png)
