### PR TITLE
Fix task destruction for log download controller

### DIFF
--- a/app/controllers/migration_log_controller.rb
+++ b/app/controllers/migration_log_controller.rb
@@ -18,7 +18,7 @@ class MigrationLogController < ApplicationController
     task_results = task.task_results
     task_status = task.status
     task_message = task.message
-    MiqTask.destroy(task)
+    task.destroy
 
     render :json => {
       :log_contents   => task_results,


### PR DESCRIPTION
Log download fails with the following error in production.log:

```
[----] F, [2019-08-20T03:21:23.368569 #7930:2ad42bd362e0] FATAL -- : Error caught: [ArgumentError] You are passing an instance of ActiveRecord::Base to `find`. Please pass the id of the object by calling `.id`.
/opt/rh/cfme-gemset/gems/activerecord-5.1.7/lib/active_record/relation/finder_methods.rb:451:in `find_one'
/opt/rh/cfme-gemset/gems/activerecord-5.1.7/lib/active_record/relation/finder_methods.rb:440:in `find_with_ids'
/opt/rh/cfme-gemset/gems/activerecord-5.1.7/lib/active_record/relation/finder_methods.rb:66:in `find'
/opt/rh/cfme-gemset/gems/activerecord-5.1.7/lib/active_record/relation.rb:470:in `destroy'
/opt/rh/cfme-gemset/gems/activerecord-5.1.7/lib/active_record/querying.rb:8:in `destroy'
/opt/rh/cfme-gemset/bundler/gems/cfme-v2v-1df94caea651/app/controllers/migration_log_controller.rb:21:in `download_migration_log'
/opt/rh/cfme-gemset/gems/actionpack-5.1.7/lib/action_controller/metal/basic_implicit_render.rb:4:in `send_action'
/opt/rh/cfme-gemset/gems/actionpack-5.1.7/lib/abstract_controller/base.rb:186:in `process_action'
/opt/rh/cfme-gemset/gems/actionpack-5.1.7/lib/action_controller/metal/rendering.rb:30:in `process_action'
/opt/rh/cfme-gemset/gems/actionpack-5.1.7/lib/abstract_controller/callbacks.rb:20:in `block in process_action'
/opt/rh/cfme-gemset/gems/activesupport-5.1.7/lib/active_support/callbacks.rb:131:in `run_callbacks'
/opt/rh/cfme-gemset/gems/actionpack-5.1.7/lib/abstract_controller/callbacks.rb:19:in `process_action'
/opt/rh/cfme-gemset/gems/actionpack-5.1.7/lib/action_controller/metal/rescue.rb:20:in `process_action'
/opt/rh/cfme-gemset/gems/actionpack-5.1.7/lib/action_controller/metal/instrumentation.rb:32:in `block in process_action'
/opt/rh/cfme-gemset/gems/activesupport-5.1.7/lib/active_support/notifications.rb:166:in `block in instrument'
/opt/rh/cfme-gemset/gems/activesupport-5.1.7/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
/opt/rh/cfme-gemset/gems/activesupport-5.1.7/lib/active_support/notifications.rb:166:in `instrument'
/opt/rh/cfme-gemset/gems/actionpack-5.1.7/lib/action_controller/metal/instrumentation.rb:30:in `process_action'
/opt/rh/cfme-gemset/gems/actionpack-5.1.7/lib/action_controller/metal/params_wrapper.rb:252:in `process_action'
/opt/rh/cfme-gemset/gems/activerecord-5.1.7/lib/active_record/railties/controller_runtime.rb:22:in `process_action'
/opt/rh/cfme-gemset/gems/actionpack-5.1.7/lib/abstract_controller/base.rb:124:in `process'
/opt/rh/cfme-gemset/gems/actionview-5.1.7/lib/action_view/rendering.rb:30:in `process'
/opt/rh/cfme-gemset/gems/actionpack-5.1.7/lib/action_controller/metal.rb:189:in `dispatch'
/opt/rh/cfme-gemset/gems/actionpack-5.1.7/lib/action_controller/metal.rb:253:in `dispatch'
/opt/rh/cfme-gemset/gems/actionpack-5.1.7/lib/action_dispatch/routing/route_set.rb:49:in `dispatch'
/opt/rh/cfme-gemset/gems/actionpack-5.1.7/lib/action_dispatch/routing/route_set.rb:31:in `serve'
/opt/rh/cfme-gemset/gems/actionpack-5.1.7/lib/action_dispatch/journey/router.rb:50:in `block in serve'
/opt/rh/cfme-gemset/gems/actionpack-5.1.7/lib/action_dispatch/journey/router.rb:33:in `each'
/opt/rh/cfme-gemset/gems/actionpack-5.1.7/lib/action_dispatch/journey/router.rb:33:in `serve'
/opt/rh/cfme-gemset/gems/actionpack-5.1.7/lib/action_dispatch/routing/route_set.rb:844:in `call'
/opt/rh/cfme-gemset/bundler/gems/cfme-graphql-ef6880aaae05/lib/manageiq/graphql/rest_api_proxy.rb:18:in `call'
/opt/rh/cfme-gemset/gems/secure_headers-3.0.3/lib/secure_headers/middleware.rb:10:in `call'
/var/www/miq/vmdb/lib/request_started_on_middleware.rb:12:in `call'
/opt/rh/cfme-gemset/gems/rack-2.0.7/lib/rack/etag.rb:25:in `call'
/opt/rh/cfme-gemset/gems/rack-2.0.7/lib/rack/conditional_get.rb:25:in `call'
/opt/rh/cfme-gemset/gems/rack-2.0.7/lib/rack/head.rb:12:in `call'
/opt/rh/cfme-gemset/gems/rack-2.0.7/lib/rack/session/abstract/id.rb:232:in `context'
/opt/rh/cfme-gemset/gems/rack-2.0.7/lib/rack/session/abstract/id.rb:226:in `call'
/opt/rh/cfme-gemset/gems/actionpack-5.1.7/lib/action_dispatch/middleware/cookies.rb:613:in `call'
/opt/rh/cfme-gemset/gems/actionpack-5.1.7/lib/action_dispatch/middleware/callbacks.rb:26:in `block in call'
/opt/rh/cfme-gemset/gems/activesupport-5.1.7/lib/active_support/callbacks.rb:97:in `run_callbacks'
/opt/rh/cfme-gemset/gems/actionpack-5.1.7/lib/action_dispatch/middleware/callbacks.rb:24:in `call'
/opt/rh/cfme-gemset/gems/actionpack-5.1.7/lib/action_dispatch/middleware/debug_exceptions.rb:59:in `call'
/opt/rh/cfme-gemset/gems/actionpack-5.1.7/lib/action_dispatch/middleware/show_exceptions.rb:31:in `call'
/opt/rh/cfme-gemset/gems/railties-5.1.7/lib/rails/rack/logger.rb:36:in `call_app'
/opt/rh/cfme-gemset/gems/railties-5.1.7/lib/rails/rack/logger.rb:26:in `call'
/opt/rh/cfme-gemset/gems/actionpack-5.1.7/lib/action_dispatch/middleware/remote_ip.rb:79:in `call'
/opt/rh/cfme-gemset/gems/actionpack-5.1.7/lib/action_dispatch/middleware/request_id.rb:25:in `call'
/opt/rh/cfme-gemset/gems/rack-2.0.7/lib/rack/method_override.rb:22:in `call'
/opt/rh/cfme-gemset/gems/rack-2.0.7/lib/rack/runtime.rb:22:in `call'
/opt/rh/cfme-gemset/gems/activesupport-5.1.7/lib/active_support/cache/strategy/local_cache_middleware.rb:27:in `call'
/opt/rh/cfme-gemset/gems/actionpack-5.1.7/lib/action_dispatch/middleware/executor.rb:12:in `call'
/opt/rh/cfme-gemset/gems/rack-2.0.7/lib/rack/sendfile.rb:111:in `call'
/opt/rh/cfme-gemset/gems/railties-5.1.7/lib/rails/engine.rb:522:in `call'
/usr/share/gems/gems/puma-3.7.1/lib/puma/configuration.rb:232:in `call'
/usr/share/gems/gems/puma-3.7.1/lib/puma/server.rb:578:in `handle_request'
/usr/share/gems/gems/puma-3.7.1/lib/puma/server.rb:415:in `process_client'
/usr/share/gems/gems/puma-3.7.1/lib/puma/server.rb:275:in `block in run'
/usr/share/gems/gems/puma-3.7.1/lib/puma/thread_pool.rb:120:in `block in spawn_thread'
```

It seems that destroying the task by passing it to `MiqTask.destroy` doesn't work anymore.
This PR proposes to use directly `task.destroy` as it doesn't require to use `find` on the class.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1743413