### PR TITLE
Make the rails initializer name unique so it can be referenced in other plugins

### DIFF
--- a/lib/manageiq/v2v/engine.rb
+++ b/lib/manageiq/v2v/engine.rb
@@ -10,7 +10,7 @@ module ManageIQ::V2V
       app.config.assets.paths << root.join('assets', 'images').to_s
     end
 
-    initializer 'plugin' do
+    initializer 'plugin-migration-menu' do
       Menu::CustomLoader.register(
         Menu::Section.new(:migration, N_("Migration"), 'pficon pficon-migration', [
           Menu::Item.new('plans', N_("Migration Plans"), 'migration', {:feature => 'migration', :any => true}, '/migration#/plans'),


### PR DESCRIPTION
In order to have the Migration Analytics plugin run its initializer after this plugin's initializer (to insert itself in the Migration menu section), we need a unique identifier for this plugin's initializer.

See this relevant commit in the new plugin: https://github.com/mturley/cfme-migration_analytics/commit/95323d4da8155ba157486485f0c5c9806b4f3eac

Without the Migration Analytics plugin installed, this has no effect.