### PR TITLE
Mapping wizard general step: don't pre-select non-existent provider type

### DIFF
--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardGeneralStep/MappingWizardGeneralStep.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardGeneralStep/MappingWizardGeneralStep.js
@@ -52,6 +52,8 @@ class MappingWizardGeneralStep extends React.Component {
       providers.some(provider => provider.type === option.type)
     );
 
+    const preSelectedValue = availableProviderOptions.map(option => option.id)[0];
+
     return (
       <Form className="form-horizontal">
         <Field
@@ -85,7 +87,7 @@ class MappingWizardGeneralStep extends React.Component {
           options={availableProviderOptions}
           option_key="id"
           option_value="name"
-          pre_selected_value={targetProvider || V2V_TARGET_PROVIDERS[0].id}
+          pre_selected_value={targetProvider || preSelectedValue}
           labelWidth={2}
           controlWidth={9}
           inline_label


### PR DESCRIPTION
1. Have a VMware provider added to your appliance.
2. Add just one OpenStack cloud provider to your appliance. Make sure you don't have any RHEV providers added.
3. Start v2v mapping wizard.

Previously, the general step would always pre-select RHEV provider type, which would in the next wizard step lead to a funny behavior: the cluster selection step would try to render RHEV target clusters, even though there's no RHEV target provider available.

With this fix in place, the dropdown would pre-select either:
1. OpenStack if you have just OpenStack
2. RHEV if you have just RHEV or both RHEV & OpenStack

https://bugzilla.redhat.com/show_bug.cgi?id=1741785