### PR TITLE
Allow selecting radio button by selecting on its label

### DIFF
--- a/app/javascript/react/screens/App/common/forms/FormField.js
+++ b/app/javascript/react/screens/App/common/forms/FormField.js
@@ -62,7 +62,7 @@ export const FormField = ({
       case 'radio':
         field = options.map(val => (
           <div key={val.id}>
-            <label htmlFor={input.name}>
+            <label>
               <Field name={input.name} component="input" type="radio" value={val.id} />
               {` ${val.name}`}
             </label>


### PR DESCRIPTION
It seems that when the input is nested inside a `<label>` element, we don't need to add `htmlFor`.