### PR TITLE
Rename max_concurrent_tasks_per_host setting

### DIFF
--- a/app/javascript/react/screens/App/Settings/__tests__/__snapshots__/SettingsActions.test.js.snap
+++ b/app/javascript/react/screens/App/Settings/__tests__/__snapshots__/SettingsActions.test.js.snap
@@ -170,8 +170,8 @@ Array [
         "transformation": Object {
           "limits": Object {
             "cpu_limit_per_host": 10,
-            "max_concurrent_tasks_per_ems": 10,
             "max_concurrent_tasks_per_conversion_host": 10,
+            "max_concurrent_tasks_per_ems": 10,
           },
         },
       },
@@ -208,8 +208,8 @@ Array [
         "transformation": Object {
           "limits": Object {
             "cpu_limit_per_host": 10,
-            "max_concurrent_tasks_per_ems": 10,
             "max_concurrent_tasks_per_conversion_host": 10,
+            "max_concurrent_tasks_per_ems": 10,
           },
         },
       },

--- a/app/javascript/react/screens/App/Settings/__tests__/__snapshots__/SettingsActions.test.js.snap
+++ b/app/javascript/react/screens/App/Settings/__tests__/__snapshots__/SettingsActions.test.js.snap
@@ -171,7 +171,7 @@ Array [
           "limits": Object {
             "cpu_limit_per_host": 10,
             "max_concurrent_tasks_per_ems": 10,
-            "max_concurrent_tasks_per_host": 10,
+            "max_concurrent_tasks_per_conversion_host": 10,
           },
         },
       },
@@ -209,7 +209,7 @@ Array [
           "limits": Object {
             "cpu_limit_per_host": 10,
             "max_concurrent_tasks_per_ems": 10,
-            "max_concurrent_tasks_per_host": 10,
+            "max_concurrent_tasks_per_conversion_host": 10,
           },
         },
       },

