### PR TITLE
[IVANCHUK] (Fix for earlier backport) Convert data size units from GB to GiB

### DIFF
--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsInProgressCard.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsInProgressCard.js
@@ -246,8 +246,8 @@ const MigrationsInProgressCard = ({
     }
   });
 
-  const totalDiskSpaceGb = numeral(totalDiskSpace).format('0.00b');
-  const totalMigratedDiskSpaceGb = numeral(totalMigratedDiskSpace).format('0.00b');
+  const totalDiskSpaceGb = numeral(totalDiskSpace).format('0.00 ib');
+  const totalMigratedDiskSpaceGb = numeral(totalMigratedDiskSpace).format('0.00 ib');
 
   // UX business rule: if all disks have been migrated and we have a post migration playbook running, show this instead
   if (totalMigratedDiskSpaceGb >= totalDiskSpaceGb && taskRunningPostMigrationPlaybook) {


### PR DESCRIPTION
The backport of https://github.com/ManageIQ/manageiq-v2v/pull/1050 left these two instances of the data size units unfixed because they were no longer on master. I should have opened a special PR to backport it like I did for hammer.

We don't need to un-backport the original commit, but this PR fixes it. cc @simaishi 

https://bugzilla.redhat.com/show_bug.cgi?id=1767902