### PR TITLE
Fix error when selecting multiple source clusters in an infrastructure mapping

### DIFF
--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStep.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStep.js
@@ -27,8 +27,8 @@ class MappingWizardDatastoresStep extends React.Component {
       []
     );
 
-    const synchronousSetState = fn => {
-      this.state = { ...this.state, ...fn() };
+    const synchronousSetState = newState => {
+      this.state = { ...this.state, ...newState };
     };
 
     if (sourceClusters.length === 1 || !pristine) {
@@ -89,7 +89,7 @@ class MappingWizardDatastoresStep extends React.Component {
     }
   }
 
-  selectSourceCluster = (sourceClusterId, setState = this.setState) => {
+  selectSourceCluster = (sourceClusterId, synchronousSetState) => {
     // when dropdown selection occurs for source cluster, we go retrieve the datastores for that
     // cluster
     const {
@@ -106,10 +106,16 @@ class MappingWizardDatastoresStep extends React.Component {
 
     const { nodes: sourceClusters, ...targetCluster } = selectedClusterMapping;
 
-    setState(() => ({
+    const newState = {
       selectedCluster: sourceClusters.find(sourceCluster => sourceCluster.id === sourceClusterId),
       selectedClusterMapping
-    }));
+    };
+
+    if (synchronousSetState) {
+      synchronousSetState(newState);
+    } else {
+      this.setState(newState);
+    }
 
     fetchSourceDatastoresAction(fetchStoragesUrls.source, sourceClusterId);
     fetchTargetDatastoresAction(fetchStoragesUrls[targetProvider], targetCluster.id, targetProvider);

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardNetworksStep/MappingWizardNetworksStep.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardNetworksStep/MappingWizardNetworksStep.js
@@ -27,8 +27,8 @@ class MappingWizardNetworksStep extends React.Component {
       []
     );
 
-    const synchronousSetState = fn => {
-      this.state = { ...this.state, ...fn() };
+    const synchronousSetState = newState => {
+      this.state = { ...this.state, ...newState };
     };
 
     if (sourceClusters.length === 1 || !pristine) {
@@ -90,7 +90,7 @@ class MappingWizardNetworksStep extends React.Component {
     }
   }
 
-  selectSourceCluster = (sourceClusterId, setState = this.setState) => {
+  selectSourceCluster = (sourceClusterId, synchronousSetState) => {
     // when dropdown selection occurs for source cluster, we go retrieve the
     // newworks for that cluster
     const {
@@ -108,10 +108,16 @@ class MappingWizardNetworksStep extends React.Component {
 
     const { nodes: sourceClusters, ...targetCluster } = selectedClusterMapping;
 
-    setState(() => ({
+    const newState = {
       selectedCluster: sourceClusters.find(sourceCluster => sourceCluster.id === sourceClusterId),
       selectedClusterMapping
-    }));
+    };
+
+    if (synchronousSetState) {
+      synchronousSetState(newState);
+    } else {
+      this.setState(newState);
+    }
 
     fetchSourceNetworksAction(fetchNetworksUrls.source, sourceClusterId);
     fetchTargetNetworksAction(fetchNetworksUrls[targetProvider], targetCluster.id, targetProvider);


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq-v2v/issues/1032.
Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1677677

The bug was also present on the Networks step of the wizard, which duplicates the problematic code (the more I read through this old mapping wizard code the more I see how rushed it was... we should probably clean up a lot of this code duplication). This PR fixes the bug in both places.

As mentioned in #1032, I'm not sure why this code ever worked and when/why the bug was introduced. I am still investigating which versions of ManageIQ are affected, and would appreciate help with this :)