### PR TITLE
ScheduledTimeInfoItem: fix PropType for migrationScheduled

### DIFF
--- a/app/javascript/react/screens/App/Overview/components/Migrations/ScheduledTimeInfoItem.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/ScheduledTimeInfoItem.js
@@ -22,7 +22,7 @@ ScheduledTimeInfoItem.propTypes = {
   planId: PropTypes.string,
   migrationStarting: PropTypes.bool,
   showScheduledTime: PropTypes.bool,
-  migrationScheduled: PropTypes.number
+  migrationScheduled: PropTypes.oneOfType(PropTypes.number, PropTypes.string)
 };
 
 export default ScheduledTimeInfoItem;


### PR DESCRIPTION
1. Have a failed migration plan
2. Re-schedule it
3. Observe the following js error:

```
miq_debug.self-1351f771c2cd2fab0d83069fd3f62aadbb7effc11a01ed4942f52308793453be.js?body=1:30 Warning: Failed prop type: Invalid prop `migrationScheduled` of type `string` supplied to `ScheduledTimeInfoItem`, expected `number`.
    in ScheduledTimeInfoItem (created by ListViewToolbar)
    in ListViewToolbar (created by MigrationsCompletedList)
    in Spinner (created by MigrationsCompletedList)
    in div (created by Col)
    in Col (created by MigrationsCompletedList)
    in MigrationsCompletedList (created by Migrations)
    in div (created by Migrations)
    in Migrations (created by Overview)
    in Spinner (created by Overview)
    in div (created by Overview)
    in div (created by Overview)
    in Overview (created by ConnectFunction)
    in ConnectFunction (created by I18nProviderWrapper(Connect(Overview)))
    in IntlProvider (created by I18nProviderWrapper(Connect(Overview)))
    in I18nProviderWrapper(Connect(Overview)) (created by Route)
    in Route (created by Routes)
    in Routes (created by App)
    in Router (created by ConnectedRouter)
    in ConnectedRouter (created by Context.Consumer)
    in ConnectedRouterWithContext (created by ConnectFunction)
    in ConnectFunction (created by App)
    in App (created by ConnectFunction)
    in ConnectFunction
    in Provider
```