### PR TITLE
Add expandable row support to ListViewTable and convert PlanRequestDetailList into a ListViewTable

### DIFF
--- a/app/javascript/react/screens/App/Overview/components/Migrations/MappingNameInfoItem.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MappingNameInfoItem.js
@@ -1,15 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { ListView, Icon } from 'patternfly-react';
+import { Icon } from 'patternfly-react';
+import ListViewTable from '../../../common/ListViewTable/ListViewTable';
 
 const MappingNameInfoItem = ({ plan }) => (
-  <ListView.InfoItem>
+  <ListViewTable.InfoItem>
     {plan.infraMappingName || (
       <React.Fragment>
         <Icon type="pf" name="warning-triangle-o" /> {__('Infrastucture mapping does not exist.')}
       </React.Fragment>
     )}
-  </ListView.InfoItem>
+  </ListViewTable.InfoItem>
 );
 
 MappingNameInfoItem.propTypes = {

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationInProgressListItem.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationInProgressListItem.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Spinner, ListView, Button, Icon, UtilizationBar } from 'patternfly-react';
+import { Spinner, Button, Icon, UtilizationBar } from 'patternfly-react';
 import EllipsisWithTooltip from 'react-ellipsis-with-tooltip';
 
+import ListViewTable from '../../../common/ListViewTable/ListViewTable';
 import TickingIsoElapsedTime from '../../../../../../components/dates/TickingIsoElapsedTime';
 import getPlaybookName from './helpers/getPlaybookName';
 import { MIGRATIONS_FILTERS, TRANSFORMATION_PLAN_REQUESTS_URL } from '../../OverviewConstants';
