### PR TITLE
Fix malformed __() gettext calls in mapping wizard

### DIFF
--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardClustersStep/components/ClustersStepForm/ClustersStepForm.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardClustersStep/components/ClustersStepForm/ClustersStepForm.js
@@ -143,9 +143,7 @@ class ClustersStepForm extends React.Component {
     return (
       <div className="dual-pane-mapper-form">
         <p style={{ marginLeft: -40 }}>
-          {__(
-            'Select source cluster(s) and a target cluster and click Add Mapping to add the mapping. Multiple mappings can be added.') // prettier-ignore
-          }
+          {__('Select source cluster(s) and a target cluster and click Add Mapping to add the mapping. Multiple mappings can be added.') /* prettier-ignore */}
         </p>
         <DualPaneMapper
           handleButtonClick={this.addMapping}

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardDatastoresStep/components/DatastoresStepForm/DatastoresStepForm.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardDatastoresStep/components/DatastoresStepForm/DatastoresStepForm.js
@@ -279,9 +279,7 @@ class DatastoresStepForm extends React.Component {
     return (
       <div className={classes}>
         <p style={{ marginLeft: -40 }}>
-          {__(
-            'Select source datastore(s) and a target datastore and click Add Mapping to add the mapping. Multiple mappings can be added.') // prettier-ignore
-          }
+          {__('Select source datastore(s) and a target datastore and click Add Mapping to add the mapping. Multiple mappings can be added.') /* prettier-ignore */}
         </p>
         <DualPaneMapper
           handleButtonClick={this.addDatastoreMapping}

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardNetworksStep/components/NetworksStepForm/NetworksStepForm.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardNetworksStep/components/NetworksStepForm/NetworksStepForm.js
@@ -305,9 +305,7 @@ class NetworksStepForm extends React.Component {
     return (
       <div className={classes}>
         <p style={{ marginLeft: -48 }}>
-          {__(
-            'Select one or more source networks to map to a single target. Select Add Mapping. Multiple mappings can be added.') // prettier-ignore
-          }
+          {__('Select one or more source networks to map to a single target. Select Add Mapping. Multiple mappings can be added.') /* prettier-ignore */}
         </p>
         <DualPaneMapper
           handleButtonClick={this.addNetworkMapping}


### PR DESCRIPTION
Related to https://bugzilla.redhat.com/show_bug.cgi?id=1752555. These strings are not being translated because of the line break within the `__()` calls.

I searched the rest of the repo for other instances of this (`/__\(\n/`, detecting the `__(` followed by a line break) and didn't find any more.