### PR TITLE
[BZ#1755842] Expose transformation method in the conversion hosts list

### DIFF
--- a/app/javascript/react/screens/App/Settings/__tests__/helpers.test.js
+++ b/app/javascript/react/screens/App/Settings/__tests__/helpers.test.js
@@ -95,6 +95,36 @@ describe('conversion host list item filtering and metadata', () => {
   });
 });
 
+describe('transport method helper'), () => {
+  describe('for an enablement task', () => {
+    it('detects VDDK properly', () => {
+      /// TODO
+    });
+    
+    it('detects SSH properly', () => {
+      /// TODO
+    });
+
+    it('returns null if neither match', () => {
+      /// TODO
+    });
+  });
+
+  describe('for a conversion host', () => {
+    it('detects VDDK properly', () => {
+      /// TODO
+    });
+    
+    it('detects SSH properly', () => {
+      /// TODO
+    });
+
+    it('returns null if neither match', () => {
+      /// TODO
+    });
+  });
+});
+
 describe('conversion host log file helper', () => {
   it('generates a file from an enable task', () => {
     const task = {

--- a/app/javascript/react/screens/App/Settings/__tests__/helpers.test.js
+++ b/app/javascript/react/screens/App/Settings/__tests__/helpers.test.js
@@ -5,7 +5,8 @@ import {
   attachTasksToConversionHosts,
   getCombinedConversionHostListItems,
   getConversionHostTaskLogFile,
-  getConversionHostSshKeyInfoMessage
+  getConversionHostSshKeyInfoMessage,
+  inferTransportMethod
 } from '../helpers';
 
 import {
@@ -95,32 +96,65 @@ describe('conversion host list item filtering and metadata', () => {
   });
 });
 
-describe('transport method helper'), () => {
+describe('transport method helper', () => {
   describe('for an enablement task', () => {
     it('detects VDDK properly', () => {
-      /// TODO
+      const task = {
+        meta: { isTask: true },
+        context_data: {
+          request_params: {
+            vmware_vddk_package_url: 'foo'
+          }
+        }
+      };
+      expect(inferTransportMethod(task)).toEqual(__('VDDK'));
     });
-    
+
     it('detects SSH properly', () => {
-      /// TODO
+      const task = {
+        meta: { isTask: true },
+        context_data: {
+          request_params: {
+            vmware_ssh_private_key: 'foo'
+          }
+        }
+      };
+      expect(inferTransportMethod(task)).toEqual(__('SSH'));
     });
 
     it('returns null if neither match', () => {
-      /// TODO
+      const task = {
+        meta: { isTask: true },
+        context_data: {
+          request_params: {}
+        }
+      };
+      expect(inferTransportMethod(task)).toEqual(null);
     });
   });
 
   describe('for a conversion host', () => {
     it('detects VDDK properly', () => {
-      /// TODO
+      const host = {
+        meta: { isTask: false },
+        vddk_transport_supported: true
+      };
+      expect(inferTransportMethod(host)).toEqual(__('VDDK'));
     });
-    
+
     it('detects SSH properly', () => {
-      /// TODO
+      const host = {
+        meta: { isTask: false },
+        ssh_transport_supported: true
+      };
+      expect(inferTransportMethod(host)).toEqual(__('SSH'));
     });
 
     it('returns null if neither match', () => {
-      /// TODO
+      const host = {
+        meta: { isTask: false }
+      };
+      expect(inferTransportMethod(host)).toEqual(null);
     });
   });
 });

--- a/app/javascript/react/screens/App/Settings/helpers.js
+++ b/app/javascript/react/screens/App/Settings/helpers.js
@@ -92,6 +92,20 @@ export const getCombinedConversionHostListItems = (conversionHosts, tasksWithMet
   return [...activeEnableTasks, ...conversionHostsWithTasks];
 };
 
+export const inferTransportMethod = conversionHostsListItem => {
+  const vddk = __('VDDK');
+  const ssh = __('SSH');
+  if (conversionHostsListItem.meta.isTask) {
+    const { request_params } = conversionHostsListItem.context_data;
+    if (request_params.vmware_vddk_package_url) return vddk;
+    if (request_params.vmware_ssh_private_key) return ssh;
+  } else {
+    if (conversionHostsListItem.vddk_transport_supported) return vddk;
+    if (conversionHostsListItem.ssh_transport_supported) return ssh;
+  }
+  return null;
+};
+
 export const getConversionHostTaskLogFile = task => {
   const {
     meta: { resourceName, operation },

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostsListItem.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostsListItem.js
@@ -6,7 +6,7 @@ import ConversionHostRemoveButton from './ConversionHostRemoveButton';
 import ConversionHostRetryButton from './ConversionHostRetryButton';
 import StopPropagationOnClick from '../../../../common/StopPropagationOnClick';
 import { FINISHED, ERROR, ENABLE, DISABLE } from '../ConversionHostsSettingsConstants';
-import { getConversionHostTaskLogFile } from '../../../helpers';
+import { getConversionHostTaskLogFile, inferTransportMethod } from '../../../helpers';
 
 const removeFailedTaskSupported = false; // TODO remove me when the Remove button works
 
@@ -52,6 +52,8 @@ const ConversionHostsListItem = ({
       placement="top"
       overlay={
         <Popover id="task-info-popover" style={{ width: 400 }}>
+          <strong>{__('Transport method:')}</strong> {inferTransportMethod(listItem)}
+          <br />
           {mostRecentTask ? (
             <React.Fragment>
               <strong>{__('State:')}</strong> {mostRecentTask.state}

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostsListItem.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostsListItem.js
@@ -45,15 +45,21 @@ const ConversionHostsListItem = ({
     statusMessage = __('Configured');
   }
 
-  const taskInfoPopover = (
+  const transportMethod = inferTransportMethod(listItem);
+
+  const infoPopover = (
     <OverlayTrigger
       rootClose
       trigger="click"
       placement="top"
       overlay={
         <Popover id="task-info-popover" style={{ width: 400 }}>
-          <strong>{__('Transport method:')}</strong> {inferTransportMethod(listItem)}
-          <br />
+          {transportMethod && (
+            <React.Fragment>
+              <strong>{__('Transformation method:')}</strong> {transportMethod}
+              <br />
+            </React.Fragment>
+          )}
           {mostRecentTask ? (
             <React.Fragment>
               <strong>{__('State:')}</strong> {mostRecentTask.state}
@@ -125,7 +131,7 @@ const ConversionHostsListItem = ({
         <ListView.InfoItem key="task-status">
           {statusIcon}
           {statusMessage}
-          {taskInfoPopover}
+          {infoPopover}
         </ListView.InfoItem>
       ]}
       stacked

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostsListItem.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostsListItem.js
@@ -45,21 +45,13 @@ const ConversionHostsListItem = ({
     statusMessage = __('Configured');
   }
 
-  const transportMethod = inferTransportMethod(listItem);
-
-  const infoPopover = (
+  const taskInfoPopover = (
     <OverlayTrigger
       rootClose
       trigger="click"
       placement="top"
       overlay={
         <Popover id="task-info-popover" style={{ width: 400 }}>
-          {transportMethod && (
-            <React.Fragment>
-              <strong>{__('Transformation method:')}</strong> {transportMethod}
-              <br />
-            </React.Fragment>
-          )}
           {mostRecentTask ? (
             <React.Fragment>
               <strong>{__('State:')}</strong> {mostRecentTask.state}
@@ -128,10 +120,11 @@ const ConversionHostsListItem = ({
     <ListView.Item
       heading={listItem.name}
       additionalInfo={[
+        <ListView.InfoItem key="transport-method">{inferTransportMethod(listItem)}</ListView.InfoItem>,
         <ListView.InfoItem key="task-status">
           {statusIcon}
           {statusMessage}
-          {infoPopover}
+          {taskInfoPopover}
         </ListView.InfoItem>
       ]}
       stacked

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/__tests__/ConversionHostsListItem.test.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/__tests__/ConversionHostsListItem.test.js
@@ -9,6 +9,7 @@ import ConversionHostRetryButton from '../ConversionHostRetryButton';
 const conversionHostEnabled = {
   name: 'Conversion Host 1',
   id: '1',
+  vddk_transport_supported: true,
   meta: {
     tasksByOperation: {
       enable: [
@@ -35,6 +36,7 @@ const conversionHostEnabled = {
 const conversionHostDisabling = {
   name: 'Conversion Host 1',
   id: '1',
+  vddk_transport_supported: true,
   meta: {
     tasksByOperation: {
       enable: [
@@ -63,17 +65,22 @@ const conversionHostDisabling = {
     }
   }
 };
-const enableTaskInProgress = { id: '1', meta: { isTask: true, operation: 'enable' }, ...inProgress };
+const enableTaskInProgress = {
+  id: '1',
+  meta: { isTask: true, operation: 'enable' },
+  context_data: { request_params: { vmware_vddk_package_url: 'foo' } },
+  ...inProgress
+};
 const enableTaskFailed = {
   id: '1',
   meta: { isTask: true, operation: 'enable' },
-  context_data: { request_params: { mock: 'params' } },
+  context_data: { request_params: { vmware_vddk_package_url: 'foo' } },
   ...failed
 };
 const disableTaskFailed = {
   id: '1',
   meta: { isTask: true, operation: 'disable' },
-  context_data: { request_params: { mock: 'params' } },
+  context_data: { request_params: { vmware_vddk_package_url: 'foo' } },
   ...failed
 };
 

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/__tests__/__snapshots__/ConversionHostsListItem.test.js.snap
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/__tests__/__snapshots__/ConversionHostsListItem.test.js.snap
@@ -58,6 +58,7 @@ exports[`conversion hosts list item renders correctly with a conversion host bei
               },
             },
             "name": "Conversion Host 1",
+            "vddk_transport_supported": true,
           }
         }
         setHostToDeleteAction={[MockFunction]}
@@ -111,6 +112,14 @@ exports[`conversion hosts list item renders correctly with a conversion host bei
                 }
               }
             >
+              <UNDEFINED>
+                <strong>
+                  Transformation method:
+                </strong>
+                 
+                VDDK
+                <br />
+              </UNDEFINED>
               <UNDEFINED>
                 <strong>
                   State:
@@ -175,7 +184,7 @@ exports[`conversion hosts list item renders correctly with a failed disable task
             Object {
               "context_data": Object {
                 "request_params": Object {
-                  "mock": "params",
+                  "vmware_vddk_package_url": "foo",
                 },
               },
               "id": "1",
@@ -237,6 +246,14 @@ exports[`conversion hosts list item renders correctly with a failed disable task
                 }
               }
             >
+              <UNDEFINED>
+                <strong>
+                  Transformation method:
+                </strong>
+                 
+                VDDK
+                <br />
+              </UNDEFINED>
               <UNDEFINED>
                 <strong>
                   State:
@@ -301,7 +318,7 @@ exports[`conversion hosts list item renders correctly with a failed enable task 
             Object {
               "context_data": Object {
                 "request_params": Object {
-                  "mock": "params",
+                  "vmware_vddk_package_url": "foo",
                 },
               },
               "id": "1",
@@ -363,6 +380,14 @@ exports[`conversion hosts list item renders correctly with a failed enable task 
                 }
               }
             >
+              <UNDEFINED>
+                <strong>
+                  Transformation method:
+                </strong>
+                 
+                VDDK
+                <br />
+              </UNDEFINED>
               <UNDEFINED>
                 <strong>
                   State:
@@ -542,6 +567,7 @@ exports[`conversion hosts list item renders correctly with an enabled conversion
               },
             },
             "name": "Conversion Host 1",
+            "vddk_transport_supported": true,
           }
         }
         setHostToDeleteAction={[MockFunction]}
@@ -594,6 +620,14 @@ exports[`conversion hosts list item renders correctly with an enabled conversion
                 }
               }
             >
+              <UNDEFINED>
+                <strong>
+                  Transformation method:
+                </strong>
+                 
+                VDDK
+                <br />
+              </UNDEFINED>
               <UNDEFINED>
                 <strong>
                   State:
@@ -708,6 +742,14 @@ exports[`conversion hosts list item renders correctly with an in-progress enable
                 }
               }
             >
+              <UNDEFINED>
+                <strong>
+                  Transformation method:
+                </strong>
+                 
+                VDDK
+                <br />
+              </UNDEFINED>
               <UNDEFINED>
                 <strong>
                   State:

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/__tests__/__snapshots__/ConversionHostsListItem.test.js.snap
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/__tests__/__snapshots__/ConversionHostsListItem.test.js.snap
@@ -91,6 +91,12 @@ exports[`conversion hosts list item renders correctly with a conversion host bei
         className=""
         stacked={false}
       >
+        VDDK
+      </ListViewInfoItem>,
+      <ListViewInfoItem
+        className=""
+        stacked={false}
+      >
         <Spinner
           className=""
           inline={true}
@@ -112,14 +118,6 @@ exports[`conversion hosts list item renders correctly with a conversion host bei
                 }
               }
             >
-              <UNDEFINED>
-                <strong>
-                  Transformation method:
-                </strong>
-                 
-                VDDK
-                <br />
-              </UNDEFINED>
               <UNDEFINED>
                 <strong>
                   State:
@@ -226,6 +224,12 @@ exports[`conversion hosts list item renders correctly with a failed disable task
         className=""
         stacked={false}
       >
+        VDDK
+      </ListViewInfoItem>,
+      <ListViewInfoItem
+        className=""
+        stacked={false}
+      >
         <ListViewIcon
           className=""
           name="error-circle-o"
@@ -246,14 +250,6 @@ exports[`conversion hosts list item renders correctly with a failed disable task
                 }
               }
             >
-              <UNDEFINED>
-                <strong>
-                  Transformation method:
-                </strong>
-                 
-                VDDK
-                <br />
-              </UNDEFINED>
               <UNDEFINED>
                 <strong>
                   State:
@@ -360,6 +356,12 @@ exports[`conversion hosts list item renders correctly with a failed enable task 
         className=""
         stacked={false}
       >
+        VDDK
+      </ListViewInfoItem>,
+      <ListViewInfoItem
+        className=""
+        stacked={false}
+      >
         <ListViewIcon
           className=""
           name="error-circle-o"
@@ -380,14 +382,6 @@ exports[`conversion hosts list item renders correctly with a failed enable task 
                 }
               }
             >
-              <UNDEFINED>
-                <strong>
-                  Transformation method:
-                </strong>
-                 
-                VDDK
-                <br />
-              </UNDEFINED>
               <UNDEFINED>
                 <strong>
                   State:
@@ -461,6 +455,10 @@ exports[`conversion hosts list item renders correctly with a manually enabled ho
   }
   additionalInfo={
     Array [
+      <ListViewInfoItem
+        className=""
+        stacked={false}
+      />,
       <ListViewInfoItem
         className=""
         stacked={false}
@@ -600,6 +598,12 @@ exports[`conversion hosts list item renders correctly with an enabled conversion
         className=""
         stacked={false}
       >
+        VDDK
+      </ListViewInfoItem>,
+      <ListViewInfoItem
+        className=""
+        stacked={false}
+      >
         <ListViewIcon
           className=""
           name="ok"
@@ -620,14 +624,6 @@ exports[`conversion hosts list item renders correctly with an enabled conversion
                 }
               }
             >
-              <UNDEFINED>
-                <strong>
-                  Transformation method:
-                </strong>
-                 
-                VDDK
-                <br />
-              </UNDEFINED>
               <UNDEFINED>
                 <strong>
                   State:
@@ -721,6 +717,12 @@ exports[`conversion hosts list item renders correctly with an in-progress enable
         className=""
         stacked={false}
       >
+        VDDK
+      </ListViewInfoItem>,
+      <ListViewInfoItem
+        className=""
+        stacked={false}
+      >
         <Spinner
           className=""
           inline={true}
@@ -742,14 +744,6 @@ exports[`conversion hosts list item renders correctly with an in-progress enable
                 }
               }
             >
-              <UNDEFINED>
-                <strong>
-                  Transformation method:
-                </strong>
-                 
-                VDDK
-                <br />
-              </UNDEFINED>
               <UNDEFINED>
                 <strong>
                   State:


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1755842

On the Conversion Hosts tab of the Migration Settings page, this PR adds text before each conversion host's status indicator to show that host's configured transformation method (VDDK or SSH).

![Screenshot 2019-10-31 15 25 22](https://user-images.githubusercontent.com/811963/67979535-db374280-fbf2-11e9-9e0b-4ca708bf7aff.png)
