### PR TITLE
 Hide Back and Cancel buttons on the last step of Migration wizards

### DIFF
--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/MappingWizard.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/MappingWizard.js
@@ -141,16 +141,12 @@ class MappingWizard extends React.Component {
     return (
       <Wizard
         show={!hideMappingWizard}
-        onClose={() => {
-          hideMappingWizardAction(onFinalStep);
-        }}
+        onClose={hideMappingWizardAction}
         onExited={mappingWizardExitedAction}
         backdrop="static"
       >
         <Wizard.Header
-          onClose={() => {
-            hideMappingWizardAction(onFinalStep);
-          }}
+          onClose={hideMappingWizardAction}
           title={!editingMapping ? __('Create Infrastructure Mapping') : __('Edit Infrastructure Mapping')}
         />
 
@@ -172,24 +168,20 @@ class MappingWizard extends React.Component {
           />
         </Wizard.Body>
         <Wizard.Footer>
-          <Button
-            bsStyle="default"
-            className="btn-cancel"
-            onClick={() => {
-              hideMappingWizardAction(onFinalStep);
-            }}
-            disabled={onFinalStep}
-          >
-            {__('Cancel')}
-          </Button>
-
-          <Button bsStyle="default" onClick={this.prevStep} disabled={onFirstStep || onFinalStep}>
-            <Icon type="fa" name="angle-left" />
-            {__('Back')}
-          </Button>
+          {!onFinalStep && (
+            <React.Fragment>
+              <Button bsStyle="default" className="btn-cancel" onClick={hideMappingWizardAction}>
+                {__('Cancel')}
+              </Button>
+              <Button bsStyle="default" onClick={this.prevStep} disabled={onFirstStep}>
+                <Icon type="fa" name="angle-left" />
+                {__('Back')}
+              </Button>
+            </React.Fragment>
+          )}
           <Button
             bsStyle="primary"
-            onClick={onFinalStep ? () => hideMappingWizardAction(onFinalStep) : this.nextStep}
+            onClick={onFinalStep ? hideMappingWizardAction : this.nextStep}
             disabled={disableNextStep}
           >
             {onFinalStep

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/__tests__/__snapshots__/MappingWizard.test.js.snap
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/__tests__/__snapshots__/MappingWizard.test.js.snap
@@ -5,12 +5,12 @@ exports[`MappingWizard component renders the mapping wizard 1`] = `
   backdrop="static"
   className=""
   dialogClassName=""
-  onClose={[Function]}
+  onClose={[MockFunction]}
   onExited={[MockFunction]}
   show={true}
 >
   <WizardHeader
-    onClose={[Function]}
+    onClose={[MockFunction]}
     title="Create Infrastructure Mapping"
   />
   <WizardBody
@@ -33,31 +33,33 @@ exports[`MappingWizard component renders the mapping wizard 1`] = `
   <WizardFooter
     className=""
   >
-    <Button
-      active={false}
-      block={false}
-      bsClass="btn"
-      bsStyle="default"
-      className="btn-cancel"
-      disabled={false}
-      onClick={[Function]}
-    >
-      Cancel
-    </Button>
-    <Button
-      active={false}
-      block={false}
-      bsClass="btn"
-      bsStyle="default"
-      disabled={true}
-      onClick={[Function]}
-    >
-      <Icon
-        name="angle-left"
-        type="fa"
-      />
-      Back
-    </Button>
+    <React.Fragment>
+      <Button
+        active={false}
+        block={false}
+        bsClass="btn"
+        bsStyle="default"
+        className="btn-cancel"
+        disabled={false}
+        onClick={[MockFunction]}
+      >
+        Cancel
+      </Button>
+      <Button
+        active={false}
+        block={false}
+        bsClass="btn"
+        bsStyle="default"
+        disabled={true}
+        onClick={[Function]}
+      >
+        <Icon
+          name="angle-left"
+          type="fa"
+        />
+        Back
+      </Button>
+    </React.Fragment>
     <Button
       active={false}
       block={false}

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/PlanWizard.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/PlanWizard.js
@@ -250,13 +250,17 @@ class PlanWizard extends React.Component {
         </Wizard.Body>
 
         <Wizard.Footer className="wizard-pf-footer">
-          <Button bsStyle="default" className="btn-cancel" onClick={hidePlanWizardAction} disabled={onFinalStep}>
-            {__('Cancel')}
-          </Button>
-          <Button bsStyle="default" onClick={this.prevStep} disabled={onFirstStep || onFinalStep}>
-            <Icon type="fa" name="angle-left" />
-            {__('Back')}
-          </Button>
+          {!onFinalStep && (
+            <React.Fragment>
+              <Button bsStyle="default" className="btn-cancel" onClick={hidePlanWizardAction}>
+                {__('Cancel')}
+              </Button>
+              <Button bsStyle="default" onClick={this.prevStep} disabled={onFirstStep}>
+                <Icon type="fa" name="angle-left" />
+                {__('Back')}
+              </Button>
+            </React.Fragment>
+          )}
           <Button
             bsStyle="primary"
             onClick={onFinalStep ? hidePlanWizardAction : this.nextStep}

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizard.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizard.js
@@ -103,18 +103,17 @@ class ConversionHostWizard extends React.Component {
           />
         </Wizard.Body>
         <Wizard.Footer className="wizard-pf-footer">
-          <Button
-            bsStyle="default"
-            className="btn-cancel"
-            onClick={hideConversionHostWizardAction}
-            disabled={onFinalStep}
-          >
-            {__('Cancel')}
-          </Button>
-          <Button bsStyle="default" onClick={this.prevStep} disabled={onFirstStep || onFinalStep}>
-            <Icon type="fa" name="angle-left" />
-            {__('Back')}
-          </Button>
+          {!onFinalStep && (
+            <React.Fragment>
+              <Button bsStyle="default" className="btn-cancel" onClick={hideConversionHostWizardAction}>
+                {__('Cancel')}
+              </Button>
+              <Button bsStyle="default" onClick={this.prevStep} disabled={onFirstStep}>
+                <Icon type="fa" name="angle-left" />
+                {__('Back')}
+              </Button>
+            </React.Fragment>
+          )}
           <Button
             bsStyle="primary"
             onClick={onFinalStep ? hideConversionHostWizardAction : this.nextStep}

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/__tests__/__snapshots__/ConversionHostWizard.test.js.snap
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/__tests__/__snapshots__/ConversionHostWizard.test.js.snap
@@ -51,31 +51,33 @@ exports[`conversion host wizard renders correctly 1`] = `
   <WizardFooter
     className="wizard-pf-footer"
   >
-    <Button
-      active={false}
-      block={false}
-      bsClass="btn"
-      bsStyle="default"
-      className="btn-cancel"
-      disabled={false}
-      onClick={[MockFunction]}
-    >
-      Cancel
-    </Button>
-    <Button
-      active={false}
-      block={false}
-      bsClass="btn"
-      bsStyle="default"
-      disabled={true}
-      onClick={[Function]}
-    >
-      <Icon
-        name="angle-left"
-        type="fa"
-      />
-      Back
-    </Button>
+    <React.Fragment>
+      <Button
+        active={false}
+        block={false}
+        bsClass="btn"
+        bsStyle="default"
+        className="btn-cancel"
+        disabled={false}
+        onClick={[MockFunction]}
+      >
+        Cancel
+      </Button>
+      <Button
+        active={false}
+        block={false}
+        bsClass="btn"
+        bsStyle="default"
+        disabled={true}
+        onClick={[Function]}
+      >
+        <Icon
+          name="angle-left"
+          type="fa"
+        />
+        Back
+      </Button>
+    </React.Fragment>
     <Button
       active={false}
       block={false}


### PR DESCRIPTION
Closes #1000 
Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1726844

Since the user cannot go back from the last step of these wizards, the always-disabled Back and Cancel buttons on these steps were confusing. This PR removes those buttons once the user reaches the final step. Now the only button on these steps is "Close".

Note: in the MappingWizard, the `onFinalStep` param was being passed to `hideMappingWizardAction`, which is unnecessary since we removed that action creator's `shouldReloadMappings` param in https://github.com/ManageIQ/manageiq-v2v/commit/a7498a8503a3a419f8cb387ff68873ed97d9b7b6#diff-d178c7aa8d6dab9f5efdf6462b59669aL13. I was confused by that at first, so I cleaned it up while I was touching this code.

# Screens

<img width="903" alt="Screenshot 2019-07-24 16 38 35" src="https://user-images.githubusercontent.com/811963/61827464-9735e400-ae32-11e9-984b-2b7b9c1a2977.png">

<img width="906" alt="Screenshot 2019-07-24 16 38 00" src="https://user-images.githubusercontent.com/811963/61827470-9ac96b00-ae32-11e9-8f88-857ce89c6aac.png">

<img width="912" alt="Screenshot 2019-07-24 16 37 32" src="https://user-images.githubusercontent.com/811963/61827475-9d2bc500-ae32-11e9-88f1-5fb81e73b845.png">