--- a/app/javascript/react/screens/App/Settings/__tests__/__snapshots__/SettingsReducer.test.js.snap
+++ b/app/javascript/react/screens/App/Settings/__tests__/__snapshots__/SettingsReducer.test.js.snap
@@ -587,8 +587,8 @@ Object {
   "postConversionHostsResults": Array [],
   "savedSettings": Object {
     "cpu_limit_per_host": 10,
-    "max_concurrent_tasks_per_ems": 10,
     "max_concurrent_tasks_per_conversion_host": 10,
+    "max_concurrent_tasks_per_ems": 10,
   },
   "savingSettingsRejected": false,
   "servers": Array [],
@@ -829,8 +829,8 @@ Object {
   "postConversionHostsResults": Array [],
   "savedSettings": Object {
     "cpu_limit_per_host": 10,
-    "max_concurrent_tasks_per_ems": 10,
     "max_concurrent_tasks_per_conversion_host": 10,
+    "max_concurrent_tasks_per_ems": 10,
   },
   "savingSettingsRejected": false,
   "servers": Array [],

--- a/app/javascript/react/screens/App/Settings/__tests__/__snapshots__/SettingsReducer.test.js.snap
+++ b/app/javascript/react/screens/App/Settings/__tests__/__snapshots__/SettingsReducer.test.js.snap
@@ -588,7 +588,7 @@ Object {
   "savedSettings": Object {
     "cpu_limit_per_host": 10,
     "max_concurrent_tasks_per_ems": 10,
-    "max_concurrent_tasks_per_host": 10,
+    "max_concurrent_tasks_per_conversion_host": 10,
   },
   "savingSettingsRejected": false,
   "servers": Array [],
@@ -830,7 +830,7 @@ Object {
   "savedSettings": Object {
     "cpu_limit_per_host": 10,
     "max_concurrent_tasks_per_ems": 10,
-    "max_concurrent_tasks_per_host": 10,
+    "max_concurrent_tasks_per_conversion_host": 10,
   },
   "savingSettingsRejected": false,
   "servers": Array [],

--- a/app/javascript/react/screens/App/Settings/helpers.js
+++ b/app/javascript/react/screens/App/Settings/helpers.js
@@ -2,7 +2,7 @@ import { FINISHED, ERROR } from './screens/ConversionHostsSettings/ConversionHos
 import { RHV, OPENSTACK } from '../../../../common/constants';
 
 export const getFormValuesFromApiSettings = payload => ({
-  max_concurrent_tasks_per_host: payload.transformation.limits.max_concurrent_tasks_per_host,
+  max_concurrent_tasks_per_conversion_host: payload.transformation.limits.max_concurrent_tasks_per_conversion_host,
   max_concurrent_tasks_per_ems: payload.transformation.limits.max_concurrent_tasks_per_ems,
   cpu_limit_per_host: payload.transformation.limits.cpu_limit_per_host
 });
@@ -10,7 +10,7 @@ export const getFormValuesFromApiSettings = payload => ({
 export const getApiSettingsFromFormValues = values => ({
   transformation: {
     limits: {
-      max_concurrent_tasks_per_host: values.max_concurrent_tasks_per_host,
+      max_concurrent_tasks_per_conversion_host: values.max_concurrent_tasks_per_conversion_host,
       max_concurrent_tasks_per_ems: values.max_concurrent_tasks_per_ems,
       cpu_limit_per_host: values.cpu_limit_per_host
     }

--- a/app/javascript/react/screens/App/Settings/screens/GeneralSettings/GeneralSettings.js
+++ b/app/javascript/react/screens/App/Settings/screens/GeneralSettings/GeneralSettings.js
@@ -28,7 +28,10 @@ export class GeneralSettings extends React.Component {
     } = this.props;
     if (fieldChanging === 'max_concurrent_tasks_per_conversion_host' && newValue > max_concurrent_tasks_per_ems) {
       formChangeAction(FORM_NAME, 'max_concurrent_tasks_per_ems', newValue);
-    } else if (fieldChanging === 'max_concurrent_tasks_per_ems' && newValue < max_concurrent_tasks_per_conversion_host) {
+    } else if (
+      fieldChanging === 'max_concurrent_tasks_per_ems' &&
+      newValue < max_concurrent_tasks_per_conversion_host
+    ) {
       formChangeAction(FORM_NAME, 'max_concurrent_tasks_per_conversion_host', newValue);
     }
   };

--- a/app/javascript/react/screens/App/Settings/screens/GeneralSettings/GeneralSettings.js
+++ b/app/javascript/react/screens/App/Settings/screens/GeneralSettings/GeneralSettings.js
@@ -22,14 +22,14 @@ export class GeneralSettings extends React.Component {
   enforceConstraintsOnChange = (event, newValue, prevValue, fieldChanging) => {
     const {
       settingsForm: {
-        values: { max_concurrent_tasks_per_host, max_concurrent_tasks_per_ems }
+        values: { max_concurrent_tasks_per_conversion_host, max_concurrent_tasks_per_ems }
       },
       formChangeAction
     } = this.props;
-    if (fieldChanging === 'max_concurrent_tasks_per_host' && newValue > max_concurrent_tasks_per_ems) {
+    if (fieldChanging === 'max_concurrent_tasks_per_conversion_host' && newValue > max_concurrent_tasks_per_ems) {
       formChangeAction(FORM_NAME, 'max_concurrent_tasks_per_ems', newValue);
-    } else if (fieldChanging === 'max_concurrent_tasks_per_ems' && newValue < max_concurrent_tasks_per_host) {
-      formChangeAction(FORM_NAME, 'max_concurrent_tasks_per_host', newValue);
+    } else if (fieldChanging === 'max_concurrent_tasks_per_ems' && newValue < max_concurrent_tasks_per_conversion_host) {
+      formChangeAction(FORM_NAME, 'max_concurrent_tasks_per_conversion_host', newValue);
     }
   };
 
@@ -88,8 +88,8 @@ export class GeneralSettings extends React.Component {
               </Form.ControlLabel>
               <div style={{ width: 150 }}>
                 <Field
-                  id="max_concurrent_tasks_per_host"
-                  name="max_concurrent_tasks_per_host"
+                  id="max_concurrent_tasks_per_conversion_host"
+                  name="max_concurrent_tasks_per_conversion_host"
                   component={NumberInput}
                   normalize={NumberInput.normalizeStringToInt}
                   min={1}

--- a/app/javascript/react/screens/App/Settings/screens/GeneralSettings/__tests__/__snapshots__/GeneralSettings.test.js.snap
+++ b/app/javascript/react/screens/App/Settings/screens/GeneralSettings/__tests__/__snapshots__/GeneralSettings.test.js.snap
@@ -89,9 +89,9 @@ exports[`GeneralSettings component renders the general settings page 1`] = `
         >
           <Field
             component={[Function]}
-            id="max_concurrent_tasks_per_host"
+            id="max_concurrent_tasks_per_conversion_host"
             min={1}
-            name="max_concurrent_tasks_per_host"
+            name="max_concurrent_tasks_per_conversion_host"
             normalize={[Function]}
             onChange={[Function]}
           />

--- a/app/javascript/react/screens/App/Settings/settings.fixtures.js
+++ b/app/javascript/react/screens/App/Settings/settings.fixtures.js
@@ -18,7 +18,7 @@ export const servers = Immutable({
 export const settings = Immutable({
   transformation: {
     limits: {
-      max_concurrent_tasks_per_host: 10,
+      max_concurrent_tasks_per_conversion_host: 10,
       max_concurrent_tasks_per_ems: 10,
       cpu_limit_per_host: 10
     }
@@ -29,7 +29,7 @@ export const settings = Immutable({
 });
 
 export const settingsFormValues = Immutable({
-  max_concurrent_tasks_per_host: 10,
+  max_concurrent_tasks_per_conversion_host: 10,
   max_concurrent_tasks_per_ems: 10,
   cpu_limit_per_host: 10
 });


### PR DESCRIPTION
To implement https://github.com/ManageIQ/manageiq/issues/19562, we will want to have a new setting to configure the maximum number of concurrent conversions per VMware host, with a default to 20. Looking at the existing settings, it appears that renaming max_concurrent_tasks_per_host into max_concurrent_tasks_per_conversion_host would make sense to reduce confusion.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1777274
Depends on: https://github.com/ManageIQ/manageiq/pull/19563