### PR TITLE
Update rubies tested on Travis CI to match core manageiq

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
   - name: "Ruby: 2.4.5"
     language: ruby
     rvm:
-    - 2.4.5
+    - 2.5.7
     cache: bundler
     addons:
       postgresql: '10'
@@ -18,7 +18,7 @@ matrix:
   - name: "Ruby: 2.5.5"
     language: ruby
     rvm:
-    - 2.5.5
+    - 2.6.5
     cache: bundler
     addons:
       postgresql: '10'


### PR DESCRIPTION
Currently our PRs in this repo are blocked because Travis is [testing them against Ruby 2.4](https://travis-ci.org/ManageIQ/manageiq-v2v/jobs/605712845?utm_medium=notification&utm_source=github_status), which is now incompatible with manageiq master.

This PR updates the ruby versions in our Travis CI config to match the latest 2.5 and 2.6 versions found in the core manageiq Travis config. (see https://github.com/ManageIQ/manageiq/pull/19414)