### PR TITLE
Schedule migration modal changes for warm migration

### DIFF
--- a/app/javascript/react/screens/App/Overview/Overview.js
+++ b/app/javascript/react/screens/App/Overview/Overview.js
@@ -278,6 +278,7 @@ class Overview extends React.Component {
       scheduleMigrationModal,
       scheduleMigrationPlan,
       scheduleMigration,
+      scheduleCutover,
       fetchTransformationMappingsUrl,
       fetchTransformationMappingsAction,
       openMappingWizardOnTransitionAction,
@@ -341,6 +342,7 @@ class Overview extends React.Component {
                 scheduleMigrationModal={scheduleMigrationModal}
                 scheduleMigrationPlan={scheduleMigrationPlan}
                 scheduleMigration={scheduleMigration}
+                scheduleCutover={scheduleCutover}
                 showPlanWizardEditModeAction={this.showPlanWizardEditModeOrError}
                 fetchTransformationMappingsUrl={fetchTransformationMappingsUrl}
                 fetchTransformationMappingsAction={fetchTransformationMappingsAction}
@@ -473,6 +475,7 @@ Overview.propTypes = {
   scheduleMigrationModal: PropTypes.bool,
   scheduleMigrationPlan: PropTypes.object,
   scheduleMigration: PropTypes.func,
+  scheduleCutover: PropTypes.func,
   fetchServiceTemplateAnsiblePlaybooksAction: PropTypes.func,
   fetchServiceTemplateAnsiblePlaybooksUrl: PropTypes.string,
   serviceTemplatePlaybooks: PropTypes.array,

--- a/app/javascript/react/screens/App/Overview/OverviewActions.js
+++ b/app/javascript/react/screens/App/Overview/OverviewActions.js
@@ -197,6 +197,40 @@ export const toggleScheduleMigrationModal = plan => ({
   payload: plan
 });
 
+export const scheduleCutover = payload => dispatch =>
+  dispatch({
+    type: V2V_SCHEDULE_MIGRATION,
+    payload: new Promise((resolve, reject) => {
+      const {
+        cutoverTime,
+        plan: { id: planId }
+      } = payload;
+      const url = `/api/service_templates/${planId}`;
+      const body = {
+        action: 'edit',
+        resource: {
+          config_info: {
+            warm_migration_cutover_datetime: cutoverTime
+          }
+        }
+      };
+      return API.post(url, body)
+        .then(response => {
+          resolve(response);
+          dispatch({
+            type: V2V_NOTIFICATION_ADD,
+            message: sprintf(
+              __('Migration cutover successfully scheduled for %s'),
+              formatDateTime(response.data.options.config_info.warm_migration_cutover_datetime)
+            ),
+            notificationType: 'success',
+            actionEnabled: false
+          });
+        })
+        .catch(e => reject(e));
+    })
+  });
+
 export const scheduleMigration = payload => dispatch =>
   dispatch({
     type: V2V_SCHEDULE_MIGRATION,

--- a/app/javascript/react/screens/App/Overview/__test__/__snapshots__/index.test.js.snap
+++ b/app/javascript/react/screens/App/Overview/__test__/__snapshots__/index.test.js.snap
@@ -60,6 +60,7 @@ Object {
   "removeNotificationAction": [Function],
   "requestsProcessingCancellation": Array [],
   "retryMigrationAction": [Function],
+  "scheduleCutover": [Function],
   "scheduleMigration": [Function],
   "setMigrationsFilterAction": [Function],
   "showConfirmModalAction": [Function],

--- a/app/javascript/react/screens/App/Overview/components/Migrations/CutoverTimeInfoItem.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/CutoverTimeInfoItem.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Icon } from 'patternfly-react';
+import { formatDateTime } from '../../../../../../components/dates/MomentDate';
+import ListViewTable from '../../../common/ListViewTable/ListViewTable';
+
+const CutoverTimeInfoItem = ({ plan }) => {
+  if (
+    !plan.options.config_info.warm_migration ||
+    (plan.options.config_info.warm_migration && !plan.options.config_info.warm_migration_cutover_datetime)
+  ) {
+    return null;
+  }
+
+  return (
+    <ListViewTable.InfoItem key={`${plan.id}-cutoverTime`} style={{ textAlign: 'left' }}>
+      <Icon type="fa" name="clock-o" />
+      {__('Cutover scheduled')}
+      <br />
+      {formatDateTime(plan.options.config_info.warm_migration_cutover_datetime)}
+    </ListViewTable.InfoItem>
+  );
+};
+
+CutoverTimeInfoItem.propTypes = {
+  plan: PropTypes.object
+};
+
+export default CutoverTimeInfoItem;

--- a/app/javascript/react/screens/App/Overview/components/Migrations/Migrations.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/Migrations.js
@@ -65,6 +65,7 @@ class Migrations extends React.Component {
       scheduleMigrationModal,
       scheduleMigrationPlan,
       scheduleMigration,
+      scheduleCutover,
       showPlanWizardEditModeAction,
       fetchTransformationMappingsUrl,
       fetchTransformationMappingsAction,
@@ -118,7 +119,7 @@ class Migrations extends React.Component {
             {activeFilter === MIGRATIONS_FILTERS.notStarted && (
               <MigrationsNotStartedList
                 notStartedPlans={Immutable.asMutable(notStartedPlans, { deep: true })}
-                migrateClick={createTransformationPlanRequestClick}
+                scheduleMigrationNow={createTransformationPlanRequestClick}
                 loading={isCreatingTransformationPlanRequest}
                 redirectTo={redirectTo}
                 showConfirmModalAction={showConfirmModalAction}
@@ -128,6 +129,7 @@ class Migrations extends React.Component {
                 scheduleMigrationModal={scheduleMigrationModal}
                 scheduleMigrationPlan={scheduleMigrationPlan}
                 scheduleMigration={scheduleMigration}
+                scheduleCutover={scheduleCutover}
                 fetchTransformationPlansAction={fetchTransformationPlansAction}
                 fetchTransformationPlansUrl={fetchTransformationPlansUrl}
                 deleteTransformationPlanAction={deleteTransformationPlanAction}
@@ -155,11 +157,18 @@ class Migrations extends React.Component {
                 cancelPlanRequestAction={cancelPlanRequestAction}
                 isCancellingPlanRequest={isCancellingPlanRequest}
                 requestsProcessingCancellation={requestsProcessingCancellation}
+                toggleScheduleMigrationModal={toggleScheduleMigrationModal}
+                scheduleMigrationModal={scheduleMigrationModal}
+                scheduleMigrationPlan={scheduleMigrationPlan}
+                scheduleMigration={scheduleMigration}
+                scheduleMigrationNow={createTransformationPlanRequestClick}
+                scheduleCutover={scheduleCutover}
               />
             )}
             {activeFilter === MIGRATIONS_FILTERS.completed && (
               <MigrationsCompletedList
-                migrateClick={createTransformationPlanRequestClick}
+                scheduleMigrationNow={createTransformationPlanRequestClick}
+                scheduleCutover={scheduleCutover}
                 finishedTransformationPlans={Immutable.asMutable(finishedTransformationPlans, { deep: true })}
                 allRequestsWithTasks={allRequestsWithTasks}
                 retryClick={createTransformationPlanRequestClick}
@@ -245,6 +254,7 @@ Migrations.propTypes = {
   scheduleMigrationModal: PropTypes.bool,
   scheduleMigrationPlan: PropTypes.object,
   scheduleMigration: PropTypes.func,
+  scheduleCutover: PropTypes.func,
   showPlanWizardEditModeAction: PropTypes.func,
   fetchTransformationMappingsAction: PropTypes.func,
   fetchTransformationMappingsUrl: PropTypes.string,

--- a/app/javascript/react/screens/App/Overview/components/Migrations/Migrations.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/Migrations.js
@@ -159,6 +159,7 @@ class Migrations extends React.Component {
             )}
             {activeFilter === MIGRATIONS_FILTERS.completed && (
               <MigrationsCompletedList
+                migrateClick={createTransformationPlanRequestClick}
                 finishedTransformationPlans={Immutable.asMutable(finishedTransformationPlans, { deep: true })}
                 allRequestsWithTasks={allRequestsWithTasks}
                 retryClick={createTransformationPlanRequestClick}

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
@@ -47,7 +47,8 @@ const MigrationsCompletedList = ({
   fetchTransformationMappingsAction,
   fetchTransformationMappingsUrl,
   showEditPlanNameModalAction,
-  migrateClick
+  scheduleMigrationNow,
+  scheduleCutover
 }) => (
   <React.Fragment>
     <Grid.Col xs={12}>
@@ -340,7 +341,8 @@ const MigrationsCompletedList = ({
       scheduleMigrationModal={scheduleMigrationModal}
       scheduleMigrationPlan={scheduleMigrationPlan}
       scheduleMigration={scheduleMigration}
-      migrateClick={migrateClick}
+      scheduleMigrationNow={scheduleMigrationNow}
+      scheduleCutover={scheduleCutover}
       fetchTransformationPlansAction={fetchTransformationPlansAction}
       fetchTransformationPlansUrl={fetchTransformationPlansUrl}
     />
@@ -348,7 +350,7 @@ const MigrationsCompletedList = ({
 );
 
 MigrationsCompletedList.propTypes = {
-  migrateClick: PropTypes.func,
+  scheduleMigrationNow: PropTypes.func,
   finishedTransformationPlans: PropTypes.array,
   allRequestsWithTasks: PropTypes.array,
   retryClick: PropTypes.func,
@@ -369,12 +371,14 @@ MigrationsCompletedList.propTypes = {
   scheduleMigrationModal: PropTypes.bool,
   scheduleMigrationPlan: PropTypes.object,
   scheduleMigration: PropTypes.func,
+  scheduleCutover: PropTypes.func,
   fetchTransformationMappingsAction: PropTypes.func,
   fetchTransformationMappingsUrl: PropTypes.string,
   showEditPlanNameModalAction: PropTypes.func
 };
 MigrationsCompletedList.defaultProps = {
-  migrateClick: noop,
+  scheduleMigrationNow: noop,
+  scheduleCutover: noop,
   finishedTransformationPlans: [],
   retryClick: noop,
   loading: false

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { noop, Button, ListView, Grid, Spinner, Icon, Toolbar, DropdownKebab, MenuItem } from 'patternfly-react';
+import { noop, ListView, Grid, Spinner, Icon, Toolbar, DropdownKebab, MenuItem } from 'patternfly-react';
 import { IsoElapsedTime } from '../../../../../../components/dates/IsoElapsedTime';
 import ShowWizardEmptyState from '../../../common/ShowWizardEmptyState/ShowWizardEmptyState';
 import getMostRecentRequest from '../../../common/getMostRecentRequest';
@@ -46,7 +46,8 @@ const MigrationsCompletedList = ({
   scheduleMigration,
   fetchTransformationMappingsAction,
   fetchTransformationMappingsUrl,
-  showEditPlanNameModalAction
+  showEditPlanNameModalAction,
+  migrateClick
 }) => (
   <React.Fragment>
     <Grid.Col xs={12}>
@@ -255,15 +256,6 @@ const MigrationsCompletedList = ({
                                   isMissingMapping={isMissingMapping}
                                 />
                               </Visibility>
-                              <Button
-                                onClick={e => {
-                                  e.stopPropagation();
-                                  retryClick(plan.href, plan.id);
-                                }}
-                                disabled={isMissingMapping || loading === plan.href || migrationStarting}
-                              >
-                                {__('Retry')}
-                              </Button>
                             </Visibility>
                             <StopPropagationOnClick>
                               <DropdownKebab id={`${plan.id}-kebab`} pullRight>
@@ -348,6 +340,7 @@ const MigrationsCompletedList = ({
       scheduleMigrationModal={scheduleMigrationModal}
       scheduleMigrationPlan={scheduleMigrationPlan}
       scheduleMigration={scheduleMigration}
+      migrateClick={migrateClick}
       fetchTransformationPlansAction={fetchTransformationPlansAction}
       fetchTransformationPlansUrl={fetchTransformationPlansUrl}
     />
@@ -355,6 +348,7 @@ const MigrationsCompletedList = ({
 );
 
 MigrationsCompletedList.propTypes = {
+  migrateClick: PropTypes.func,
   finishedTransformationPlans: PropTypes.array,
   allRequestsWithTasks: PropTypes.array,
   retryClick: PropTypes.func,
@@ -380,6 +374,7 @@ MigrationsCompletedList.propTypes = {
   showEditPlanNameModalAction: PropTypes.func
 };
 MigrationsCompletedList.defaultProps = {
+  migrateClick: noop,
   finishedTransformationPlans: [],
   retryClick: noop,
   loading: false

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsInProgressList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsInProgressList.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Grid, Spinner, Toolbar } from 'patternfly-react';
+import { noop, Grid, Spinner, Toolbar } from 'patternfly-react';
 import ShowWizardEmptyState from '../../../common/ShowWizardEmptyState/ShowWizardEmptyState';
 import MigrationInProgressListItem from './MigrationInProgressListItem';
 import ListViewTable from '../../../common/ListViewTable/ListViewTable';
 import ListViewToolbar from '../../../common/ListViewToolbar/ListViewToolbar';
+import ScheduleMigrationModal from '../ScheduleMigrationModal/ScheduleMigrationModal';
 import { MIGRATIONS_FILTER_TYPES, MIGRATIONS_IN_PROGRESS_SORT_FIELDS } from './MigrationsConstants';
 
 const MigrationsInProgressList = ({
@@ -23,68 +24,87 @@ const MigrationsInProgressList = ({
   setMigrationsFilterAction,
   cancelPlanRequestAction,
   isCancellingPlanRequest,
-  requestsProcessingCancellation
+  requestsProcessingCancellation,
+  toggleScheduleMigrationModal,
+  scheduleMigrationModal,
+  scheduleMigrationPlan,
+  scheduleMigration,
+  scheduleMigrationNow,
+  scheduleCutover
 }) => (
-  <Grid.Col xs={12} id="progress-bar-items">
-    <Spinner loading={!!loading}>
-      {activeTransformationPlans.length > 0 && allRequestsWithTasks.length > 0 ? (
-        <ListViewToolbar
-          filterTypes={MIGRATIONS_FILTER_TYPES}
-          sortFields={MIGRATIONS_IN_PROGRESS_SORT_FIELDS}
-          listItems={activeTransformationPlans}
-        >
-          {({
-            filteredSortedPaginatedListItems,
-            renderFilterControls,
-            renderSortControls,
-            renderActiveFilters,
-            renderPaginationRow
-          }) => (
-            <React.Fragment>
-              <Grid.Row>
-                <Toolbar>
-                  {renderFilterControls()}
-                  {renderSortControls()}
-                  {renderActiveFilters(filteredSortedPaginatedListItems)}
-                </Toolbar>
-              </Grid.Row>
-              <ListViewTable className="plans-in-progress-list" style={{ marginTop: 10 }}>
-                {filteredSortedPaginatedListItems.items.map(plan => (
-                  <MigrationInProgressListItem
-                    plan={plan}
-                    serviceTemplatePlaybooks={serviceTemplatePlaybooks}
-                    allRequestsWithTasks={allRequestsWithTasks}
-                    reloadCard={reloadCard}
-                    key={plan.id}
-                    redirectTo={redirectTo}
-                    fetchTransformationPlansAction={fetchTransformationPlansAction}
-                    fetchTransformationPlansUrl={fetchTransformationPlansUrl}
-                    isFetchingTransformationPlans={isFetchingTransformationPlans}
-                    isFetchingAllRequestsWithTasks={isFetchingAllRequestsWithTasks}
-                    acknowledgeDeniedPlanRequestAction={acknowledgeDeniedPlanRequestAction}
-                    isEditingPlanRequest={isEditingPlanRequest}
-                    setMigrationsFilterAction={setMigrationsFilterAction}
-                    cancelPlanRequestAction={cancelPlanRequestAction}
-                    isCancellingPlanRequest={isCancellingPlanRequest}
-                    requestsProcessingCancellation={requestsProcessingCancellation}
-                  />
-                ))}
-              </ListViewTable>
-              {renderPaginationRow(filteredSortedPaginatedListItems)}
-            </React.Fragment>
-          )}
-        </ListViewToolbar>
-      ) : (
-        <ShowWizardEmptyState
-          title={__('No Migration Plans In Progress')}
-          iconType="pf"
-          iconName="info"
-          description={<span>{__('There are no existing migration plans in an In Progress state.')}</span>}
-        />
-      )}
-    </Spinner>
-    {/* TODO: scheduling modal here? maybe lift that out of CompletedList? */}
-  </Grid.Col>
+  <React.Fragment>
+    <Grid.Col xs={12} id="progress-bar-items">
+      <Spinner loading={!!loading}>
+        {activeTransformationPlans.length > 0 && allRequestsWithTasks.length > 0 ? (
+          <ListViewToolbar
+            filterTypes={MIGRATIONS_FILTER_TYPES}
+            sortFields={MIGRATIONS_IN_PROGRESS_SORT_FIELDS}
+            listItems={activeTransformationPlans}
+          >
+            {({
+              filteredSortedPaginatedListItems,
+              renderFilterControls,
+              renderSortControls,
+              renderActiveFilters,
+              renderPaginationRow
+            }) => (
+              <React.Fragment>
+                <Grid.Row>
+                  <Toolbar>
+                    {renderFilterControls()}
+                    {renderSortControls()}
+                    {renderActiveFilters(filteredSortedPaginatedListItems)}
+                  </Toolbar>
+                </Grid.Row>
+                <ListViewTable className="plans-in-progress-list" style={{ marginTop: 10 }}>
+                  {filteredSortedPaginatedListItems.items.map(plan => (
+                    <MigrationInProgressListItem
+                      plan={plan}
+                      serviceTemplatePlaybooks={serviceTemplatePlaybooks}
+                      allRequestsWithTasks={allRequestsWithTasks}
+                      reloadCard={reloadCard}
+                      key={plan.id}
+                      redirectTo={redirectTo}
+                      fetchTransformationPlansAction={fetchTransformationPlansAction}
+                      fetchTransformationPlansUrl={fetchTransformationPlansUrl}
+                      isFetchingTransformationPlans={isFetchingTransformationPlans}
+                      isFetchingAllRequestsWithTasks={isFetchingAllRequestsWithTasks}
+                      acknowledgeDeniedPlanRequestAction={acknowledgeDeniedPlanRequestAction}
+                      isEditingPlanRequest={isEditingPlanRequest}
+                      setMigrationsFilterAction={setMigrationsFilterAction}
+                      cancelPlanRequestAction={cancelPlanRequestAction}
+                      isCancellingPlanRequest={isCancellingPlanRequest}
+                      requestsProcessingCancellation={requestsProcessingCancellation}
+                      loading={loading}
+                      toggleScheduleMigrationModal={toggleScheduleMigrationModal}
+                    />
+                  ))}
+                </ListViewTable>
+                {renderPaginationRow(filteredSortedPaginatedListItems)}
+              </React.Fragment>
+            )}
+          </ListViewToolbar>
+        ) : (
+          <ShowWizardEmptyState
+            title={__('No Migration Plans In Progress')}
+            iconType="pf"
+            iconName="info"
+            description={<span>{__('There are no existing migration plans in an In Progress state.')}</span>}
+          />
+        )}
+      </Spinner>
+    </Grid.Col>
+    <ScheduleMigrationModal
+      toggleScheduleMigrationModal={toggleScheduleMigrationModal}
+      scheduleMigrationModal={scheduleMigrationModal}
+      scheduleMigrationPlan={scheduleMigrationPlan}
+      scheduleMigration={scheduleMigration}
+      scheduleMigrationNow={scheduleMigrationNow}
+      scheduleCutover={scheduleCutover}
+      fetchTransformationPlansAction={fetchTransformationPlansAction}
+      fetchTransformationPlansUrl={fetchTransformationPlansUrl}
+    />
+  </React.Fragment>
 );
 
 MigrationsInProgressList.propTypes = {
@@ -103,13 +123,19 @@ MigrationsInProgressList.propTypes = {
   setMigrationsFilterAction: PropTypes.func,
   cancelPlanRequestAction: PropTypes.func,
   isCancellingPlanRequest: PropTypes.bool,
-  requestsProcessingCancellation: PropTypes.array
+  requestsProcessingCancellation: PropTypes.array,
+  toggleScheduleMigrationModal: PropTypes.func,
+  scheduleMigrationModal: PropTypes.bool,
+  scheduleMigrationPlan: PropTypes.object,
+  scheduleMigration: PropTypes.func,
+  scheduleMigrationNow: PropTypes.func,
+  scheduleCutover: PropTypes.func
 };
 
 MigrationsInProgressList.defaultProps = {
   activeTransformationPlans: [],
   serviceTemplatePlaybooks: [],
-  loading: false
+  scheduleMigrationNow: noop
 };
 
 export default MigrationsInProgressList;

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
@@ -17,7 +17,7 @@ import NumVmsInfoItem from './NumVmsInfoItem';
 import MappingNameInfoItem from './MappingNameInfoItem';
 
 const MigrationsNotStartedList = ({
-  migrateClick,
+  scheduleMigrationNow,
   notStartedPlans,
   loading,
   redirectTo,
@@ -28,6 +28,7 @@ const MigrationsNotStartedList = ({
   scheduleMigrationModal,
   scheduleMigrationPlan,
   scheduleMigration,
+  scheduleCutover,
   fetchTransformationPlansAction,
   fetchTransformationPlansUrl,
   deleteTransformationPlanAction,
@@ -169,7 +170,8 @@ const MigrationsNotStartedList = ({
       scheduleMigrationModal={scheduleMigrationModal}
       scheduleMigrationPlan={scheduleMigrationPlan}
       scheduleMigration={scheduleMigration}
-      migrateClick={migrateClick}
+      scheduleMigrationNow={scheduleMigrationNow}
+      scheduleCutover={scheduleCutover}
       fetchTransformationPlansAction={fetchTransformationPlansAction}
       fetchTransformationPlansUrl={fetchTransformationPlansUrl}
     />
@@ -177,7 +179,7 @@ const MigrationsNotStartedList = ({
 );
 
 MigrationsNotStartedList.propTypes = {
-  migrateClick: PropTypes.func,
+  scheduleMigrationNow: PropTypes.func,
   showConfirmModalAction: PropTypes.func,
   hideConfirmModalAction: PropTypes.func,
   addNotificationAction: PropTypes.func,
@@ -188,6 +190,7 @@ MigrationsNotStartedList.propTypes = {
   scheduleMigrationModal: PropTypes.bool,
   scheduleMigrationPlan: PropTypes.object,
   scheduleMigration: PropTypes.func,
+  scheduleCutover: PropTypes.func,
   fetchTransformationPlansAction: PropTypes.func,
   fetchTransformationPlansUrl: PropTypes.string,
   deleteTransformationPlanAction: PropTypes.func,
@@ -197,7 +200,7 @@ MigrationsNotStartedList.propTypes = {
   fetchTransformationMappingsUrl: PropTypes.string
 };
 MigrationsNotStartedList.defaultProps = {
-  migrateClick: noop,
+  scheduleMigrationNow: noop,
   notStartedPlans: [],
   loading: ''
 };

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { noop, Button, Grid, Spinner, Toolbar, DropdownKebab, MenuItem } from 'patternfly-react';
+import { noop, Grid, Spinner, Toolbar, DropdownKebab, MenuItem } from 'patternfly-react';
 import EllipsisWithTooltip from 'react-ellipsis-with-tooltip';
 import ShowWizardEmptyState from '../../../common/ShowWizardEmptyState/ShowWizardEmptyState';
 import ScheduleMigrationModal from '../ScheduleMigrationModal/ScheduleMigrationModal';
@@ -86,18 +86,6 @@ const MigrationsNotStartedList = ({
                                 isMissingMapping={isMissingMapping}
                               />
                             )}
-                            <Button
-                              id={`migrate_${plan.id}`}
-                              onClick={e => {
-                                e.stopPropagation();
-                                migrateClick(plan.href);
-                              }}
-                              disabled={
-                                isMissingMapping || loading === plan.href || plan.schedule_type || migrationStarting
-                              }
-                            >
-                              {__('Migrate')}
-                            </Button>
                             <StopPropagationOnClick>
                               <DropdownKebab id={`${plan.id}-kebab`} pullRight>
                                 <MenuItem
@@ -181,6 +169,7 @@ const MigrationsNotStartedList = ({
       scheduleMigrationModal={scheduleMigrationModal}
       scheduleMigrationPlan={scheduleMigrationPlan}
       scheduleMigration={scheduleMigration}
+      migrateClick={migrateClick}
       fetchTransformationPlansAction={fetchTransformationPlansAction}
       fetchTransformationPlansUrl={fetchTransformationPlansUrl}
     />

--- a/app/javascript/react/screens/App/Overview/components/Migrations/ScheduleMigrationButton.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/ScheduleMigrationButton.js
@@ -2,18 +2,22 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Button } from 'patternfly-react';
 
-const ScheduleMigrationButton = ({ loading, toggleScheduleMigrationModal, plan, isMissingMapping }) => (
-  <Button
-    id={`schedule_${plan.id}`}
-    onClick={e => {
-      e.stopPropagation();
-      toggleScheduleMigrationModal({ plan });
-    }}
-    disabled={isMissingMapping || loading === plan.href || plan.schedule_type}
-  >
-    {__('Schedule')}
-  </Button>
-);
+const ScheduleMigrationButton = ({ loading, toggleScheduleMigrationModal, plan, isMissingMapping }) => {
+  const retry = plan.status === 'Error' || plan.status === 'Denied';
+
+  return (
+    <Button
+      id={`schedule_${plan.id}`}
+      onClick={e => {
+        e.stopPropagation();
+        toggleScheduleMigrationModal({ plan });
+      }}
+      disabled={isMissingMapping || loading === plan.href || plan.schedule_type}
+    >
+      {retry ? __('Schedule Retry') : __('Schedule Migration')}
+    </Button>
+  );
+};
 
 ScheduleMigrationButton.propTypes = {
   loading: PropTypes.string,

--- a/app/javascript/react/screens/App/Overview/components/Migrations/ScheduleMigrationButton.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/ScheduleMigrationButton.js
@@ -3,7 +3,15 @@ import PropTypes from 'prop-types';
 import { Button } from 'patternfly-react';
 
 const ScheduleMigrationButton = ({ loading, toggleScheduleMigrationModal, plan, isMissingMapping }) => {
-  const retry = plan.status === 'Error' || plan.status === 'Denied';
+  const buttonLabel = migrationPlan => {
+    let label = __('Schedule Migration');
+    if (migrationPlan.options.config_info.warm_migration && migrationPlan.status === 'Ok') {
+      label = __('Schedule Cutover');
+    } else if (migrationPlan.status === 'Error' || migrationPlan.status === 'Denied') {
+      label = __('Schedule Retry');
+    }
+    return label;
+  };
 
   return (
     <Button
@@ -14,13 +22,13 @@ const ScheduleMigrationButton = ({ loading, toggleScheduleMigrationModal, plan, 
       }}
       disabled={isMissingMapping || loading === plan.href || plan.schedule_type}
     >
-      {retry ? __('Schedule Retry') : __('Schedule Migration')}
+      {buttonLabel(plan)}
     </Button>
   );
 };
 
 ScheduleMigrationButton.propTypes = {
-  loading: PropTypes.string,
+  loading: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   toggleScheduleMigrationModal: PropTypes.func,
   plan: PropTypes.object,
   isMissingMapping: PropTypes.bool

--- a/app/javascript/react/screens/App/Overview/components/Migrations/__test__/MigrationsNotStartedList.test.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/__test__/MigrationsNotStartedList.test.js
@@ -8,15 +8,15 @@ import ListViewTableRow from '../../../../common/ListViewTable/ListViewTableRow'
 const { resources: plans } = transformationPlans;
 const [notStartedPlan] = plans;
 
-let migrateClick;
+let scheduleMigrationNow;
 let redirectTo;
 let wrapper;
 beforeEach(() => {
-  migrateClick = jest.fn();
+  scheduleMigrationNow = jest.fn();
   redirectTo = jest.fn();
   wrapper = mount(
     <MigrationsNotStartedList
-      migrateClick={migrateClick}
+      scheduleMigrationNow={scheduleMigrationNow}
       redirectTo={redirectTo}
       loading=""
       notStartedPlans={[notStartedPlan]}
@@ -33,7 +33,7 @@ test('clicking on a plan fires redirectTo with the path to its details page', ()
   expect(redirectTo).toHaveBeenLastCalledWith(`/plan/${notStartedPlan.id}`);
 });
 
-test.skip('clicking on the Migrate button fires migrateClick with the correct API endpoint', () => {
+test.skip('clicking on the Migrate button fires scheduleMigrationNow with the correct API endpoint', () => {
   const e = {
     stopPropagation: jest.fn()
   };
@@ -42,5 +42,5 @@ test.skip('clicking on the Migrate button fires migrateClick with the correct AP
     .prop('actions')
     .props.children.props.onClick(e);
 
-  expect(migrateClick).toHaveBeenLastCalledWith(`/api/service_templates/${notStartedPlan.id}`);
+  expect(scheduleMigrationNow).toHaveBeenLastCalledWith(`/api/service_templates/${notStartedPlan.id}`);
 });

--- a/app/javascript/react/screens/App/Overview/components/Migrations/__test__/__snapshots__/MigrationInProgressListItem.test.js.snap
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/__test__/__snapshots__/MigrationInProgressListItem.test.js.snap
@@ -37,6 +37,73 @@ exports[`if there are no conversion hosts available renders an error view 1`] = 
           Waiting for an available conversion host. You can continue waiting or go to the Migration Settings page to increase the number of migrations per host.
         </EllipisWithTooltip>
       </ListViewTableInfoItem>,
+      <CutoverTimeInfoItem
+        plan={
+          Object {
+            "configVmLength": 2,
+            "created_on": "2018-05-01T12:13:50Z",
+            "fulfilledOn": "2018-04-06T12:31:30Z",
+            "href": "http://localhost:3000/api/service_templates/60",
+            "id": "60",
+            "miq_requests": Array [
+              Object {
+                "approval_state": "approved",
+                "created_on": "2018-04-06T12:31:30Z",
+                "description": "Migration Plan F-0",
+                "destination_id": null,
+                "destination_type": null,
+                "fulfilled_on": "2018-04-06T12:31:30Z",
+                "href": "http://localhost:3000/api/service_requests/6000",
+                "id": "6000",
+                "message": "VM Transformations <SOMETHING>",
+                "options": Object {
+                  "cart_state": "ordered",
+                  "delivered_on": "2018-04-06T12:49:30Z",
+                  "dialog": null,
+                  "initiator": null,
+                  "requester_group": "EvmGroup-super_administrator",
+                  "src_id": "60",
+                  "workflow_settings": Object {
+                    "resource_action_id": "2507",
+                  },
+                },
+                "process": true,
+                "request_state": "active",
+                "request_type": "transformation_plan",
+                "requester_id": "1",
+                "requester_name": "Administrator",
+                "service_order_id": "91",
+                "source_id": "60",
+                "source_type": "ServiceTemplate",
+                "status": "Ok",
+                "tenant_id": "1",
+                "type": "ServiceTemplateTransformationPlanRequest",
+                "updated_on": "2018-04-06T12:31:30Z",
+                "userid": "admin",
+              },
+            ],
+            "name": "Migration Plan F-0",
+            "options": Object {
+              "config_info": Object {
+                "actions": Array [
+                  Object {
+                    "vm_id": "1",
+                  },
+                  Object {
+                    "vm_id": "3",
+                  },
+                ],
+                "transformation_mapping_id": "1",
+              },
+            },
+            "scheduleTime": null,
+            "status": "Ok",
+            "transformation_mapping": Object {
+              "transformation_mapping_items": Array [],
+            },
+          }
+        }
+      />,
     ]
   }
   numFailedVms={0}
@@ -146,6 +213,73 @@ exports[`when the request is denied renders an error view 1`] = `
           See the product documentation for information on configuring conversion hosts.
         </EllipisWithTooltip>
       </ListViewTableInfoItem>,
+      <CutoverTimeInfoItem
+        plan={
+          Object {
+            "configVmLength": 2,
+            "created_on": "2018-05-01T12:13:50Z",
+            "fulfilledOn": "2018-04-06T12:31:30Z",
+            "href": "http://localhost:3000/api/service_templates/80",
+            "id": "80",
+            "miq_requests": Array [
+              Object {
+                "approval_state": "denied",
+                "cancelation_status": null,
+                "created_on": "2018-04-06T12:31:30Z",
+                "description": "Migration Plan H-0",
+                "destination_id": null,
+                "destination_type": null,
+                "fulfilled_on": "2018-04-06T12:31:30Z",
+                "href": "http://localhost:3000/api/service_requests/8000",
+                "id": "8000",
+                "message": "VM Transformations <SOMETHING>",
+                "options": Object {
+                  "cart_state": "ordered",
+                  "delivered_on": "2018-04-06T12:49:30Z",
+                  "dialog": null,
+                  "initiator": null,
+                  "requester_group": "EvmGroup-super_administrator",
+                  "src_id": "60",
+                  "workflow_settings": Object {
+                    "resource_action_id": "2507",
+                  },
+                },
+                "process": true,
+                "request_state": "active",
+                "request_type": "transformation_plan",
+                "requester_id": "1",
+                "requester_name": "Administrator",
+                "service_order_id": "91",
+                "source_id": "80",
+                "source_type": "ServiceTemplate",
+                "status": "Ok",
+                "tenant_id": "1",
+                "updated_on": "2018-04-06T12:31:30Z",
+                "userid": "admin",
+              },
+            ],
+            "name": "Migration Plan H-0",
+            "options": Object {
+              "config_info": Object {
+                "actions": Array [
+                  Object {
+                    "vm_id": "1",
+                  },
+                  Object {
+                    "vm_id": "3",
+                  },
+                ],
+                "transformation_mapping_id": "1",
+              },
+            },
+            "scheduleTime": null,
+            "status": "Ok",
+            "transformation_mapping": Object {
+              "transformation_mapping_items": Array [],
+            },
+          }
+        }
+      />,
     ]
   }
   numFailedVms={0}

--- a/app/javascript/react/screens/App/Overview/components/Migrations/helpers/getPlanScheduleInfo.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/helpers/getPlanScheduleInfo.js
@@ -3,11 +3,19 @@ const getPlanScheduleInfo = plan => {
   const staleMigrationSchedule = new Date(migrationScheduled).getTime() < Date.now();
   const migrationStarting = staleMigrationSchedule && new Date(migrationScheduled).getTime() > Date.now() - 120000;
   const showInitialScheduleButton = staleMigrationSchedule && !migrationStarting;
+  const migrationCutover =
+    (plan &&
+      plan.options &&
+      plan.options.config_info &&
+      plan.options.config_info.warm_migration &&
+      plan.options.config_info.warm_migration_cutover_datetime) ||
+    0;
   return {
     migrationScheduled,
     staleMigrationSchedule,
     migrationStarting,
-    showInitialScheduleButton
+    showInitialScheduleButton,
+    migrationCutover
   };
 };
 

--- a/app/javascript/react/screens/App/Overview/components/Migrations/helpers/isPlanWarmMigration.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/helpers/isPlanWarmMigration.js
@@ -1,0 +1,4 @@
+const isPlanWarmMigration = plan =>
+  plan != null && plan.options && plan.options.config_info && plan.options.config_info.warm_migration;
+
+export default isPlanWarmMigration;

--- a/app/javascript/react/screens/App/Overview/components/ScheduleMigrationModal/ScheduleMigrationModalBody.js
+++ b/app/javascript/react/screens/App/Overview/components/ScheduleMigrationModal/ScheduleMigrationModalBody.js
@@ -1,59 +1,30 @@
 import React from 'react';
 import { Icon } from 'patternfly-react';
 import PropTypes from 'prop-types';
+import { initializeDatepicker } from '../../helpers';
 
 class ScheduleMigrationModalBody extends React.Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      showDatepicker: false
-    };
-  }
-
   componentDidMount() {
-    const { startMigrationNowHandler } = this.props;
-    startMigrationNowHandler(!this.state.showDatepicker);
+    if (this.props.showDatepicker) {
+      const { handleDatepickerChange, defaultDate } = this.props;
+      initializeDatepicker(handleDatepickerChange, defaultDate);
+    }
   }
 
   componentDidUpdate(prevProps, prevState, snapshot) {
-    if (prevState.showDatepicker !== this.state.showDatepicker) {
-      const { startMigrationNowHandler } = this.props;
-      startMigrationNowHandler(!this.state.showDatepicker);
-
-      if (this.state.showDatepicker) {
+    if (prevProps.showDatepicker !== this.props.showDatepicker) {
+      if (this.props.showDatepicker) {
         const { handleDatepickerChange, defaultDate } = this.props;
-        const datetimeSelector = $('#dateTimePicker');
-        const minDate = new Date(Date.now() + 120000);
-
-        datetimeSelector.datetimepicker({
-          defaultDate: defaultDate > minDate ? defaultDate : minDate,
-          useCurrent: !defaultDate,
-          allowInputToggle: true,
-          showTodayButton: true,
-          minDate,
-          toolbarPlacement: 'bottom',
-          sideBySide: true,
-          icons: {
-            today: 'today-button-pf'
-          }
-        });
-
-        datetimeSelector.on('dp.change', e => {
-          handleDatepickerChange(e.date._d);
-        });
-
-        const picker = datetimeSelector.data('DateTimePicker');
-        handleDatepickerChange(picker.date().toDate());
+        initializeDatepicker(handleDatepickerChange, defaultDate);
       }
     }
   }
 
   render() {
+    const { setScheduleMode, startNowLabel, startLaterLabel, showDatepicker } = this.props;
+
     const handleRadioChange = event => {
-      this.setState({
-        showDatepicker: event.currentTarget.value === 'schedule_migration_later'
-      });
+      setScheduleMode(event.currentTarget.value === 'schedule_migration_now');
     };
 
     return (
@@ -68,9 +39,9 @@ class ScheduleMigrationModalBody extends React.Component {
                     name="schedule_migration_start"
                     value="schedule_migration_now"
                     onChange={handleRadioChange}
-                    checked={!this.state.showDatepicker}
+                    checked={!showDatepicker}
                   />
-                  {__('Start migration immediately')}
+                  {startNowLabel}
                 </label>
               </div>
               <div className="radio">
@@ -80,14 +51,15 @@ class ScheduleMigrationModalBody extends React.Component {
                     name="schedule_migration_start"
                     value="schedule_migration_later"
                     onChange={handleRadioChange}
+                    checked={showDatepicker}
                   />
-                  {__('Select date and time for the start of the migration')}
+                  {startLaterLabel}
                 </label>
               </div>
             </div>
           </div>
         </div>
-        {this.state.showDatepicker && (
+        {showDatepicker && (
           <div className="row">
             <div className="col-xs-12">
               <div className="form-group">
@@ -108,8 +80,11 @@ class ScheduleMigrationModalBody extends React.Component {
 
 ScheduleMigrationModalBody.propTypes = {
   handleDatepickerChange: PropTypes.func,
-  startMigrationNowHandler: PropTypes.func,
-  defaultDate: PropTypes.instanceOf(Date)
+  setScheduleMode: PropTypes.func,
+  defaultDate: PropTypes.instanceOf(Date),
+  startNowLabel: PropTypes.string,
+  startLaterLabel: PropTypes.string,
+  showDatepicker: PropTypes.bool
 };
 
 export default ScheduleMigrationModalBody;

--- a/app/javascript/react/screens/App/Overview/components/ScheduleMigrationModal/ScheduleMigrationModalBody.js
+++ b/app/javascript/react/screens/App/Overview/components/ScheduleMigrationModal/ScheduleMigrationModalBody.js
@@ -3,54 +3,113 @@ import { Icon } from 'patternfly-react';
 import PropTypes from 'prop-types';
 
 class ScheduleMigrationModalBody extends React.Component {
-  componentDidMount() {
-    const { handleChange, defaultDate } = this.props;
-    const datetimeSelector = $('#dateTimePicker');
+  constructor(props) {
+    super(props);
 
-    const minDate = new Date(Date.now() + 120000);
-    const validDefaultDate = defaultDate && new Date(defaultDate) > minDate ? new Date(defaultDate) : false;
-
-    datetimeSelector.datetimepicker({
-      defaultDate: validDefaultDate,
-      useCurrent: !validDefaultDate,
-      allowInputToggle: true,
-      showTodayButton: true,
-      minDate,
-      toolbarPlacement: 'bottom',
-      sideBySide: true,
-      icons: {
-        today: 'today-button-pf'
-      }
-    });
-
-    datetimeSelector.on('dp.change', e => {
-      handleChange(e.date._d);
-    });
-
-    const picker = datetimeSelector.data('DateTimePicker');
-    handleChange(picker.date().toDate());
+    this.state = {
+      showDatepicker: false
+    };
   }
+
+  componentDidMount() {
+    const { startMigrationNowHandler } = this.props;
+    startMigrationNowHandler(!this.state.showDatepicker);
+  }
+
+  componentDidUpdate(prevProps, prevState, snapshot) {
+    if (prevState.showDatepicker !== this.state.showDatepicker) {
+      const { startMigrationNowHandler } = this.props;
+      startMigrationNowHandler(!this.state.showDatepicker);
+
+      if (this.state.showDatepicker) {
+        const { handleDatepickerChange, defaultDate } = this.props;
+        const datetimeSelector = $('#dateTimePicker');
+        const minDate = new Date(Date.now() + 120000);
+
+        datetimeSelector.datetimepicker({
+          defaultDate: defaultDate > minDate ? defaultDate : minDate,
+          useCurrent: !defaultDate,
+          allowInputToggle: true,
+          showTodayButton: true,
+          minDate,
+          toolbarPlacement: 'bottom',
+          sideBySide: true,
+          icons: {
+            today: 'today-button-pf'
+          }
+        });
+
+        datetimeSelector.on('dp.change', e => {
+          handleDatepickerChange(e.date._d);
+        });
+
+        const picker = datetimeSelector.data('DateTimePicker');
+        handleDatepickerChange(picker.date().toDate());
+      }
+    }
+  }
+
   render() {
+    const handleRadioChange = event => {
+      this.setState({
+        showDatepicker: event.currentTarget.value === 'schedule_migration_later'
+      });
+    };
+
     return (
-      <div className="row">
-        <div className="col-xs-12">
-          <div className="form-group">
-            <div id="dateTimePicker" className="input-group date-time-picker-pf">
-              <input id="dateTimeInput" type="text" className="form-control" />
-              <span className="input-group-addon">
-                <Icon type="fa" name="calendar" />
-              </span>
+      <div>
+        <div className="row">
+          <div className="col-xs-12">
+            <div className="form-group">
+              <div className="radio">
+                <label style={{ fontWeight: '600' }}>
+                  <input
+                    type="radio"
+                    name="schedule_migration_start"
+                    value="schedule_migration_now"
+                    onChange={handleRadioChange}
+                    checked={!this.state.showDatepicker}
+                  />
+                  {__('Start migration immediately')}
+                </label>
+              </div>
+              <div className="radio">
+                <label style={{ fontWeight: '600' }}>
+                  <input
+                    type="radio"
+                    name="schedule_migration_start"
+                    value="schedule_migration_later"
+                    onChange={handleRadioChange}
+                  />
+                  {__('Select date and time for the start of the migration')}
+                </label>
+              </div>
             </div>
           </div>
         </div>
+        {this.state.showDatepicker && (
+          <div className="row">
+            <div className="col-xs-12">
+              <div className="form-group">
+                <div id="dateTimePicker" className="input-group date-time-picker-pf">
+                  <input id="dateTimeInput" type="text" className="form-control" />
+                  <span className="input-group-addon">
+                    <Icon type="fa" name="calendar" />
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
       </div>
     );
   }
 }
 
 ScheduleMigrationModalBody.propTypes = {
-  handleChange: PropTypes.func,
-  defaultDate: PropTypes.string
+  handleDatepickerChange: PropTypes.func,
+  startMigrationNowHandler: PropTypes.func,
+  defaultDate: PropTypes.instanceOf(Date)
 };
 
 export default ScheduleMigrationModalBody;

--- a/app/javascript/react/screens/App/Overview/helpers.js
+++ b/app/javascript/react/screens/App/Overview/helpers.js
@@ -33,3 +33,28 @@ export const attachTargetProvider = (plan, providers, clusters, targetProviderTy
 
   return { ...plan, targetProvider };
 };
+
+export const initializeDatepicker = (handleDatepickerChange, defaultDate) => {
+  const datetimeSelector = $('#dateTimePicker');
+  const minDate = new Date(Date.now() + 120000);
+
+  datetimeSelector.datetimepicker({
+    defaultDate: defaultDate > minDate ? defaultDate : minDate,
+    useCurrent: !defaultDate,
+    allowInputToggle: true,
+    showTodayButton: true,
+    minDate,
+    toolbarPlacement: 'bottom',
+    sideBySide: true,
+    icons: {
+      today: 'today-button-pf'
+    }
+  });
+
+  datetimeSelector.on('dp.change', e => {
+    handleDatepickerChange(e.date._d);
+  });
+
+  const picker = datetimeSelector.data('DateTimePicker');
+  handleDatepickerChange(picker.date().toDate());
+};


### PR DESCRIPTION
Schedule & Migrate buttons got merged into one
![warm-scheduling-01](https://user-images.githubusercontent.com/6648365/69562390-5d771480-0faf-11ea-842d-ff63002ff88d.png)

Schedule migration now
![warm-scheduling-02](https://user-images.githubusercontent.com/6648365/69562391-5e0fab00-0faf-11ea-87c9-94802266206b.png)

Schedule migration later
![warm-scheduling-03](https://user-images.githubusercontent.com/6648365/69562392-5e0fab00-0faf-11ea-82d5-9c852a0c8592.png)

Schedule retry button
![warm-scheduling-04](https://user-images.githubusercontent.com/6648365/69562393-5e0fab00-0faf-11ea-92a2-3c55b0e26e0c.png)

Schedule retry modal
![warm-scheduling-05](https://user-images.githubusercontent.com/6648365/69562394-5ea84180-0faf-11ea-9e76-df50de3530bc.png)

Schedule cutover button
![warm-scheduling-06](https://user-images.githubusercontent.com/6648365/69562395-5ea84180-0faf-11ea-868d-945bd131d9f4.png)

Schedule cutover modal
![warm-scheduling-07](https://user-images.githubusercontent.com/6648365/69562398-5f40d800-0faf-11ea-8fe3-d89419c5c097.png)
