### PR TITLE
Remove dead V2V_EDIT_PLAN_TITLE_SHOW_ALERT V2V_EDIT_PLAN_TITLE_HIDE_ALERT

### DIFF
--- a/app/javascript/react/screens/App/Overview/components/EditPlanNameModal/EditPlanNameReducer.js
+++ b/app/javascript/react/screens/App/Overview/components/EditPlanNameModal/EditPlanNameReducer.js
@@ -1,9 +1,5 @@
 import Immutable from 'seamless-immutable';
-import {
-  V2V_EDIT_PLAN_TITLE_SHOW_ALERT,
-  V2V_EDIT_PLAN_TITLE_HIDE_ALERT,
-  V2V_POST_EDIT_PLAN_NAME
-} from './EditPlanNameConstants';
+import { V2V_POST_EDIT_PLAN_NAME } from './EditPlanNameConstants';
 
 const initialState = Immutable({
   alertText: '',
@@ -14,10 +10,6 @@ const initialState = Immutable({
 
 export default (state = initialState, action) => {
   switch (action.type) {
-    case V2V_EDIT_PLAN_TITLE_SHOW_ALERT:
-      return Immutable.merge(state, action.payload);
-    case V2V_EDIT_PLAN_TITLE_HIDE_ALERT:
-      return state.set('alertText', '');
     case `${V2V_POST_EDIT_PLAN_NAME}_PENDING`:
       return state
         .set('savingPlan', true)


### PR DESCRIPTION
Cc @mturley , @mzazrivec 

Looks like these were introduced in https://github.com/ManageIQ/manageiq-v2v/pull/663,
but the last commit of that PR (https://github.com/ManageIQ/manageiq-v2v/pull/663/commits/1b79249fb96298a501df302fa23db73d1b5b01cb) removes these from all but this one place.

(With new babel, this produces a warning:

    "export 'V2V_EDIT_PLAN_TITLE_HIDE_ALERT' was not found in './EditPlanNameConstants'
    "export 'V2V_EDIT_PLAN_TITLE_SHOW_ALERT' was not found in './EditPlanNameConstants'

)