### PR TITLE
Fix usage of PropTypes.oneOfType

### DIFF
--- a/app/javascript/react/screens/App/Overview/components/Migrations/ScheduledTimeInfoItem.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/ScheduledTimeInfoItem.js
@@ -22,7 +22,7 @@ ScheduledTimeInfoItem.propTypes = {
   planId: PropTypes.string,
   migrationStarting: PropTypes.bool,
   showScheduledTime: PropTypes.bool,
-  migrationScheduled: PropTypes.oneOfType(PropTypes.number, PropTypes.string)
+  migrationScheduled: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
 };
 
 export default ScheduledTimeInfoItem;


### PR DESCRIPTION
When I reviewed #1067 I missed the new warning that appeared:

```
Warning: Invalid argument supplied to oneOfType, expected an instance of array.
```

I always forget that `PropTypes.oneOfType` takes an array, this PR fixes it. Sorry @mzazrivec 