### PR TITLE
[Part of BZ#1789479] UI changes for UCI: use VMs instead of Hosts for RHV conversion host configuration

### DIFF
--- a/app/javascript/common/constants.js
+++ b/app/javascript/common/constants.js
@@ -36,8 +36,10 @@ export const V2V_TARGET_PROVIDERS = [
 ];
 
 export const CONVERSION_HOST_TYPES = {
-  [RHV]: 'ManageIQ::Providers::Redhat::InfraManager::Host',
-  [OPENSTACK]: 'ManageIQ::Providers::Openstack::CloudManager::Vm'
+  // With UCI support, all new conversion hosts must be VMs. But, RHV conversion hosts
+  // could have been configured pre-UCI on a Host, so those are still valid when checking for CHs.
+  [RHV]: ['ManageIQ::Providers::Redhat::InfraManager::Vm', 'ManageIQ::Providers::Redhat::InfraManager::Host'],
+  [OPENSTACK]: ['ManageIQ::Providers::Openstack::CloudManager::Vm']
 };
 
 export const TRANSFORMATION_MAPPING_ITEM_SOURCE_TYPES = {

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardClustersStep/MappingWizardClustersStepSelectors.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardClustersStep/MappingWizardClustersStepSelectors.js
@@ -12,4 +12,4 @@ export const sourceClustersFilter = (sourceClustersToFilter, clustersStepMapping
 };
 
 export const conversionHostsFilter = (conversionHosts, providerType) =>
-  conversionHosts.filter(host => host.resource && host.resource.type === CONVERSION_HOST_TYPES[providerType]);
+  conversionHosts.filter(host => host.resource && CONVERSION_HOST_TYPES[providerType].includes(host.resource.type));

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardHostsStep/ConversionHostWizardHostsStep.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardHostsStep/ConversionHostWizardHostsStep.js
@@ -17,12 +17,12 @@ const ConversionHostWizardHostsStep = ({
   let hostOptions = [];
   let emptyLabel = '';
   if (selectedProviderType === RHV) {
-    hostOptions = selectedCluster.hosts;
-    emptyLabel = __('No hosts available for the selected cluster.');
+    hostOptions = selectedCluster.vms;
+    emptyLabel = __('No VMs available for the selected cluster.');
   }
   if (selectedProviderType === OPENSTACK) {
     hostOptions = selectedCluster.vms;
-    emptyLabel = __('No hosts available for the selected project.');
+    emptyLabel = __('No VMs available for the selected project.');
   }
   const filteredHostOptions = hostOptions.filter(host => {
     // Don't allow selection of hosts already configured as conversion hosts
@@ -37,7 +37,7 @@ const ConversionHostWizardHostsStep = ({
   return (
     <Form className="form-vertical">
       <Form.FormGroup controlId="host-selection">
-        <Form.ControlLabel>{__('Hosts to configure as conversion hosts')}</Form.ControlLabel>
+        <Form.ControlLabel>{__('VMs to configure as conversion hosts')}</Form.ControlLabel>
         <Field
           component={TypeAheadSelectField}
           name="hosts"
@@ -46,7 +46,7 @@ const ConversionHostWizardHostsStep = ({
           clearButton
           options={filteredHostOptions}
           labelKey="name"
-          placeholder={__('Select one or more hosts...')}
+          placeholder={__('Select one or more VMs...')}
           emptyLabel={hostOptions.length === 0 ? emptyLabel : __('No matches found.')}
           highlightOnlyResult
           selectHintOnEnter

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardHostsStep/__tests__/ConversionHostWizardHostsStep.test.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardHostsStep/__tests__/ConversionHostWizardHostsStep.test.js
@@ -8,19 +8,19 @@ import ConversionHostWizardHostsStep from '../ConversionHostWizardHostsStep';
 import { RHV, CONVERSION_HOST_TYPES, OPENSTACK } from '../../../../../../../../../../common/constants';
 import { FINISHED } from '../../../../ConversionHostsSettingsConstants';
 
-const mockConfiguredRhvHost = { id: '1', name: 'already-configured-host', type: CONVERSION_HOST_TYPES[RHV] };
-const mockInProgressRhvHost = { id: '2', name: 'host-being-configured', type: CONVERSION_HOST_TYPES[RHV] };
+const mockConfiguredRhvHost = { id: '1', name: 'already-configured-host', type: CONVERSION_HOST_TYPES[RHV][0] };
+const mockInProgressRhvHost = { id: '2', name: 'host-being-configured', type: CONVERSION_HOST_TYPES[RHV][0] };
 
-const mockConfiguredOspVm = { id: '1', name: 'already-configured-vm', type: CONVERSION_HOST_TYPES[OPENSTACK] };
-const mockInProgressOspVm = { id: '2', name: 'vm-being-configured', type: CONVERSION_HOST_TYPES[OPENSTACK] };
+const mockConfiguredOspVm = { id: '1', name: 'already-configured-vm', type: CONVERSION_HOST_TYPES[OPENSTACK][0] };
+const mockInProgressOspVm = { id: '2', name: 'vm-being-configured', type: CONVERSION_HOST_TYPES[OPENSTACK][0] };
 
 const mockRhvCluster = {
   mock: 'cluster',
-  hosts: [
+  vms: [
     mockConfiguredRhvHost,
     mockInProgressRhvHost,
-    { id: '3', name: 'available-host-1', type: CONVERSION_HOST_TYPES[RHV] },
-    { id: '4', name: 'available-host-2', type: CONVERSION_HOST_TYPES[RHV] }
+    { id: '3', name: 'available-host-1', type: CONVERSION_HOST_TYPES[RHV][0] },
+    { id: '4', name: 'available-host-2', type: CONVERSION_HOST_TYPES[RHV][0] }
   ]
 };
 
@@ -29,8 +29,8 @@ const mockOspTenant = {
   vms: [
     mockConfiguredOspVm,
     mockInProgressOspVm,
-    { id: '3', name: 'available-vm-1', type: CONVERSION_HOST_TYPES[OPENSTACK] },
-    { id: '4', name: 'available-vm-2', type: CONVERSION_HOST_TYPES[OPENSTACK] }
+    { id: '3', name: 'available-vm-1', type: CONVERSION_HOST_TYPES[OPENSTACK][0] },
+    { id: '4', name: 'available-vm-2', type: CONVERSION_HOST_TYPES[OPENSTACK][0] }
   ]
 };
 
@@ -46,11 +46,11 @@ const mockConversionHosts = [
 ];
 
 const mockTasksByResource = {
-  [CONVERSION_HOST_TYPES[RHV]]: {
+  [CONVERSION_HOST_TYPES[RHV][0]]: {
     '1': { enable: [{ mock: 'task', state: FINISHED }] },
     '2': { enable: [{ mock: 'task', state: 'Active' }] }
   },
-  [CONVERSION_HOST_TYPES[OPENSTACK]]: {
+  [CONVERSION_HOST_TYPES[OPENSTACK][0]]: {
     '1': { enable: [{ mock: 'task', state: FINISHED }] },
     '2': { enable: [{ mock: 'task', state: 'Active' }] }
   }
@@ -126,7 +126,7 @@ describe('conversion host wizard hosts step', () => {
   });
 
   it('renders correctly when there are no hosts available', () => {
-    const component = shallowDive(<ConversionHostWizardHostsStep {...baseProps} selectedCluster={{ hosts: [] }} />);
+    const component = shallowDive(<ConversionHostWizardHostsStep {...baseProps} selectedCluster={{ vms: [] }} />);
     expect(component).toMatchSnapshot();
   });
 });

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardHostsStep/__tests__/__snapshots__/ConversionHostWizardHostsStep.test.js.snap
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardHostsStep/__tests__/__snapshots__/ConversionHostWizardHostsStep.test.js.snap
@@ -23,7 +23,7 @@ exports[`conversion host wizard hosts step renders correctly in the OSP example 
           ],
         },
       },
-      "ManageIQ::Providers::Redhat::InfraManager::Host": Object {
+      "ManageIQ::Providers::Redhat::InfraManager::Vm": Object {
         "1": Object {
           "enable": Array [
             Object {
@@ -50,7 +50,7 @@ exports[`conversion host wizard hosts step renders correctly in the OSP example 
         "resource": Object {
           "id": "1",
           "name": "already-configured-host",
-          "type": "ManageIQ::Providers::Redhat::InfraManager::Host",
+          "type": "ManageIQ::Providers::Redhat::InfraManager::Vm",
         },
       },
       Object {
@@ -147,7 +147,7 @@ exports[`conversion host wizard hosts step renders correctly in the RHV example 
           ],
         },
       },
-      "ManageIQ::Providers::Redhat::InfraManager::Host": Object {
+      "ManageIQ::Providers::Redhat::InfraManager::Vm": Object {
         "1": Object {
           "enable": Array [
             Object {
@@ -174,7 +174,7 @@ exports[`conversion host wizard hosts step renders correctly in the RHV example 
         "resource": Object {
           "id": "1",
           "name": "already-configured-host",
-          "type": "ManageIQ::Providers::Redhat::InfraManager::Host",
+          "type": "ManageIQ::Providers::Redhat::InfraManager::Vm",
         },
       },
       Object {
@@ -202,29 +202,29 @@ exports[`conversion host wizard hosts step renders correctly in the RHV example 
   pure={true}
   selectedCluster={
     Object {
-      "hosts": Array [
+      "mock": "cluster",
+      "vms": Array [
         Object {
           "id": "1",
           "name": "already-configured-host",
-          "type": "ManageIQ::Providers::Redhat::InfraManager::Host",
+          "type": "ManageIQ::Providers::Redhat::InfraManager::Vm",
         },
         Object {
           "id": "2",
           "name": "host-being-configured",
-          "type": "ManageIQ::Providers::Redhat::InfraManager::Host",
+          "type": "ManageIQ::Providers::Redhat::InfraManager::Vm",
         },
         Object {
           "id": "3",
           "name": "available-host-1",
-          "type": "ManageIQ::Providers::Redhat::InfraManager::Host",
+          "type": "ManageIQ::Providers::Redhat::InfraManager::Vm",
         },
         Object {
           "id": "4",
           "name": "available-host-2",
-          "type": "ManageIQ::Providers::Redhat::InfraManager::Host",
+          "type": "ManageIQ::Providers::Redhat::InfraManager::Vm",
         },
       ],
-      "mock": "cluster",
     }
   }
   selectedProviderType="rhevm"
@@ -271,7 +271,7 @@ exports[`conversion host wizard hosts step renders correctly when there are no h
           ],
         },
       },
-      "ManageIQ::Providers::Redhat::InfraManager::Host": Object {
+      "ManageIQ::Providers::Redhat::InfraManager::Vm": Object {
         "1": Object {
           "enable": Array [
             Object {
@@ -298,7 +298,7 @@ exports[`conversion host wizard hosts step renders correctly when there are no h
         "resource": Object {
           "id": "1",
           "name": "already-configured-host",
-          "type": "ManageIQ::Providers::Redhat::InfraManager::Host",
+          "type": "ManageIQ::Providers::Redhat::InfraManager::Vm",
         },
       },
       Object {
@@ -326,7 +326,7 @@ exports[`conversion host wizard hosts step renders correctly when there are no h
   pure={true}
   selectedCluster={
     Object {
-      "hosts": Array [],
+      "vms": Array [],
     }
   }
   selectedProviderType="rhevm"
@@ -372,7 +372,7 @@ exports[`conversion host wizard hosts step renders the redux-form wrapper correc
           ],
         },
       },
-      "ManageIQ::Providers::Redhat::InfraManager::Host": Object {
+      "ManageIQ::Providers::Redhat::InfraManager::Vm": Object {
         "1": Object {
           "enable": Array [
             Object {
@@ -399,7 +399,7 @@ exports[`conversion host wizard hosts step renders the redux-form wrapper correc
         "resource": Object {
           "id": "1",
           "name": "already-configured-host",
-          "type": "ManageIQ::Providers::Redhat::InfraManager::Host",
+          "type": "ManageIQ::Providers::Redhat::InfraManager::Vm",
         },
       },
       Object {
@@ -428,29 +428,29 @@ exports[`conversion host wizard hosts step renders the redux-form wrapper correc
   pure={true}
   selectedCluster={
     Object {
-      "hosts": Array [
+      "mock": "cluster",
+      "vms": Array [
         Object {
           "id": "1",
           "name": "already-configured-host",
-          "type": "ManageIQ::Providers::Redhat::InfraManager::Host",
+          "type": "ManageIQ::Providers::Redhat::InfraManager::Vm",
         },
         Object {
           "id": "2",
           "name": "host-being-configured",
-          "type": "ManageIQ::Providers::Redhat::InfraManager::Host",
+          "type": "ManageIQ::Providers::Redhat::InfraManager::Vm",
         },
         Object {
           "id": "3",
           "name": "available-host-1",
-          "type": "ManageIQ::Providers::Redhat::InfraManager::Host",
+          "type": "ManageIQ::Providers::Redhat::InfraManager::Vm",
         },
         Object {
           "id": "4",
           "name": "available-host-2",
-          "type": "ManageIQ::Providers::Redhat::InfraManager::Host",
+          "type": "ManageIQ::Providers::Redhat::InfraManager::Vm",
         },
       ],
-      "mock": "cluster",
     }
   }
   selectedProviderType="rhevm"

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardHostsStep/__tests__/__snapshots__/index.test.js.snap
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardHostsStep/__tests__/__snapshots__/index.test.js.snap
@@ -25,9 +25,9 @@ Object {
   "persistentSubmitErrors": false,
   "pure": true,
   "selectedCluster": Object {
-    "hosts": Array [],
     "id": "1",
     "mock": "cluster",
+    "vms": Array [],
   },
   "selectedProviderType": "rhevm",
   "shouldAsyncValidate": [Function],

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardHostsStep/__tests__/index.test.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardHostsStep/__tests__/index.test.js
@@ -13,7 +13,7 @@ describe('ConversionHostWizardHostsStep integration test', () => {
     { form: formReducer },
     {
       form: { conversionHostWizardLocationStep: { values: { providerType: RHV, cluster: '1' } } },
-      targetResources: { targetClusters: [{ mock: 'cluster', id: '1', hosts: [] }] },
+      targetResources: { targetClusters: [{ mock: 'cluster', id: '1', vms: [] }] },
       settings: {
         conversionHosts: [{ mock: 'conversionHost1' }, { mock: 'conversionHost2' }],
         conversionHostTasksByResource: { mock: 'tasksByResource' }

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/RetryConversionHostConfirmationModal/RetryConversionHostConfirmationModal.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/RetryConversionHostConfirmationModal/RetryConversionHostConfirmationModal.js
@@ -24,8 +24,8 @@ export const RetryConversionHostConfirmationModal = ({
     conversionHostTaskToRetry.context_data.request_params;
   const isUsingSshTransformation = !requestParams.vmware_vddk_package_url;
 
-  const selectedProviderType = Object.keys(CONVERSION_HOST_TYPES).find(
-    key => CONVERSION_HOST_TYPES[key] === requestParams.resource_type
+  const selectedProviderType = Object.keys(CONVERSION_HOST_TYPES).find(key =>
+    CONVERSION_HOST_TYPES[key].includes(requestParams.resource_type)
   );
   const formHasErrors = retryForm && !!retryForm.syncErrors;
 

--- a/app/javascript/react/screens/App/common/forms/TypeAheadSelectField.js
+++ b/app/javascript/react/screens/App/common/forms/TypeAheadSelectField.js
@@ -4,7 +4,13 @@ import { TypeAheadSelect } from 'patternfly-react';
 
 // Wraps TypeAheadSelect for use as the `component` prop of a redux-form Field.
 const TypeAheadSelectField = ({ input: { value, onChange }, controlId, ...props }) => (
-  <TypeAheadSelect selected={value} onChange={onChange} inputProps={{ id: controlId }} {...props} />
+  <TypeAheadSelect
+    selected={value}
+    onChange={onChange}
+    inputProps={{ id: controlId }}
+    id={`typeahead-${controlId}`}
+    {...props}
+  />
 );
 
 TypeAheadSelectField.propTypes = {

--- a/app/javascript/redux/common/targetResources/targetResourcesConstants.js
+++ b/app/javascript/redux/common/targetResources/targetResourcesConstants.js
@@ -5,7 +5,7 @@ export const FETCH_V2V_TARGET_CLUSTERS = 'FETCH_V2V_TARGET_CLUSTERS';
 export const FETCH_TARGET_COMPUTE_URLS = {
   [RHV]:
     '/api/clusters?expand=resources' +
-    '&attributes=ext_management_system.emstype,v_parent_datacenter,ext_management_system.name,hosts' +
+    '&attributes=ext_management_system.emstype,v_parent_datacenter,ext_management_system.name,hosts,vms' +
     '&filter[]=ext_management_system.emstype=rhevm',
   [OPENSTACK]:
     '/api/cloud_tenants?expand=resources&filter[]=ext_management_system.type=ManageIQ::Providers::Openstack::CloudManager&attributes=ext_management_system.name,ext_management_system.id,vms'


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1789479
JIRA: https://issues.redhat.com/browse/MIGENG-316

When configuring a RHV conversion host, we now choose from VMs instead of Hosts. I've updated the messaging on that step of the wizard to refer to "Select VMs" / "VMs to configure as conversion hosts" etc, since it will now always be VMs regardless of provider type.

The `CONVERSION_HOST_TYPES` constant, which is used for filtering conversion hosts by provider type via their resource_type, now includes both the Vm and Host types for RHV. This is to support legacy conversion hosts that were configured before UCI support was added.

I also added an `id` prop to the `TypeAheadSelect` in this step of the wizard because I was seeing warnings that it will be required in a future version of `react-bootstrap-typeahead`.