### PR TITLE
Conversion Host Wizard: Set VDDK as default transformation method

### DIFF
--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/ConversionHostWizardAuthenticationStep.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/ConversionHostWizardAuthenticationStep.js
@@ -46,7 +46,7 @@ const ConversionHostWizardAuthenticationStep = ({
         name="transformationMethod"
         label={__('Transformation method')}
         component={BootstrapSelect}
-        options={[{ id: SSH, name: __('SSH') }, { id: VDDK, name: __('VDDK') }]}
+        options={[{ id: VDDK, name: __('VDDK') }, { id: SSH, name: __('SSH') }]}
         option_key="id"
         option_value="name"
         inline_label
@@ -129,6 +129,7 @@ export default reduxForm({
   initialValues: {
     openstackUser: 'cloud-user',
     conversionHostSshKey: { filename: '', body: '' },
+    transformationMethod: VDDK,
     vmwareSshKey: { filename: '', body: '' },
     openstackCaCerts: { filename: '', body: '' },
     verifyOpenstackCerts: false

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/__tests__/__snapshots__/ConversionHostWizardAuthenticationStep.test.js.snap
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/__tests__/__snapshots__/ConversionHostWizardAuthenticationStep.test.js.snap
@@ -45,12 +45,12 @@ exports[`conversion host wizard authentication step renders correctly in the ini
     options={
       Array [
         Object {
-          "id": "SSH",
-          "name": "SSH",
-        },
-        Object {
           "id": "VDDK",
           "name": "VDDK",
+        },
+        Object {
+          "id": "SSH",
+          "name": "SSH",
         },
       ]
     }
@@ -115,12 +115,12 @@ exports[`conversion host wizard authentication step renders correctly in the ini
     options={
       Array [
         Object {
-          "id": "SSH",
-          "name": "SSH",
-        },
-        Object {
           "id": "VDDK",
           "name": "VDDK",
+        },
+        Object {
+          "id": "SSH",
+          "name": "SSH",
         },
       ]
     }
@@ -169,12 +169,12 @@ exports[`conversion host wizard authentication step renders correctly with SSH t
     options={
       Array [
         Object {
-          "id": "SSH",
-          "name": "SSH",
-        },
-        Object {
           "id": "VDDK",
           "name": "VDDK",
+        },
+        Object {
+          "id": "SSH",
+          "name": "SSH",
         },
       ]
     }
@@ -232,12 +232,12 @@ exports[`conversion host wizard authentication step renders correctly with VDDK 
     options={
       Array [
         Object {
-          "id": "SSH",
-          "name": "SSH",
-        },
-        Object {
           "id": "VDDK",
           "name": "VDDK",
+        },
+        Object {
+          "id": "SSH",
+          "name": "SSH",
         },
       ]
     }
@@ -317,12 +317,12 @@ exports[`conversion host wizard authentication step renders correctly with verif
     options={
       Array [
         Object {
-          "id": "SSH",
-          "name": "SSH",
-        },
-        Object {
           "id": "VDDK",
           "name": "VDDK",
+        },
+        Object {
+          "id": "SSH",
+          "name": "SSH",
         },
       ]
     }
@@ -384,6 +384,7 @@ exports[`conversion host wizard authentication step renders the redux-form wrapp
         "filename": "",
       },
       "openstackUser": "cloud-user",
+      "transformationMethod": "VDDK",
       "verifyOpenstackCerts": false,
       "vmwareSshKey": Object {
         "body": "",

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/__tests__/__snapshots__/index.test.js.snap
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/__tests__/__snapshots__/index.test.js.snap
@@ -3,7 +3,7 @@
 exports[`ConversionHostWizardAuthenticationStep integration test should mount ConversionHostWizardAuthenticationStep with mapStateToProps reduced 1`] = `
 Object {
   "selectedProviderType": "openstack",
-  "selectedTransformationMethod": undefined,
+  "selectedTransformationMethod": "VDDK",
   "verifyOpenstackCerts": false,
 }
 `;

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/__tests__/index.test.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/__tests__/index.test.js
@@ -42,13 +42,13 @@ describe('ConversionHostWizardAuthenticationStep integration test', () => {
     const form = () => store.getState().form[stepIDs.authenticationStep];
     const changeFormValue = (key, val) => store.dispatch(change(stepIDs.authenticationStep, key, val));
 
-    // Form starts with two empty required fields mounted.
-    expect(Object.keys(form().syncErrors)).toEqual(['conversionHostSshKey', 'transformationMethod']);
+    // Form starts with two empty required fields mounted. (with VDDK default selected)
+    expect(Object.keys(form().syncErrors)).toEqual(['conversionHostSshKey', 'vddkLibraryPath']);
 
-    // Filling these in mounts another empty required field (vmwareSshKey).
+    // Filling in conversionHostSshKey and switching to SSH transformation mounts another empty required field (vmwareSshKey).
     changeFormValue('conversionHostSshKey', { filename: '', body: 'foo' });
     changeFormValue('transformationMethod', 'SSH');
-    expect(Object.keys(form().syncErrors)).toEqual(['vmwareSshKey']);
+    expect(Object.keys(form().syncErrors)).toEqual(['vmwareSshKey']); // The vddkLibraryPath that was unmounted is still empty+required, but has no error.
 
     // Filling in vmwareSshKey makes the form pass validation.
     changeFormValue('vmwareSshKey', { filename: '', body: 'foo' });


### PR DESCRIPTION
Closes #1002.

This PR updates the Authentication step of the Conversion Host Wizard so that the Transformation Method field (previously having no default) now defaults to VDDK. This means the VDDK Library Path field will be visible by default when the user first visits the step.

<img width="758" alt="Screenshot 2019-07-24 15 41 28" src="https://user-images.githubusercontent.com/811963/61824874-1aecd200-ae2d-11e9-9fcf-0d8f9d05f9a0.png">

The Transformation Method field also previously had SSH before VDDK in the list, this order has been reversed.

<img width="760" alt="Screenshot 2019-07-24 15 41 21" src="https://user-images.githubusercontent.com/811963/61824895-2809c100-ae2d-11e9-82d5-569bc85b5db2.png">

I also fixed a unit test that broke because the initial mounted/unmounted fields were changed.