### PR TITLE
Limit warm migration to RHV targets only

### DIFF
--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/PlanWizardSelectors.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/PlanWizardSelectors.js
@@ -86,16 +86,19 @@ export const getWarmMigrationCompatibility = ({
     vms
   });
 
+  const isRhvTarget = targetProviderType === RHV;
   const isEveryVmCompatible = vms.every(vm => vm.warm_migration_compatible);
   const areConversionHostsConfigured = targetClustersInPlan.every(targetCluster =>
     getAvailableConversionHostsForCluster({ settings, targetProviderType, targetCluster }).some(
       conversionHost => conversionHost.vddk_transport_supported
     )
   );
-  const shouldEnableWarmMigration = isEveryVmCompatible && areConversionHostsConfigured;
+
+  const shouldEnableWarmMigration = isRhvTarget && isEveryVmCompatible && areConversionHostsConfigured;
 
   return {
     isFetchingTargetValidationData: false,
+    isRhvTarget,
     isEveryVmCompatible,
     areConversionHostsConfigured,
     shouldEnableWarmMigration

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardScheduleStep/PlanWizardScheduleStep.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardScheduleStep/PlanWizardScheduleStep.js
@@ -34,6 +34,7 @@ export class PlanWizardScheduleStep extends React.Component {
         alertType: 'info'
       });
     }
+    // TODO if target isn't RHV, disallow warm migration and pop another alert
   }
 
   componentWillUnmount() {

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardScheduleStep/PlanWizardScheduleStep.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardScheduleStep/PlanWizardScheduleStep.js
@@ -7,9 +7,21 @@ import { FormField } from '../../../../../common/forms/FormField';
 export class PlanWizardScheduleStep extends React.Component {
   componentDidMount() {
     const {
-      warmMigrationCompatibility: { isEveryVmCompatible, areConversionHostsConfigured },
+      warmMigrationCompatibility: { isRhvTarget, isEveryVmCompatible, areConversionHostsConfigured },
       showAlertAction
     } = this.props;
+    if (!isRhvTarget) {
+      showAlertAction({
+        alertId: 'warmMigrationNonRhvTarget',
+        alertText: (
+          <span>
+            <strong>{__('Warm migration not supported.')}</strong>{' '}
+            {__('Warm migration is currently only supported for Red Hat Virtualization targets.')}
+          </span>
+        ),
+        alertType: 'info'
+      });
+    }
     if (!isEveryVmCompatible) {
       showAlertAction({
         alertId: 'warmMigrationBadVms',
@@ -34,7 +46,6 @@ export class PlanWizardScheduleStep extends React.Component {
         alertType: 'info'
       });
     }
-    // TODO if target isn't RHV, disallow warm migration and pop another alert
   }
 
   componentWillUnmount() {
@@ -121,6 +132,7 @@ PlanWizardScheduleStep.propTypes = {
   migration_plan_choice_radio: PropTypes.string,
   warmMigrationCompatibility: PropTypes.shape({
     isFetchingTargetValidationData: PropTypes.bool,
+    isRhvTarget: PropTypes.bool,
     isEveryVmCompatible: PropTypes.bool,
     areConversionHostsConfigured: PropTypes.bool,
     shouldEnableWarmMigration: PropTypes.bool


### PR DESCRIPTION
Warm migration is being rolled out in two stages, and the initial release will support RHV targets only. If the user selects an OSP target, this alert will appear on the Type and Schedule step of the plan wizard and warm migration will be disabled.

<img width="905" alt="Screenshot 2020-01-19 13 59 30" src="https://user-images.githubusercontent.com/811963/72686575-3f67f500-3ac4-11ea-8dd0-142a3795f78a.png">

This modifies code introduced in https://github.com/ManageIQ/manageiq-v2v/pull/1082 which already has `needs-tests`, so I will leave the label off of this PR and test this code when I write tests for that code.
