### PR TITLE
[#1072] [BZ#1775998] Fix logic for providers check on Conversion Hosts Settings page

### DIFF
--- a/app/javascript/react/screens/App/Overview/__test__/__snapshots__/index.test.js.snap
+++ b/app/javascript/react/screens/App/Overview/__test__/__snapshots__/index.test.js.snap
@@ -34,6 +34,7 @@ Object {
   "fetchTransformationPlansUrl": "/api/dummyTransformationPlans",
   "finishedTransformationPlans": Array [],
   "hasSufficientProviders": false,
+  "hasTargetProvider": false,
   "hideConfirmModalAction": [Function],
   "hideEditPlanNameModalAction": [Function],
   "hideMappingWizard": false,

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/ConversionHostsSettings.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/ConversionHostsSettings.js
@@ -64,7 +64,7 @@ class ConversionHostsSettings extends React.Component {
   render() {
     const {
       isFetchingProviders,
-      hasSufficientProviders,
+      hasTargetProvider,
       combinedListItems,
       setHostToDeleteAction,
       showConversionHostDeleteModalAction,
@@ -90,7 +90,7 @@ class ConversionHostsSettings extends React.Component {
 
     return (
       <Spinner loading={isFetchingProviders || !hasMadeInitialFetch} style={{ marginTop: 15 }}>
-        {!hasSufficientProviders ? (
+        {!hasTargetProvider ? (
           <NoProvidersEmptyState
             className="full-page-empty"
             description={
@@ -154,7 +154,7 @@ ConversionHostsSettings.propTypes = {
   fetchProvidersUrl: PropTypes.string,
   fetchProvidersAction: PropTypes.func,
   isFetchingProviders: PropTypes.bool,
-  hasSufficientProviders: PropTypes.bool,
+  hasTargetProvider: PropTypes.bool,
   fetchConversionHostsUrl: PropTypes.string,
   fetchConversionHostsAction: PropTypes.func,
   fetchConversionHostTasksAction: PropTypes.func,

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/__tests__/ConversionHostsSettings.test.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/__tests__/ConversionHostsSettings.test.js
@@ -11,7 +11,7 @@ const getBaseProps = () => ({
   deleteConversionHostAction: jest.fn(),
   fetchProvidersAction: jest.fn(),
   isFetchingProviders: false,
-  hasSufficientProviders: true,
+  hasTargetProvider: true,
   fetchConversionHostsAction: jest.fn(() => Promise.resolve()),
   fetchConversionHostTasksAction: jest.fn(() => Promise.resolve()),
   combinedListItems: [],
@@ -37,7 +37,7 @@ describe('ConversionHostsSettings component', () => {
   });
 
   it('renders an empty state when insufficient providers are present', () => {
-    const component = shallow(<ConversionHostsSettings {...getBaseProps()} hasSufficientProviders={false} />);
+    const component = shallow(<ConversionHostsSettings {...getBaseProps()} hasTargetProvider={false} />);
     expect(component.find(NoProvidersEmptyState)).toHaveLength(1);
     expect(component.find(ConversionHostsEmptyState)).toHaveLength(0);
     expect(component.find(ConversionHostsList)).toHaveLength(0);

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/__tests__/__snapshots__/index.test.js.snap
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/__tests__/__snapshots__/index.test.js.snap
@@ -15,7 +15,7 @@ Object {
   "fetchConversionHostsUrl": "/api/conversion_hosts?attributes=resource&expand=resources",
   "fetchProvidersAction": [Function],
   "fetchProvidersUrl": "/api/providers?expand=resources&attributes=authentications",
-  "hasSufficientProviders": false,
+  "hasTargetProvider": false,
   "hideConversionHostDeleteModalAction": [Function],
   "isDeletingConversionHost": false,
   "isFetchingProviders": true,

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/index.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/index.js
@@ -19,7 +19,7 @@ import { getCombinedConversionHostListItems } from '../../helpers';
 
 const mapStateToProps = (
   {
-    providers: { isFetchingProviders, hasSufficientProviders },
+    providers: { isFetchingProviders, hasTargetProvider },
     settings: {
       conversionHosts,
       conversionHostTasks,
@@ -35,7 +35,7 @@ const mapStateToProps = (
   ownProps
 ) => ({
   isFetchingProviders,
-  hasSufficientProviders,
+  hasTargetProvider,
   combinedListItems: getCombinedConversionHostListItems(
     conversionHosts,
     conversionHostTasks,

--- a/app/javascript/redux/common/providers/__tests__/providersHelpers.test.js
+++ b/app/javascript/redux/common/providers/__tests__/providersHelpers.test.js
@@ -1,4 +1,52 @@
-import { sufficientProviders } from '../providersHelpers';
+import { sufficientProviders, checkTargetProviders, checkSourceProviders } from '../providersHelpers';
+
+const VMWARE_TYPE = 'ManageIQ::Providers::Vmware::InfraManager';
+const RHV_TYPE = 'ManageIQ::Providers::Redhat::InfraManager';
+const OSP_TYPE = 'ManageIQ::Providers::Openstack::CloudManager';
+
+describe('checkSourceProviders helper', () => {
+  test('false when there are no providers', () => {
+    expect(checkSourceProviders()).toBeFalsy();
+    expect(checkSourceProviders([])).toBeFalsy();
+  });
+
+  test('false when only a target provider exists', () => {
+    expect(checkSourceProviders([{ type: RHV_TYPE }])).toBeFalsy();
+    expect(checkSourceProviders([{ type: OSP_TYPE }])).toBeFalsy();
+  });
+
+  test('true when only a source provider exists', () => {
+    expect(checkSourceProviders([{ type: VMWARE_TYPE }])).toBeTruthy();
+  });
+
+  test('true when both a source and a target provider exist', () => {
+    expect(sufficientProviders([{ type: VMWARE_TYPE }, { type: RHV_TYPE }])).toBeTruthy();
+    expect(sufficientProviders([{ type: VMWARE_TYPE }, { type: OSP_TYPE }])).toBeTruthy();
+    expect(sufficientProviders([{ type: VMWARE_TYPE }, { type: RHV_TYPE }, { type: OSP_TYPE }])).toBeTruthy();
+  });
+});
+
+describe('checkTargetProviders helper', () => {
+  test('false when there are no providers', () => {
+    expect(checkTargetProviders()).toBeFalsy();
+    expect(checkTargetProviders([])).toBeFalsy();
+  });
+
+  test('true when only a target provider exists', () => {
+    expect(checkTargetProviders([{ type: RHV_TYPE }])).toBeTruthy();
+    expect(checkTargetProviders([{ type: OSP_TYPE }])).toBeTruthy();
+  });
+
+  test('false when only a source provider exists', () => {
+    expect(checkTargetProviders([{ type: VMWARE_TYPE }])).toBeFalsy();
+  });
+
+  test('true when both a source and a target provider exist', () => {
+    expect(sufficientProviders([{ type: VMWARE_TYPE }, { type: RHV_TYPE }])).toBeTruthy();
+    expect(sufficientProviders([{ type: VMWARE_TYPE }, { type: OSP_TYPE }])).toBeTruthy();
+    expect(sufficientProviders([{ type: VMWARE_TYPE }, { type: RHV_TYPE }, { type: OSP_TYPE }])).toBeTruthy();
+  });
+});
 
 describe('sufficientProviders helper', () => {
   test('false when there are no providers', () => {
@@ -7,39 +55,18 @@ describe('sufficientProviders helper', () => {
   });
 
   test('false when only a source provider exists', () => {
-    expect(sufficientProviders([{ type: 'ManageIQ::Providers::Vmware::InfraManager' }])).toBeFalsy();
+    expect(sufficientProviders([{ type: VMWARE_TYPE }])).toBeFalsy();
   });
 
   test('false when only a target provider exists', () => {
-    expect(sufficientProviders([{ type: 'ManageIQ::Providers::Redhat::InfraManager' }])).toBeFalsy();
-    expect(sufficientProviders([{ type: 'ManageIQ::Providers::Openstack::CloudManager' }])).toBeFalsy();
-    expect(
-      sufficientProviders([
-        { type: 'ManageIQ::Providers::Redhat::InfraManager' },
-        { type: 'ManageIQ::Providers::Openstack::CloudManager' }
-      ])
-    ).toBeFalsy();
+    expect(sufficientProviders([{ type: RHV_TYPE }])).toBeFalsy();
+    expect(sufficientProviders([{ type: OSP_TYPE }])).toBeFalsy();
+    expect(sufficientProviders([{ type: RHV_TYPE }, { type: OSP_TYPE }])).toBeFalsy();
   });
 
   test('true when both a source and a target provider exist', () => {
-    expect(
-      sufficientProviders([
-        { type: 'ManageIQ::Providers::Vmware::InfraManager' },
-        { type: 'ManageIQ::Providers::Redhat::InfraManager' }
-      ])
-    ).toBeTruthy();
-    expect(
-      sufficientProviders([
-        { type: 'ManageIQ::Providers::Vmware::InfraManager' },
-        { type: 'ManageIQ::Providers::Openstack::CloudManager' }
-      ])
-    ).toBeTruthy();
-    expect(
-      sufficientProviders([
-        { type: 'ManageIQ::Providers::Vmware::InfraManager' },
-        { type: 'ManageIQ::Providers::Redhat::InfraManager' },
-        { type: 'ManageIQ::Providers::Openstack::CloudManager' }
-      ])
-    ).toBeTruthy();
+    expect(sufficientProviders([{ type: VMWARE_TYPE }, { type: RHV_TYPE }])).toBeTruthy();
+    expect(sufficientProviders([{ type: VMWARE_TYPE }, { type: OSP_TYPE }])).toBeTruthy();
+    expect(sufficientProviders([{ type: VMWARE_TYPE }, { type: RHV_TYPE }, { type: OSP_TYPE }])).toBeTruthy();
   });
 });

--- a/app/javascript/redux/common/providers/__tests__/providersReducer.test.js
+++ b/app/javascript/redux/common/providers/__tests__/providersReducer.test.js
@@ -34,6 +34,7 @@ describe('fetching providers', () => {
       isRejectedProviders: false,
       errorFetchingProviders: null,
       hasSufficientProviders: true,
+      hasTargetProvider: true,
       providers: providers.resources
     });
   });

--- a/app/javascript/redux/common/providers/providersHelpers.js
+++ b/app/javascript/redux/common/providers/providersHelpers.js
@@ -1,5 +1,9 @@
 import { PROVIDERS } from '../providers/providersConstants';
 
-export const sufficientProviders = (providers = []) =>
-  providers.some(provider => PROVIDERS.source.includes(provider.type)) &&
+export const checkSourceProviders = (providers = []) =>
+  providers.some(provider => PROVIDERS.source.includes(provider.type));
+export const checkTargetProviders = (providers = []) =>
   providers.some(provider => PROVIDERS.target.includes(provider.type));
+
+export const sufficientProviders = (providers = []) =>
+  checkSourceProviders(providers) && checkTargetProviders(providers);

--- a/app/javascript/redux/common/providers/providersReducer.js
+++ b/app/javascript/redux/common/providers/providersReducer.js
@@ -2,14 +2,15 @@ import Immutable from 'seamless-immutable';
 
 import { FETCH_V2V_PROVIDERS } from './providersConstants';
 import { validateProviders } from './providersValidators';
-import { sufficientProviders } from './providersHelpers';
+import { sufficientProviders, checkTargetProviders } from './providersHelpers';
 
 export const initialState = Immutable({
   isFetchingProviders: false,
   isRejectedProviders: false,
   errorFetchingProviders: null,
   providers: [],
-  hasSufficientProviders: false
+  hasSufficientProviders: false,
+  hasTargetProvider: false
 });
 
 export default (state = initialState, action) => {
@@ -32,6 +33,7 @@ export default (state = initialState, action) => {
         validateProviders(action.payload.data.resources);
         return insufficient
           .set('hasSufficientProviders', sufficientProviders(action.payload.data.resources))
+          .set('hasTargetProvider', checkTargetProviders(action.payload.data.resources))
           .set('providers', action.payload.data.resources);
       })();
     case `${FETCH_V2V_PROVIDERS}_REJECTED`:


### PR DESCRIPTION
Fix #1072 
The Conversion Hosts Settings page was sharing the same `hasSufficientProviders` logic as other pages, but the error messaging was inconsistent with that logic. Since you only need a target provider configured to set up a conversion host, I changed the logic to match the error messaging.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1775998