### PR TITLE
Modify rails config filters for v2v

### DIFF
--- a/lib/manageiq/v2v/engine.rb
+++ b/lib/manageiq/v2v/engine.rb
@@ -10,6 +10,10 @@ module ManageIQ::V2V
       app.config.assets.paths << root.join('assets', 'images').to_s
     end
 
+    initializer 'plugin.filter' do |app|
+      app.config.filter_parameters += %i[conversion_host_ssh_private_key openstack_tls_ca_certs vmware_ssh_private_key]
+    end
+
     initializer 'plugin-migration-menu' do
       Menu::CustomLoader.register(
         Menu::Section.new(:migration, N_("Migration"), 'pficon pficon-migration', [

--- a/spec/initializers/filter_params_spec.rb
+++ b/spec/initializers/filter_params_spec.rb
@@ -1,0 +1,11 @@
+RSpec.describe Rails::Application::Configuration do
+  let(:filter_parameters) { Rails.application.config.filter_parameters }
+
+  context "filters" do
+    it "includes additional parameters to filter" do
+      expect(filter_parameters).to include(:conversion_host_ssh_private_key)
+      expect(filter_parameters).to include(:vmware_ssh_private_key)
+      expect(filter_parameters).to include(:openstack_tls_ca_certs)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds additional filtered parameters for V2V. The REST API internally uses this list inside the  `Logger#log_api_request` method where it filters the params

This partially addresses #595 in that it will filter the api.log data, but doesn't affect the core production (evm) log. That will need to be a separate PR.

Replaces https://github.com/ManageIQ/manageiq-api/pull/614