### PR TITLE
FormField: Don't render extraneous info popover

### DIFF
--- a/app/javascript/react/screens/App/common/forms/FormField.js
+++ b/app/javascript/react/screens/App/common/forms/FormField.js
@@ -106,8 +106,12 @@ export const FormField = ({
         </Grid.Col>
       )}
       <Grid.Col sm={Number.parseInt(controlWidth, 10) || 9} id={input.name}>
-        {!inline_label && <div style={{ fontSize: '15px', display: 'inline' }}>{label}</div>}
-        {renderInfoPopover()}
+        {!inline_label && (
+          <React.Fragment>
+            <div style={{ fontSize: '15px', display: 'inline' }}>{label}</div>
+            {renderInfoPopover()}
+          </React.Fragment>
+        )}
         {renderField()}
         {(help || (touched && error) || warning) && (
           <Form.HelpBlock>


### PR DESCRIPTION
Fixes: https://github.com/ManageIQ/manageiq-v2v/issues/1084

Example before:
![conv-host-before](https://user-images.githubusercontent.com/6648365/72349684-4adea900-36dd-11ea-9eda-a5c3ba33e18f.png)


Example after:
![conv-host-after](https://user-images.githubusercontent.com/6648365/72349698-4e723000-36dd-11ea-965e-c8792951430e.png)
