### PR TITLE
Fix logic for detecting SSH transport method on a conversion host configuration task

### DIFF
--- a/app/javascript/react/screens/App/Settings/__tests__/helpers.test.js
+++ b/app/javascript/react/screens/App/Settings/__tests__/helpers.test.js
@@ -121,26 +121,14 @@ describe('transport method helper', () => {
       expect(inferTransportMethod(task)).toEqual(__('VDDK'));
     });
 
-    it('detects SSH properly', () => {
-      const task = {
-        meta: { isTask: true },
-        context_data: {
-          request_params: {
-            vmware_ssh_private_key: 'foo'
-          }
-        }
-      };
-      expect(inferTransportMethod(task)).toEqual(__('SSH'));
-    });
-
-    it('returns null if neither match', () => {
+    it('returns SSH if VDDK not detected', () => {
       const task = {
         meta: { isTask: true },
         context_data: {
           request_params: {}
         }
       };
-      expect(inferTransportMethod(task)).toEqual(null);
+      expect(inferTransportMethod(task)).toEqual(__('SSH'));
     });
   });
 

--- a/app/javascript/react/screens/App/Settings/helpers.js
+++ b/app/javascript/react/screens/App/Settings/helpers.js
@@ -99,12 +99,10 @@ export const inferTransportMethod = conversionHostsListItem => {
   const ssh = __('SSH');
   if (conversionHostsListItem.meta.isTask) {
     const { request_params } = conversionHostsListItem.context_data;
-    if (request_params.vmware_vddk_package_url) return vddk;
-    if (request_params.vmware_ssh_private_key) return ssh;
-  } else {
-    if (conversionHostsListItem.vddk_transport_supported) return vddk;
-    if (conversionHostsListItem.ssh_transport_supported) return ssh;
+    return request_params.vmware_vddk_package_url ? vddk : ssh;
   }
+  if (conversionHostsListItem.vddk_transport_supported) return vddk;
+  if (conversionHostsListItem.ssh_transport_supported) return ssh;
   return null;
 };
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1784106

In the event that a conversion host configuration is in progress or failed, the transport method displayed on its item in the Conversion Hosts list is based on the `context_data.request_params` in the MiqTask created by the wizard. Previously, SSH was detected by looking for the `vmware_ssh_private_key` param, but the backend now [omits that param when storing `request_params`](https://github.com/ManageIQ/manageiq/blob/b8ab6d4d0ba7c47e7a810f62fdc8417d6ee2c9cf/app/models/conversion_host/configurations.rb#L45), so those tasks were being rendered without the SSH label.

This PR changes the logic to assume SSH transport if the VDDK property is not present.

The bug can be reproduced using the database `failed-conv-host-type` from [here](https://drive.google.com/drive/folders/1psxWLopcPUFeJCoHcnMiOgF40x2V0h3Q?usp=sharing).

Before:
<img width="1213" alt="Screenshot 2020-01-19 16 40 37" src="https://user-images.githubusercontent.com/811963/72688979-6f21f780-3ada-11ea-8441-e55594cc66d5.png">


After:
<img width="1214" alt="Screenshot 2020-01-19 16 37 12" src="https://user-images.githubusercontent.com/811963/72688973-59143700-3ada-11ea-8a4e-4305395edc4f.png">

