### PR TITLE
[#1046] Fix logic for determining if a migration task is completed successfully

### DIFF
--- a/app/javascript/react/screens/App/Plan/helpers.js
+++ b/app/javascript/react/screens/App/Plan/helpers.js
@@ -1,7 +1,6 @@
 import numeral from 'numeral';
 
 import {
-  STATUS_MESSAGE_KEYS,
   V2V_MIGRATION_STATUS_MESSAGES,
   V2V_DOWNLOAD_LOG_STATUS_MESSAGES,
   V2V_BACKEND_ERROR_MESSAGES
@@ -21,11 +20,8 @@ const processVMTasks = vmTasks => {
       message: V2V_MIGRATION_STATUS_MESSAGES[task.message] || __('VM migrations stalled'),
       delivered_on: new Date(task.options.delivered_on),
       updated_on: new Date(task.updated_on),
-      completed:
-        task.message === STATUS_MESSAGE_KEYS.VM_TRANSFORMATIONS_COMPLETED ||
-        task.message === STATUS_MESSAGE_KEYS.VM_TRANSFORMATIONS_FAILED ||
-        task.message === STATUS_MESSAGE_KEYS.FAILED ||
-        (!V2V_MIGRATION_STATUS_MESSAGES[task.message] && task.state === 'finished'),
+      completed: task.state === 'finished',
+      completedSuccessfully: taskCompletedSuccessfully(task),
       state: task.state,
       status: task.status,
       options: {},
@@ -74,11 +70,6 @@ const processVMTasks = vmTasks => {
 
     taskDetails.elapsedTime = IsoElapsedTime(new Date(startDateTime), new Date(lastUpdateDateTime));
 
-    if (taskDetails.completed) {
-      taskDetails.completedSuccessfully =
-        (task.options.progress && task.options.progress.current_description === 'Virtual machine migrated') ||
-        (task.options.progress && task.options.progress.current_description === 'Mark source as migrated');
-    }
     if (task.options && task.options.virtv2v_disks && task.options.virtv2v_disks.length) {
       taskDetails.totalDiskSpace = task.options.virtv2v_disks.reduce((a, b) => a + b.size, 0);
       taskDetails.totalDiskSpaceGb = numeral(taskDetails.totalDiskSpace).format('0.00b');


### PR DESCRIPTION
Fix #1046 (related to https://bugzilla.redhat.com/show_bug.cgi?id=1759062).

When we originally developed the plan details page, we wrote a lot of logic based on specific magic strings in the `task.message` property instead of using the more reliable `state` and `status` properties. In the latest version of ManageIQ, some of these task messages have changed, so the logic is failing in this case. This PR switches the logic for the `taskDetails.completedSuccessfully` property to use `state` and `status`, which fixes this icon bug.

The bug can be reproduced using the database dump named `status-message-issues` from [my collection](https://drive.google.com/drive/u/1/folders/1psxWLopcPUFeJCoHcnMiOgF40x2V0h3Q). Specifically, if you look at `/migration#/plan/4`, you can see that the migration was successful (and the plan itself has a green success icon) but the individual VM list item shows an error icon:

<img width="1225" alt="Screenshot 2019-10-10 11 52 35" src="https://user-images.githubusercontent.com/811963/66585661-3c6c7880-eb55-11e9-9522-edc94510f93a.png">

After this fix:

<img width="1229" alt="Screenshot 2019-10-10 11 53 19" src="https://user-images.githubusercontent.com/811963/66585686-47bfa400-eb55-11e9-9dbf-4f54f43434ef.png">
