### PR TITLE
[#1014][BZ#1693994] Fix conversion host name not appearing on plan details after conversion host is deleted

### DIFF
--- a/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
+++ b/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
@@ -49,7 +49,7 @@ class PlanRequestDetailList extends React.Component {
   };
 
   overlayTriggerClick = task => {
-    if (!this.props.conversionHosts[task.id]) {
+    if (!this.props.conversionHosts[task.id] && !task.options.conversion_host_name) {
       this.props.fetchConversionHostAction(this.props.fetchConversionHostUrl, task.id);
     }
 
@@ -278,6 +278,9 @@ class PlanRequestDetailList extends React.Component {
               }
               const label = sprintf(__('%s of %s Migrated'), task.diskSpaceCompletedGb, task.totalDiskSpaceGb);
 
+              const conversionHostName =
+                task.options.conversion_host_name || (conversionHosts[task.id] && conversionHosts[task.id].name);
+
               const popoverContent = (
                 <Popover
                   id={`popover${task.id}${n}`}
@@ -291,7 +294,7 @@ class PlanRequestDetailList extends React.Component {
                     </div>
                     <div>
                       <b>{__('Conversion Host')}: </b>
-                      {conversionHosts[task.id] && conversionHosts[task.id].name}
+                      {conversionHostName}
                     </div>
                     <br />
                     <div>


### PR DESCRIPTION
Closes #1014 
Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1693994

On the Migration Plan Request Details page (reached by clicking on an in-progress or completed migration plan), we have an info-icon-popover next to the Status text which shows, among other things, the name of the conversion host associated with that VM's migration task:

![Screenshot 2019-08-02 15 49 11](https://user-images.githubusercontent.com/811963/62395355-fd5eed00-b53d-11e9-8258-fc0ed54ddf1e.png)

Previously, we were querying the task's `conversion_host` attribute and using the name stored there. However, as reported in https://bugzilla.redhat.com/show_bug.cgi?id=1693994 (https://github.com/ManageIQ/manageiq-v2v/issues/1014), if a user deletes the conversion host and then tries to view this page, the object will no longer be present and the name cannot be shown.

In https://github.com/ManageIQ/manageiq/pull/19075, an additional property was added to store the conversion host's name on the task as `task.options.conversion_host_name`, which will persist if the conversion host is deleted. The popover now uses this value by default if present, and falls back on the old behavior otherwise (for viewing those migration tasks which were created before this backend change).