### PR TITLE
Add functionality for deleting warm migration cutover date

### DIFF
--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationInProgressListItem.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationInProgressListItem.js
@@ -21,6 +21,7 @@ import ProgressBarTooltip from './ProgressBarTooltip';
 import ScheduleMigrationButton from './ScheduleMigrationButton';
 import CutoverTimeInfoItem from './CutoverTimeInfoItem';
 import StopPropagationOnClick from '../../../common/StopPropagationOnClick';
+import { formatDateTime } from '../../../../../../components/dates/MomentDate';
 
 const MigrationInProgressListItem = ({
   plan,
@@ -39,7 +40,10 @@ const MigrationInProgressListItem = ({
   isCancellingPlanRequest,
   requestsProcessingCancellation,
   loading,
-  toggleScheduleMigrationModal
+  toggleScheduleMigrationModal,
+  showConfirmModalAction,
+  hideConfirmModalAction,
+  scheduleCutover
 }) => {
   const { requestsOfAssociatedPlan, mostRecentRequest } = getRequestsOfPlan({ plan, allRequestsWithTasks });
   const waitingForConversionHost = isWaitingForConversionHost(mostRecentRequest);
@@ -157,6 +161,38 @@ const MigrationInProgressListItem = ({
   };
   const baseRowProps = { plan, numFailedVms, numTotalVms, onClick: redirectToPlan };
 
+  const confirmationWarningText = (
+    <React.Fragment>
+      <p>
+        {sprintf(
+          __('Are you sure you want to unschedule cutover for plan %s targeted to run on %s ?'),
+          plan.name,
+          formatDateTime(plan.options.config_info.warm_migration_cutover_datetime)
+        )}
+      </p>
+    </React.Fragment>
+  );
+
+  const confirmModalProps = {
+    title: __('Unschedule Cutover for Migration Plan'),
+    body: confirmationWarningText,
+    icon: <Icon className="confirm-warning-icon" type="pf" name="warning-triangle-o" />,
+    confirmButtonLabel: __('Unschedule')
+  };
+
+  const onConfirm = () => {
+    scheduleCutover({
+      plan,
+      cutoverTime: null
+    }).then(() => {
+      fetchTransformationPlansAction({
+        url: fetchTransformationPlansUrl,
+        archived: false
+      });
+    });
+    hideConfirmModalAction();
+  };
+
   // UX business rule: if there are any pre migration playbooks running,
   // or if all disks have been migrated and we have a post migration playbook running, show this instead
   if (
@@ -197,6 +233,18 @@ const MigrationInProgressListItem = ({
                     }}
                   >
                     {__('Edit Cutover')}
+                  </MenuItem>
+                  <MenuItem
+                    id={`delete_cutover_${plan.id}`}
+                    onClick={e => {
+                      e.stopPropagation();
+                      showConfirmModalAction({
+                        ...confirmModalProps,
+                        onConfirm
+                      });
+                    }}
+                  >
+                    {__('Delete Scheduled Cutover')}
                   </MenuItem>
                 </DropdownKebab>
               </StopPropagationOnClick>
@@ -261,6 +309,18 @@ const MigrationInProgressListItem = ({
                 >
                   {__('Edit Cutover')}
                 </MenuItem>
+                <MenuItem
+                  id={`delete_cutover_${plan.id}`}
+                  onClick={e => {
+                    e.stopPropagation();
+                    showConfirmModalAction({
+                      ...confirmModalProps,
+                      onConfirm
+                    });
+                  }}
+                >
+                  {__('Delete Scheduled Cutover')}
+                </MenuItem>
               </DropdownKebab>
             </StopPropagationOnClick>
           )}
@@ -287,7 +347,10 @@ MigrationInProgressListItem.propTypes = {
   isCancellingPlanRequest: PropTypes.bool,
   requestsProcessingCancellation: PropTypes.array,
   loading: PropTypes.bool,
-  toggleScheduleMigrationModal: PropTypes.func
+  toggleScheduleMigrationModal: PropTypes.func,
+  showConfirmModalAction: PropTypes.func,
+  hideConfirmModalAction: PropTypes.func,
+  scheduleCutover: PropTypes.func
 };
 
 export default MigrationInProgressListItem;

--- a/app/javascript/react/screens/App/Overview/components/Migrations/Migrations.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/Migrations.js
@@ -163,6 +163,8 @@ class Migrations extends React.Component {
                 scheduleMigration={scheduleMigration}
                 scheduleMigrationNow={createTransformationPlanRequestClick}
                 scheduleCutover={scheduleCutover}
+                showConfirmModalAction={showConfirmModalAction}
+                hideConfirmModalAction={hideConfirmModalAction}
               />
             )}
             {activeFilter === MIGRATIONS_FILTERS.completed && (

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsInProgressList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsInProgressList.js
@@ -30,7 +30,9 @@ const MigrationsInProgressList = ({
   scheduleMigrationPlan,
   scheduleMigration,
   scheduleMigrationNow,
-  scheduleCutover
+  scheduleCutover,
+  showConfirmModalAction,
+  hideConfirmModalAction
 }) => (
   <React.Fragment>
     <Grid.Col xs={12} id="progress-bar-items">
@@ -77,6 +79,9 @@ const MigrationsInProgressList = ({
                       requestsProcessingCancellation={requestsProcessingCancellation}
                       loading={loading}
                       toggleScheduleMigrationModal={toggleScheduleMigrationModal}
+                      showConfirmModalAction={showConfirmModalAction}
+                      hideConfirmModalAction={hideConfirmModalAction}
+                      scheduleCutover={scheduleCutover}
                     />
                   ))}
                 </ListViewTable>
@@ -129,7 +134,9 @@ MigrationsInProgressList.propTypes = {
   scheduleMigrationPlan: PropTypes.object,
   scheduleMigration: PropTypes.func,
   scheduleMigrationNow: PropTypes.func,
-  scheduleCutover: PropTypes.func
+  scheduleCutover: PropTypes.func,
+  showConfirmModalAction: PropTypes.func,
+  hideConfirmModalAction: PropTypes.func
 };
 
 MigrationsInProgressList.defaultProps = {


### PR DESCRIPTION
New kebab menu item for deletion
![delete-cutover-01](https://user-images.githubusercontent.com/6648365/73068980-deb62f00-3eac-11ea-9da8-c193116b81a0.png)

Confirmation dialog
![delete-cutover-02](https://user-images.githubusercontent.com/6648365/73068981-deb62f00-3eac-11ea-9540-282f7701aa13.png)

This needs to be tested with https://github.com/ManageIQ/manageiq/pull/19759 in place