@@ -46,10 +47,10 @@ const MigrationInProgressListItem = ({
       <InProgressRow
         plan={plan}
         additionalInfo={[
-          <ListView.InfoItem key="initiating">
+          <ListViewTable.InfoItem key="initiating">
             <Spinner size="sm" inline loading />
             {__('Initiating migration. This might take a few minutes.')}
-          </ListView.InfoItem>
+          </ListViewTable.InfoItem>
         ]}
       />
     );
@@ -65,8 +66,7 @@ const MigrationInProgressListItem = ({
       isCancellingPlanRequest
     });
 
-    const onCancelClick = event => {
-      event.stopPropagation();
+    const onCancelClick = () => {
       cancelPlanRequestAction(TRANSFORMATION_PLAN_REQUESTS_URL, mostRecentRequest.id).then(() =>
         fetchTransformationPlansAction({ url: fetchTransformationPlansUrl, archived: false })
       );
@@ -76,12 +76,12 @@ const MigrationInProgressListItem = ({
       <InProgressRow
         plan={plan}
         additionalInfo={[
-          <ListView.InfoItem key="waiting-for-host">
+          <ListViewTable.InfoItem key="waiting-for-host">
             <Spinner size="sm" inline loading />
             <EllipsisWithTooltip style={{ maxWidth: 300 }}>
               {__('Waiting for an available conversion host. You can continue waiting or go to the Migration Settings page to increase the number of migrations per host.') /* prettier-ignore */}
             </EllipsisWithTooltip>
-          </ListView.InfoItem>
+          </ListViewTable.InfoItem>
         ]}
         actions={
           <Button disabled={cancelButtonDisabled} onClick={onCancelClick}>
@@ -104,13 +104,13 @@ const MigrationInProgressListItem = ({
       <InProgressRow
         plan={plan}
         additionalInfo={[
-          <ListView.InfoItem key="denied">
+          <ListViewTable.InfoItem key="denied">
             <Icon type="pf" name="error-circle-o" />
             <EllipsisWithTooltip style={{ maxWidth: 300 }}>
               {__('Unable to migrate VMs because no conversion host was configured at the time of the attempted migration.') /* prettier-ignore */}{' '}
               {__('See the product documentation for information on configuring conversion hosts.')}
             </EllipsisWithTooltip>
-          </ListView.InfoItem>
+          </ListViewTable.InfoItem>
         ]}
         actions={
           <Button disabled={isEditingPlanRequest} onClick={onCancelClick}>
@@ -157,10 +157,10 @@ const MigrationInProgressListItem = ({
       <InProgressRow
         {...baseRowProps}
         additionalInfo={[
-          <ListView.InfoItem key="running-playbook">
+          <ListViewTable.InfoItem key="running-playbook">
             <Spinner size="sm" inline loading />
             {sprintf(__('Running playbook service %s. This might take a few minutes.'), playbookName)}
-          </ListView.InfoItem>
+          </ListViewTable.InfoItem>
         ]}
       />
     );
@@ -170,7 +170,7 @@ const MigrationInProgressListItem = ({
     <InProgressRow
       {...baseRowProps}
       additionalInfo={[
-        <ListView.InfoItem key="migration-progress">
+        <ListViewTable.InfoItem key="migration-progress">
           <div id={`vm-progress-bar-${plan.id}`} className="vm-progress-bar">
             <UtilizationBar
               now={numCompletedVms}
@@ -195,7 +195,7 @@ const MigrationInProgressListItem = ({
               <TickingIsoElapsedTime startTime={mostRecentRequest.created_on} />
             </div>
           </div>
-        </ListView.InfoItem>
+        </ListViewTable.InfoItem>
       ]}
     />
   );

--- a/app/javascript/react/screens/App/Overview/components/Migrations/Migrations.scss
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/Migrations.scss
@@ -44,6 +44,7 @@
 
     .vm-progress-bar {
       width: 100%;
+      min-width: 250px;
       text-align: left;
 
       .progress-description,

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
@@ -212,27 +212,27 @@ const MigrationsCompletedList = ({
                         heading={plan.name}
                         description={plan.description}
                         additionalInfo={[
-                          <ListView.InfoItem className="num-vms-migrated" key={`${plan.id}-migrated`}>
+                          <ListViewTable.InfoItem className="num-vms-migrated" key={`${plan.id}-migrated`}>
                             <ListView.Icon type="pf" size="lg" name="screen" />
                             <strong>{succeedCount}</strong>
                             {__('of')}
                             <strong className="total">{Object.keys(tasks).length} </strong>
                             {__('VMs successfully migrated.')}
-                          </ListView.InfoItem>,
+                          </ListViewTable.InfoItem>,
                           <MappingNameInfoItem key={`${plan.id}-mappingName`} plan={plan} />,
                           !denied ? (
-                            <ListView.InfoItem key={`${plan.id}-elapsed`}>
+                            <ListViewTable.InfoItem key={`${plan.id}-elapsed`}>
                               <ListView.Icon type="fa" size="lg" name="clock-o" />
                               {elapsedTime}
-                            </ListView.InfoItem>
+                            </ListViewTable.InfoItem>
                           ) : null,
                           !denied && !showScheduledTime && mostRecentRequest.fulfilled_on ? (
-                            <ListView.InfoItem key={`${plan.id}-completed`} style={{ textAlign: 'left' }}>
+                            <ListViewTable.InfoItem key={`${plan.id}-completed`} style={{ textAlign: 'left' }}>
                               <Icon type="fa" name="clock-o" />
                               {__('Completed:')}
                               <br />
                               {formatDateTime(mostRecentRequest.fulfilled_on)}
-                            </ListView.InfoItem>
+                            </ListViewTable.InfoItem>
                           ) : null,
                           <ScheduledTimeInfoItem
                             planId={plan.id}

--- a/app/javascript/react/screens/App/Overview/components/Migrations/NumVmsInfoItem.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/NumVmsInfoItem.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { ListView, Icon } from 'patternfly-react';
+import { Icon } from 'patternfly-react';
+import ListViewTable from '../../../common/ListViewTable/ListViewTable';
 
 const NumVmsInfoItem = ({ plan }) => {
   const numVms =
@@ -9,10 +10,10 @@ const NumVmsInfoItem = ({ plan }) => {
     plan.options.config_info.actions &&
     plan.options.config_info.actions.length;
   return (
-    <ListView.InfoItem>
+    <ListViewTable.InfoItem>
       <Icon type="pf" name="virtual-machine" />
       <strong>{numVms}</strong> {__('VMs')}
-    </ListView.InfoItem>
+    </ListViewTable.InfoItem>
   );
 };
 

--- a/app/javascript/react/screens/App/Overview/components/Migrations/ScheduledTimeInfoItem.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/ScheduledTimeInfoItem.js
@@ -1,20 +1,21 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { ListView, Icon } from 'patternfly-react';
+import { Icon } from 'patternfly-react';
 import { formatDateTime } from '../../../../../../components/dates/MomentDate';
+import ListViewTable from '../../../common/ListViewTable/ListViewTable';
 
 const ScheduledTimeInfoItem = ({ planId, migrationStarting, showScheduledTime, migrationScheduled }) =>
   migrationStarting ? (
-    <ListView.InfoItem key={`${planId}-starting`} style={{ textAlign: 'left' }}>
+    <ListViewTable.InfoItem key={`${planId}-starting`} style={{ textAlign: 'left' }}>
       {__('Migration in progress')}
-    </ListView.InfoItem>
+    </ListViewTable.InfoItem>
   ) : showScheduledTime ? (
-    <ListView.InfoItem key={`${planId}-scheduledTime`} style={{ textAlign: 'left' }}>
+    <ListViewTable.InfoItem key={`${planId}-scheduledTime`} style={{ textAlign: 'left' }}>
       <Icon type="fa" name="clock-o" />
       {__('Migration scheduled')}
       <br />
       {formatDateTime(migrationScheduled)}
-    </ListView.InfoItem>
+    </ListViewTable.InfoItem>
   ) : null;
 
 ScheduledTimeInfoItem.propTypes = {

--- a/app/javascript/react/screens/App/Overview/components/Migrations/__test__/__snapshots__/MigrationInProgressListItem.test.js.snap
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/__test__/__snapshots__/MigrationInProgressListItem.test.js.snap
@@ -16,7 +16,7 @@ exports[`if there are no conversion hosts available renders an error view 1`] = 
   }
   additionalInfo={
     Array [
-      <ListViewInfoItem
+      <ListViewTableInfoItem
         className=""
         stacked={false}
       >
@@ -36,7 +36,7 @@ exports[`if there are no conversion hosts available renders an error view 1`] = 
         >
           Waiting for an available conversion host. You can continue waiting or go to the Migration Settings page to increase the number of migrations per host.
         </EllipisWithTooltip>
-      </ListViewInfoItem>,
+      </ListViewTableInfoItem>,
     ]
   }
   numFailedVms={0}
@@ -126,7 +126,7 @@ exports[`when the request is denied renders an error view 1`] = `
   }
   additionalInfo={
     Array [
-      <ListViewInfoItem
+      <ListViewTableInfoItem
         className=""
         stacked={false}
       >
@@ -145,7 +145,7 @@ exports[`when the request is denied renders an error view 1`] = `
            
           See the product documentation for information on configuring conversion hosts.
         </EllipisWithTooltip>
-      </ListViewInfoItem>,
+      </ListViewTableInfoItem>,
     ]
   }
   numFailedVms={0}

--- a/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
+++ b/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
@@ -13,12 +13,15 @@ import {
   Tooltip,
   UtilizationBar,
   DropdownButton,
-  MenuItem
+  MenuItem,
+  Row,
+  Col
 } from 'patternfly-react';
 import { formatDateTime } from '../../../../../../components/dates/MomentDate';
 import { migrationStatusMessage, REQUEST_TASKS_URL } from '../../PlanConstants';
 import TickingIsoElapsedTime from '../../../../../../components/dates/TickingIsoElapsedTime';
 import ConfirmModal from '../../../common/ConfirmModal';
+import ListViewTable from '../../../common/ListViewTable/ListViewTable';
 
 class PlanRequestDetailList extends React.Component {
   state = {
@@ -209,7 +212,7 @@ class PlanRequestDetailList extends React.Component {
           )}
         </Grid.Row>
         <div style={{ overflow: 'auto', paddingBottom: 300, height: '100%' }}>
-          <ListView className="plan-request-details-list">
+          <ListViewTable className="plan-request-details-list">
             {filteredSortedPaginatedListItems.items.map((task, n) => {
               let currentDescription = task.options.progress
                 ? migrationStatusMessage(task.options.progress.current_description)
@@ -307,7 +310,7 @@ class PlanRequestDetailList extends React.Component {
               );
 
               return (
-                <ListView.Item
+                <ListViewTable.Row
                   key={task.id}
                   checkboxInput={
                     <input
@@ -424,10 +427,14 @@ class PlanRequestDetailList extends React.Component {
                     </DropdownButton>
                   }
                   stacked
-                />
+                >
+                  <Row>
+                    <Col sm={11}>TODO: Hey this is the expanded stuff right here</Col>
+                  </Row>
+                </ListViewTable.Row>
               );
             })}
-          </ListView>
+          </ListViewTable>
           {renderPaginationRow(filteredSortedPaginatedListItems)}
         </div>
         <ConfirmModal

--- a/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
+++ b/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
@@ -22,6 +22,7 @@ import { migrationStatusMessage, REQUEST_TASKS_URL } from '../../PlanConstants';
 import TickingIsoElapsedTime from '../../../../../../components/dates/TickingIsoElapsedTime';
 import ConfirmModal from '../../../common/ConfirmModal';
 import ListViewTable from '../../../common/ListViewTable/ListViewTable';
+import StopPropagationOnClick from '../../../common/StopPropagationOnClick';
 
 class PlanRequestDetailList extends React.Component {
   state = {
@@ -325,7 +326,7 @@ class PlanRequestDetailList extends React.Component {
                   leftContent={leftContent}
                   heading={task.vmName}
                   additionalInfo={[
-                    <ListView.InfoItem
+                    <ListViewTable.InfoItem
                       key={`${task.id}-message`}
                       style={{
                         flexDirection: 'column',
@@ -341,17 +342,19 @@ class PlanRequestDetailList extends React.Component {
                         </div>
                         &nbsp;
                         {/* Todo: revisit FieldLevelHelp props in patternfly-react to support this */}
-                        <OverlayTrigger
-                          rootClose
-                          trigger="click"
-                          onEnter={() => this.overlayTriggerClick(task)}
-                          placement="left"
-                          overlay={popoverContent}
-                        >
-                          <Button bsStyle="link">
-                            <Icon type="pf" name="info" />
-                          </Button>
-                        </OverlayTrigger>
+                        <StopPropagationOnClick>
+                          <OverlayTrigger
+                            rootClose
+                            trigger="click"
+                            onEnter={() => this.overlayTriggerClick(task)}
+                            placement="left"
+                            overlay={popoverContent}
+                          >
+                            <Button bsStyle="link">
+                              <Icon type="pf" name="info" />
+                            </Button>
+                          </OverlayTrigger>
+                        </StopPropagationOnClick>
                       </div>
                       <div>
                         <ListView.Icon type="fa" size="lg" name="clock-o" />
@@ -360,8 +363,8 @@ class PlanRequestDetailList extends React.Component {
                           endTime={task.completed ? task.lastUpdateDateTime : null}
                         />
                       </div>
-                    </ListView.InfoItem>,
-                    <ListView.InfoItem key={`${task.id}-times`} style={{ minWidth: 150, paddingRight: 20 }}>
+                    </ListViewTable.InfoItem>,
+                    <ListViewTable.InfoItem key={`${task.id}-times`} style={{ minWidth: 150, paddingRight: 20 }}>
                       <UtilizationBar
                         now={task.percentComplete}
                         min={0}
@@ -380,7 +383,7 @@ class PlanRequestDetailList extends React.Component {
                         )}
                         descriptionPlacementTop
                       />
-                    </ListView.InfoItem>
+                    </ListViewTable.InfoItem>
                   ]}
                   actions={
                     <DropdownButton

--- a/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
+++ b/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
@@ -13,9 +13,7 @@ import {
   Tooltip,
   UtilizationBar,
   DropdownButton,
-  MenuItem,
-  Row,
-  Col
+  MenuItem
 } from 'patternfly-react';
 import EllipsisWithTooltip from 'react-ellipsis-with-tooltip';
 import { formatDateTime } from '../../../../../../components/dates/MomentDate';
@@ -434,9 +432,7 @@ class PlanRequestDetailList extends React.Component {
                   }
                   stacked
                 >
-                  <Row>
-                    <Col sm={11}>TODO: Hey this is the expanded stuff right here</Col>
-                  </Row>
+                  TODO: Expanded content still in development
                 </ListViewTable.Row>
               );
             })}

--- a/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
+++ b/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
@@ -17,6 +17,7 @@ import {
   Row,
   Col
 } from 'patternfly-react';
+import EllipsisWithTooltip from 'react-ellipsis-with-tooltip';
 import { formatDateTime } from '../../../../../../components/dates/MomentDate';
 import { migrationStatusMessage, REQUEST_TASKS_URL } from '../../PlanConstants';
 import TickingIsoElapsedTime from '../../../../../../components/dates/TickingIsoElapsedTime';
@@ -338,7 +339,9 @@ class PlanRequestDetailList extends React.Component {
                       <div>
                         <div style={{ display: 'inline-block', textAlign: 'left' }}>
                           <span>{mainStatusMessage}</span>
-                          <div>{statusDetailMessage}</div>
+                          <div style={{ maxWidth: 250 }}>
+                            <EllipsisWithTooltip>{statusDetailMessage}</EllipsisWithTooltip>
+                          </div>
                         </div>
                         &nbsp;
                         {/* Todo: revisit FieldLevelHelp props in patternfly-react to support this */}

--- a/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
+++ b/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
@@ -431,9 +431,7 @@ class PlanRequestDetailList extends React.Component {
                     </DropdownButton>
                   }
                   stacked
-                >
-                  TODO: Expanded content still in development
-                </ListViewTable.Row>
+                />
               );
             })}
           </ListViewTable>

--- a/app/javascript/react/screens/App/common/ListViewTable/ListViewTable.js
+++ b/app/javascript/react/screens/App/common/ListViewTable/ListViewTable.js
@@ -61,6 +61,10 @@ ListViewTable.propTypes = {
   ...ListView.propTypes
 };
 
+ListViewTable.defaultProps = {
+  ...ListView.defaultProps
+};
+
 ListViewTable.Row = ListViewTableRow;
 
 export default ListViewTable;

--- a/app/javascript/react/screens/App/common/ListViewTable/ListViewTable.js
+++ b/app/javascript/react/screens/App/common/ListViewTable/ListViewTable.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { ListView, layout as pfLayout } from 'patternfly-react';
 import ListViewTableRow from './ListViewTableRow';
+import ListViewTableInfoItem from './ListViewTableInfoItem';
 
 export const ListViewTableContext = React.createContext({});
 
@@ -66,5 +67,6 @@ ListViewTable.defaultProps = {
 };
 
 ListViewTable.Row = ListViewTableRow;
+ListViewTable.InfoItem = ListViewTableInfoItem;
 
 export default ListViewTable;

--- a/app/javascript/react/screens/App/common/ListViewTable/ListViewTable.scss
+++ b/app/javascript/react/screens/App/common/ListViewTable/ListViewTable.scss
@@ -1,8 +1,15 @@
 .list-view-pf.list-view-table-pf > table {
+  $expanded-border: solid 1px #bbb;
+
   width: 100%;
 
   tr.list-group-item {
     display: table-row;
+
+    &:before,
+    &:after {
+      content: none;
+    }
 
     &.clickable {
       cursor: pointer;
@@ -73,6 +80,40 @@
         text-align: right;
         white-space: nowrap;
         margin-left: 0;
+      }
+    }
+
+    &.list-view-pf-expand-active {
+      border: none;
+
+      td {
+        border-top: $expanded-border;
+        border-bottom: $expanded-border;
+
+        &:first-child {
+          border-left: $expanded-border;
+        }
+
+        &:last-child {
+          border-right: $expanded-border;
+        }
+      }
+    }
+  }
+
+  tr.list-group-item-container-row {
+    border: $expanded-border;
+
+    td.list-group-item-container {
+      width: auto;
+      margin: auto;
+      position: static;
+      box-shadow: 0 2px 6px rgba(3, 3, 3, 0.2);
+      clip-path: inset(0px -6px -6px -6px);
+
+      .close {
+        position: static;
+        right: 0;
       }
     }
   }

--- a/app/javascript/react/screens/App/common/ListViewTable/ListViewTable.scss
+++ b/app/javascript/react/screens/App/common/ListViewTable/ListViewTable.scss
@@ -1,10 +1,13 @@
 .list-view-pf.list-view-table-pf > table {
-  $expanded-border: solid 1px #bbb;
+  $normal-border: 1px solid #f5f5f5;
+  $expanded-border: 1px solid #bbb;
 
   width: 100%;
+  border-collapse: separate;
 
   tr.list-group-item {
     display: table-row;
+    border: none;
 
     &:before,
     &:after {
@@ -20,6 +23,7 @@
       width: auto;
       vertical-align: middle;
       padding-left: 15px;
+      border-top: $normal-border;
 
       &:last-child {
         padding-right: 15px;
@@ -85,10 +89,11 @@
 
     &.list-view-pf-expand-active {
       border: none;
+      // This box-shadow is visually equivalent to the top (only) of the normal list view's box-shadow.
+      box-shadow: 0 -2px 2px -2px rgba(3, 3, 3, 0.2);
 
       td {
         border-top: $expanded-border;
-        border-bottom: $expanded-border;
 
         &:first-child {
           border-left: $expanded-border;
@@ -102,13 +107,11 @@
   }
 
   tr.list-group-expanded-container-row {
-    border: $expanded-border;
-
     td.list-group-item-container {
       width: auto;
       margin: auto;
       position: static;
-      clip-path: inset(0px -6px -6px -6px);
+      border: $expanded-border;
 
       > div.expanded-content-flex-container {
         display: flex;
@@ -125,10 +128,16 @@
       }
     }
 
-    + tr:not(.list-view-pf-expand-active) {
-      // this box-shadow is visually equivalent to normal list view's box-shadow on the .list-group-item-container,
-      // but that shadow was overlapping the next expanded row incorrectly.
-      box-shadow: inset 0 8px 6px -6px rgba(3, 3, 3, 0.2);
+    + tr.list-group-item {
+      > td {
+        border-top: none;
+      }
+
+      &:not(.list-view-pf-expand-active) {
+        // This box-shadow is visually equivalent to the bottom (only) of the normal list view's box-shadow
+        // on .list-view-pf-expand-active, but that shadow was overlapping the next expanded row incorrectly.
+        box-shadow: inset 0 8px 6px -6px rgba(3, 3, 3, 0.2);
+      }
     }
   }
 }

--- a/app/javascript/react/screens/App/common/ListViewTable/ListViewTable.scss
+++ b/app/javascript/react/screens/App/common/ListViewTable/ListViewTable.scss
@@ -101,20 +101,34 @@
     }
   }
 
-  tr.list-group-item-container-row {
+  tr.list-group-expanded-container-row {
     border: $expanded-border;
 
     td.list-group-item-container {
       width: auto;
       margin: auto;
       position: static;
-      box-shadow: 0 2px 6px rgba(3, 3, 3, 0.2);
       clip-path: inset(0px -6px -6px -6px);
 
-      .close {
-        position: static;
-        right: 0;
+      > div.expanded-content-flex-container {
+        display: flex;
+        justify-content: space-between;
+
+        > div.expanded-content-children {
+          flex-grow: 1;
+        }
+
+        > .close {
+          position: static;
+          right: 0;
+        }
       }
+    }
+
+    + tr:not(.list-view-pf-expand-active) {
+      // this box-shadow is visually equivalent to normal list view's box-shadow on the .list-group-item-container,
+      // but that shadow was overlapping the next expanded row incorrectly.
+      box-shadow: inset 0 8px 6px -6px rgba(3, 3, 3, 0.2);
     }
   }
 }

--- a/app/javascript/react/screens/App/common/ListViewTable/ListViewTable.scss
+++ b/app/javascript/react/screens/App/common/ListViewTable/ListViewTable.scss
@@ -22,11 +22,26 @@
         padding-left: 0;
       }
 
+      &.list-view-table-checkbox-cell {
+        width: 50px;
+      }
+
       &.list-view-pf-left {
         width: 60px;
 
+        .spinner.spinner-md,
         .spinner.spinner-lg {
           margin-left: 20px;
+        }
+
+        &.adjacent-to-checkbox-cell {
+          width: 30px;
+          padding-left: 0;
+
+          .spinner.spinner-md,
+          .spinner.spinner-lg {
+            margin-left: 0;
+          }
         }
       }
 

--- a/app/javascript/react/screens/App/common/ListViewTable/ListViewTable.scss
+++ b/app/javascript/react/screens/App/common/ListViewTable/ListViewTable.scss
@@ -22,10 +22,6 @@
         padding-left: 0;
       }
 
-      &.list-view-table-checkbox-cell {
-        width: 50px;
-      }
-
       &.list-view-pf-left {
         width: 60px;
 
@@ -34,14 +30,22 @@
           margin-left: 20px;
         }
 
-        &.adjacent-to-checkbox-cell {
-          width: 30px;
-          padding-left: 0;
-
+        &.contains-extra-left-content {
           .spinner.spinner-md,
           .spinner.spinner-lg {
             margin-left: 0;
+            margin-top: 20px;
+            margin-bottom: 20px;
           }
+        }
+      }
+
+      .list-view-table-flex {
+        display: flex;
+        align-items: center;
+
+        & > div {
+          float: none;
         }
       }
 

--- a/app/javascript/react/screens/App/common/ListViewTable/ListViewTableInfoItem.js
+++ b/app/javascript/react/screens/App/common/ListViewTable/ListViewTableInfoItem.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { ListView, noop } from 'patternfly-react';
+
+// By default, ListView.InfoItem calls stopPropagation on its onClick handler.
+// When these info items are taking up entire table columns, we need to override this behavior.
+// This component simply renders ListView.InfoItem without its default onClick.
+// If a child needs to handle a click without clicking the row, that child must call stopPropagation itself.
+
+const ListViewTableInfoItem = props => <ListView.InfoItem onClick={noop} {...props} />;
+
+ListViewTableInfoItem.propTypes = {
+  ...ListView.InfoItem.propTypes
+};
+
+ListViewTableInfoItem.defaultProps = {
+  ...ListView.InfoItem.defaultProps
+};
+
+export default ListViewTableInfoItem;

--- a/app/javascript/react/screens/App/common/ListViewTable/ListViewTableRow.js
+++ b/app/javascript/react/screens/App/common/ListViewTable/ListViewTableRow.js
@@ -53,7 +53,7 @@ const BaseListViewTableRow = ({
       e.target.tagName !== 'INPUT' &&
       !e.target.classList.contains('fa-ellipsis-v')
     ) {
-      console.log('toggle!');
+      console.log('TOGGLE!');
       toggleExpanded();
     }
   };
@@ -95,24 +95,26 @@ const BaseListViewTableRow = ({
     </tr>
   );
 
-  if (expandable) {
+  if (expandable && expanded) {
     const numColumns = row.props.children.filter(child => !!child).length;
 
     return (
       <React.Fragment>
         {row /* TODO with ListViewExpand in leftContent? */}
-        <tr colSpan={numColumns} className="list-group-item-container container-fluid">
-          {hideCloseIcon ? (
-            children
-          ) : (
-            // TODO replace inline styles with CSS
-            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-              <div style={{ flexGrow: 1 }}>{children}</div>
-              <div className="close">
-                <Icon type="pf" name="close" onClick={toggleExpanded} />
+        <tr className="list-group-item-container container-fluid">
+          <td colSpan={numColumns}>
+            {hideCloseIcon ? (
+              children
+            ) : (
+              // TODO replace inline styles with CSS
+              <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                <div style={{ flexGrow: 1 }}>{children}</div>
+                <div className="close">
+                  <Icon type="pf" name="close" onClick={toggleExpanded} />
+                </div>
               </div>
-            </div>
-          )}
+            )}
+          </td>
         </tr>
       </React.Fragment>
     );

--- a/app/javascript/react/screens/App/common/ListViewTable/ListViewTableRow.js
+++ b/app/javascript/react/screens/App/common/ListViewTable/ListViewTableRow.js
@@ -28,9 +28,7 @@ const BaseListViewTableRow = ({
   // TODO Look at ListViewItem, what do the `list-group-item-header` and `list-group-item-container` CSS classes do?
 
   // TODO do we need multiple <tbody> elements to achieve these styles? how does that work for a non-expandable list?
-  //      is it acceptable to just have every row in a tbody no matter what? would match the original ListViewGroupItem...s
-
-  // TODO add the expand chevron thing .list-view-pf-expand, ListViewExpand?
+  //      is it acceptable to just have every row in a tbody no matter what? would match the original ListViewGroupItem...
 
   if (compoundExpand) {
     // eslint-disable-next-line no-console
@@ -68,18 +66,17 @@ const BaseListViewTableRow = ({
       onClick={expandable ? handleExpandClick : noop}
       {...props}
     >
-      {checkboxInput && (
-        <td className="list-view-table-checkbox-cell">
-          <ListView.Checkbox>{checkboxInput}</ListView.Checkbox>
-        </td>
-      )}
-      {leftContent && (
+      {(expandable || checkboxInput || leftContent) && (
         <td
           className={classNames('list-view-pf-left', 'list-view-pf-main-info', {
-            'adjacent-to-checkbox-cell': !!checkboxInput
+            'contains-extra-left-content': expandable || checkboxInput
           })}
         >
-          {leftContent}
+          <div className="list-view-table-flex">
+            {expandable && <ListView.Expand expanded={expanded} toggleExpanded={toggleExpanded} />}
+            {checkboxInput && <ListView.Checkbox>{checkboxInput}</ListView.Checkbox>}
+            {leftContent}
+          </div>
         </td>
       )}
       {(heading || description) && (

--- a/app/javascript/react/screens/App/common/ListViewTable/ListViewTableRow.js
+++ b/app/javascript/react/screens/App/common/ListViewTable/ListViewTableRow.js
@@ -55,18 +55,21 @@ const BaseListViewTableRow = ({
     }
   };
 
+  const hasLeftContentCell = expandable || checkboxInput || leftContent;
+  const hasHeadingCell = heading || description;
+
   const row = (
     <tr
       className={classNames(className, {
         'list-group-item': true,
         'list-view-pf-stacked': stacked,
-        'list-group-item-header': expandable, // TODO ??? maybe this needs to be on a wrapping <tbody> instead
+        'list-group-item-header': expandable,
         'list-view-pf-expand-active': expanded
       })}
       onClick={expandable ? handleExpandClick : noop}
       {...props}
     >
-      {(expandable || checkboxInput || leftContent) && (
+      {hasLeftContentCell && (
         <td
           className={classNames('list-view-pf-left', 'list-view-pf-main-info', {
             'contains-extra-left-content': expandable || checkboxInput
@@ -79,7 +82,7 @@ const BaseListViewTableRow = ({
           </div>
         </td>
       )}
-      {(heading || description) && (
+      {hasHeadingCell && (
         <td className="list-view-pf-main-info">
           <ListView.Description>
             {heading && <ListView.DescriptionHeading>{heading}</ListView.DescriptionHeading>}
@@ -107,13 +110,17 @@ const BaseListViewTableRow = ({
   );
 
   if (expandable && expanded) {
-    const numColumns = row.props.children.filter(child => !!child).length;
+    const numColumns =
+      (hasLeftContentCell ? 1 : 0) +
+      (hasHeadingCell ? 1 : 0) +
+      (additionalInfo ? additionalInfo.length : 0) +
+      (actions ? 1 : 0);
 
     return (
       <React.Fragment>
-        {row /* TODO with ListViewExpand in leftContent? */}
-        <tr className="list-group-item-container container-fluid">
-          <td colSpan={numColumns}>
+        {row}
+        <tr className="list-group-item-container-row">
+          <td colSpan={numColumns} className="list-group-item-container">
             {hideCloseIcon ? (
               children
             ) : (

--- a/app/javascript/react/screens/App/common/ListViewTable/ListViewTableRow.js
+++ b/app/javascript/react/screens/App/common/ListViewTable/ListViewTableRow.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { ListView, Icon } from 'patternfly-react';
+import { ListView, Icon, noop } from 'patternfly-react';
 import { ListViewTableContext } from './ListViewTable';
+import StopPropagationOnClick from '../StopPropagationOnClick';
 
 // TODO implement expandable support
 
@@ -43,9 +44,9 @@ const BaseListViewTableRow = ({
 
   const expandable = !!children;
 
-  const handleClick = e => {
-    console.log('CLICK!');
+  const handleExpandClick = e => {
     // ignore selected child elements click
+    // (this is copied from patternfly-react's ListViewGroupItemHeader)
     if (
       expandable &&
       e.target.tagName !== 'BUTTON' &&
@@ -53,7 +54,6 @@ const BaseListViewTableRow = ({
       e.target.tagName !== 'INPUT' &&
       !e.target.classList.contains('fa-ellipsis-v')
     ) {
-      console.log('TOGGLE!');
       toggleExpanded();
     }
   };
@@ -66,7 +66,7 @@ const BaseListViewTableRow = ({
         'list-group-item-header': expandable, // TODO ??? maybe this needs to be on a wrapping <tbody> instead
         'list-view-pf-expand-active': expanded
       })}
-      onClick={handleClick}
+      onClick={expandable ? handleExpandClick : noop}
       {...props}
     >
       {leftContent && <td className="list-view-pf-left list-view-pf-main-info">{leftContent}</td>}
@@ -89,7 +89,9 @@ const BaseListViewTableRow = ({
         ))}
       {actions && (
         <td>
-          <ListView.Actions>{actions}</ListView.Actions>
+          <ListView.Actions>
+            <StopPropagationOnClick>{actions}</StopPropagationOnClick>
+          </ListView.Actions>
         </td>
       )}
     </tr>

--- a/app/javascript/react/screens/App/common/ListViewTable/ListViewTableRow.js
+++ b/app/javascript/react/screens/App/common/ListViewTable/ListViewTableRow.js
@@ -32,7 +32,6 @@ const BaseListViewTableRow = ({
 
   // TODO add the expand chevron thing .list-view-pf-expand, ListViewExpand?
 
-  console.log('TODO: handle checkbox input!', checkboxInput); // eslint-disable-line no-console
   if (compoundExpand) {
     // eslint-disable-next-line no-console
     console.warn('ListViewTable does not currently support the compoundExpand props.', {
@@ -69,7 +68,20 @@ const BaseListViewTableRow = ({
       onClick={expandable ? handleExpandClick : noop}
       {...props}
     >
-      {leftContent && <td className="list-view-pf-left list-view-pf-main-info">{leftContent}</td>}
+      {checkboxInput && (
+        <td className="list-view-table-checkbox-cell">
+          <ListView.Checkbox>{checkboxInput}</ListView.Checkbox>
+        </td>
+      )}
+      {leftContent && (
+        <td
+          className={classNames('list-view-pf-left', 'list-view-pf-main-info', {
+            'adjacent-to-checkbox-cell': !!checkboxInput
+          })}
+        >
+          {leftContent}
+        </td>
+      )}
       {(heading || description) && (
         <td className="list-view-pf-main-info">
           <ListView.Description>

--- a/app/javascript/react/screens/App/common/ListViewTable/ListViewTableRow.js
+++ b/app/javascript/react/screens/App/common/ListViewTable/ListViewTableRow.js
@@ -119,14 +119,13 @@ const BaseListViewTableRow = ({
     return (
       <React.Fragment>
         {row}
-        <tr className="list-group-item-container-row">
+        <tr className="list-group-expanded-container-row">
           <td colSpan={numColumns} className="list-group-item-container">
             {hideCloseIcon ? (
               children
             ) : (
-              // TODO replace inline styles with CSS
-              <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-                <div style={{ flexGrow: 1 }}>{children}</div>
+              <div className="expanded-content-flex-container">
+                <div className="expanded-content-children">{children}</div>
                 <div className="close">
                   <Icon type="pf" name="close" onClick={toggleExpanded} />
                 </div>

--- a/app/javascript/react/screens/App/common/ListViewTable/ListViewTableRow.js
+++ b/app/javascript/react/screens/App/common/ListViewTable/ListViewTableRow.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { ListView } from 'patternfly-react';
 import { ListViewTableContext } from './ListViewTable';
@@ -13,12 +14,20 @@ const BaseListViewTableRow = ({
   description,
   additionalInfo,
   actions,
+  children,
+  expanded,
+  toggleExpanded,
   ...props
 }) => {
+  // TODO Look at ListViewItem, what do the `list-group-item-header` and `list-group-item-container` CSS classes do?
+
+  // TODO add the expand chevron thing .list-view-pf-expand, compare with original ListViewItem
+  // TODO call toggleExpanded on click, where?
   const row = (
     <tr
       className={classNames(className, 'list-group-item', {
-        'list-view-pf-stacked': stacked
+        'list-view-pf-stacked': stacked,
+        'list-view-pf-expand-active': expanded
       })}
       {...props}
     >
@@ -53,17 +62,59 @@ const BaseListViewTableRow = ({
 };
 
 BaseListViewTableRow.propTypes = {
+  ...ListView.Item.propTypes,
+  expanded: PropTypes.bool.isRequired,
+  toggleExpanded: PropTypes.func.isRequired
+};
+
+BaseListViewTableRow.defaultProps = {
+  ...ListView.Item.defaultProps
+};
+
+class ListViewTableRow extends React.Component {
+  state = { expanded: this.props.initExpanded };
+  toggleExpanded = () => {
+    const { onExpand, onExpandClose } = this.props;
+    if (this.state.expanded) {
+      onExpandClose();
+    } else {
+      onExpand();
+    }
+    this.setState(prevState => ({ expanded: !prevState.expanded }));
+  };
+
+  render() {
+    const {
+      props,
+      state: { expanded },
+      toggleExpanded
+    } = this;
+
+    return (
+      <ListViewTableContext.Consumer>
+        {({ isSmallViewport }) =>
+          isSmallViewport ? (
+            <ListView.Item
+              {...props}
+              initExpanded={expanded}
+              onExpand={toggleExpanded}
+              onExpandClose={toggleExpanded}
+            />
+          ) : (
+            <BaseListViewTableRow {...props} expanded={expanded} toggleExpanded={toggleExpanded} />
+          )
+        }
+      </ListViewTableContext.Consumer>
+    );
+  }
+}
+
+ListViewTableRow.propTypes = {
   ...ListView.Item.propTypes
 };
 
-const ListViewTableRow = props => (
-  <ListViewTableContext.Consumer>
-    {({ isSmallViewport }) => (isSmallViewport ? <ListView.Item {...props} /> : <BaseListViewTableRow {...props} />)}
-  </ListViewTableContext.Consumer>
-);
-
-ListViewTableRow.propTypes = {
-  ...BaseListViewTableRow.propTypes
+ListViewTableRow.defaultProps = {
+  ...ListView.Item.defaultProps
 };
 
 export default ListViewTableRow;

--- a/app/javascript/react/screens/App/common/ListViewTable/ListViewTableRow.js
+++ b/app/javascript/react/screens/App/common/ListViewTable/ListViewTableRow.js
@@ -25,11 +25,6 @@ const BaseListViewTableRow = ({
   onCloseCompoundExpand,
   ...props
 }) => {
-  // TODO Look at ListViewItem, what do the `list-group-item-header` and `list-group-item-container` CSS classes do?
-
-  // TODO do we need multiple <tbody> elements to achieve these styles? how does that work for a non-expandable list?
-  //      is it acceptable to just have every row in a tbody no matter what? would match the original ListViewGroupItem...
-
   if (compoundExpand) {
     // eslint-disable-next-line no-console
     console.warn('ListViewTable does not currently support the compoundExpand props.', {


### PR DESCRIPTION
Part of preparations for Warm Migration.

This PR enhances the ListViewTable component to handle more of the props handled by the original ListView, namely `children` and `checkboxInput`. It also converts the PlanRequestDetailList to use a ListViewTable (fixing column layout issues in that view). If the `ListViewTableRow`s in this view are given `children`, they will become expandable and the children will be rendered in the expanded content area.

Because the warm-migration-specific expanded content for these rows is still in development, this PR's last commit removes the placeholder `children`, disabling the expandable rows. To test the expandable row functionality, you can revert the last commit (https://github.com/ManageIQ/manageiq-v2v/pull/1057/commits/63fd1ea343caec5ee3b634b04c77c07cc4f90b8c).

Note that some funky CSS overrides were necessary to preserve expanded row styles, and we'll probably want to revisit the CSS later on with some other UXD team members. This part took me way too damn long.

# Screens

Plan details view after this PR (only visible change is the fixed column alignment):
<img width="1437" alt="Screenshot 2019-10-25 15 08 31" src="https://user-images.githubusercontent.com/811963/67599290-bdbf3000-f73d-11e9-85c6-2277835b3bd5.png">

Plan details view with https://github.com/ManageIQ/manageiq-v2v/pull/1057/commits/63fd1ea343caec5ee3b634b04c77c07cc4f90b8c reverted to enable expandable content:
<img width="1436" alt="Screenshot 2019-10-25 15 07 06" src="https://user-images.githubusercontent.com/811963/67599347-da5b6800-f73d-11e9-8260-3f1154129d54.png">
