### PR TITLE
[#992][BZ#1752568] Fix "none found" / "all mapped" messages in networks and datastores steps of mapping wizard

### DIFF
--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardDatastoresStep/components/DatastoresStepForm/DatastoresStepForm.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardDatastoresStep/components/DatastoresStepForm/DatastoresStepForm.js
@@ -243,8 +243,18 @@ class DatastoresStepForm extends React.Component {
     input.onChange([]);
   };
 
-  allDatastoresMapped = filteredDatastores =>
-    !filteredDatastores.length && (
+  noDatastoresFound = (datastores, loading) =>
+    !datastores.length &&
+    !loading && (
+      <div className="dual-pane-mapper-item">
+        <Icon type="pf" name="error-circle-o" /> {__('No datastores found.')}
+      </div>
+    );
+
+  allDatastoresMapped = (sourceDatastores, filteredDatastores, loading) =>
+    !!sourceDatastores.length &&
+    !filteredDatastores.length &&
+    !loading && (
       <div className="dual-pane-mapper-item">
         <Icon type="pf" name="ok" /> {__('All source datastores have been mapped.')}
       </div>
@@ -267,10 +277,12 @@ class DatastoresStepForm extends React.Component {
       'is-hidden': !selectedCluster
     });
 
+    const filteredSourceDatastores = sourceDatastoreFilter(sourceDatastores, input.value);
+
     const sourceCounter = (
       <DualPaneMapperCount
         selectedItems={selectedSourceDatastores.length}
-        totalItems={sourceDatastoreFilter(sourceDatastores, input.value).length}
+        totalItems={filteredSourceDatastores.length}
       />
     );
 
@@ -293,7 +305,7 @@ class DatastoresStepForm extends React.Component {
           >
             {sourceDatastores && (
               <React.Fragment>
-                {sourceDatastoreFilter(sourceDatastores, input.value).map(item => (
+                {filteredSourceDatastores.map(item => (
                   <DualPaneMapperListItem
                     item={item}
                     text={sourceDatastoreInfo(item)}
@@ -306,7 +318,8 @@ class DatastoresStepForm extends React.Component {
                     handleKeyPress={this.selectSourceDatastore}
                   />
                 ))}
-                {this.allDatastoresMapped(sourceDatastoreFilter(sourceDatastores, input.value))}
+                {this.noDatastoresFound(sourceDatastores, isFetchingSourceDatastores)}
+                {this.allDatastoresMapped(sourceDatastores, filteredSourceDatastores, isFetchingSourceDatastores)}
               </React.Fragment>
             )}
           </DualPaneMapperList>

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardNetworksStep/components/NetworksStepForm/NetworksStepForm.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardNetworksStep/components/NetworksStepForm/NetworksStepForm.js
@@ -269,8 +269,18 @@ class NetworksStepForm extends React.Component {
     input.onChange([]);
   };
 
-  allNetworksMapped = filteredNetworks =>
-    !filteredNetworks.length && (
+  noNetworksFound = (networks, loading) =>
+    !networks.length &&
+    !loading && (
+      <div className="dual-pane-mapper-item">
+        <Icon type="pf" name="error-circle-o" /> {__('No networks found.')}
+      </div>
+    );
+
+  allNetworksMapped = (sourceNetworks, filteredNetworks, loading) =>
+    !!sourceNetworks.length &&
+    !filteredNetworks.length &&
+    !loading && (
       <div className="dual-pane-mapper-item">
         <Icon type="pf" name="ok" /> {__('All source networks have been mapped.')}
       </div>
@@ -293,11 +303,10 @@ class NetworksStepForm extends React.Component {
       'is-hidden': !selectedCluster
     });
 
+    const filteredSourceNetworks = sourceNetworksFilter(groupedSourceNetworks, input.value);
+
     const sourceCounter = (
-      <DualPaneMapperCount
-        selectedItems={selectedSourceNetworks.length}
-        totalItems={sourceNetworksFilter(groupedSourceNetworks, input.value).length}
-      />
+      <DualPaneMapperCount selectedItems={selectedSourceNetworks.length} totalItems={filteredSourceNetworks.length} />
     );
 
     const targetCounter = <DualPaneMapperCount selectedItems={selectedTargetNetwork ? 1 : 0} totalItems={1} />;
@@ -319,7 +328,7 @@ class NetworksStepForm extends React.Component {
           >
             {groupedSourceNetworks && (
               <React.Fragment>
-                {sourceNetworksFilter(groupedSourceNetworks, input.value).map(sourceNetwork => (
+                {filteredSourceNetworks.map(sourceNetwork => (
                   <DualPaneMapperListItem
                     item={sourceNetwork}
                     text={`${sourceNetwork.providerName} \\ ${selectedCluster.v_parent_datacenter} \\ ${
@@ -336,7 +345,8 @@ class NetworksStepForm extends React.Component {
                     handleKeyPress={this.selectSourceNetwork}
                   />
                 ))}
-                {this.allNetworksMapped(sourceNetworksFilter(groupedSourceNetworks, input.value))}
+                {this.noNetworksFound(groupedSourceNetworks, isFetchingSourceNetworks)}
+                {this.allNetworksMapped(groupedSourceNetworks, filteredSourceNetworks, isFetchingSourceNetworks)}
               </React.Fragment>
             )}
           </DualPaneMapperList>

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardNetworksStep/components/NetworksStepForm/NetworksStepForm.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardNetworksStep/components/NetworksStepForm/NetworksStepForm.js
@@ -269,16 +269,16 @@ class NetworksStepForm extends React.Component {
     input.onChange([]);
   };
 
-  noNetworksFound = (networks, loading) =>
-    !networks.length &&
+  noNetworksFound = (groupedSourceNetworks, loading) =>
+    !Object.keys(groupedSourceNetworks).length &&
     !loading && (
       <div className="dual-pane-mapper-item">
         <Icon type="pf" name="error-circle-o" /> {__('No networks found.')}
       </div>
     );
 
-  allNetworksMapped = (sourceNetworks, filteredNetworks, loading) =>
-    !!sourceNetworks.length &&
+  allNetworksMapped = (groupedSourceNetworks, filteredNetworks, loading) =>
+    !!Object.keys(groupedSourceNetworks).length &&
     !filteredNetworks.length &&
     !loading && (
       <div className="dual-pane-mapper-item">


### PR DESCRIPTION
Fix #992 
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1752568

In the unlikely event of an empty source cluster (no datastores found, or no networks found) the UI will now properly display "No [datastores/networks] found" instead of "All [datastores/networks] have been mapped".