### PR TITLE
[Part 2/2 of BZ#1789479] UI changes for UCI: disable CPU throttling, accept TLS certificates for both RHV and OSP conv hosts

### DIFF
--- a/app/javascript/react/screens/App/Settings/__tests__/__snapshots__/SettingsActions.test.js.snap
+++ b/app/javascript/react/screens/App/Settings/__tests__/__snapshots__/SettingsActions.test.js.snap
@@ -169,7 +169,6 @@ Array [
         },
         "transformation": Object {
           "limits": Object {
-            "cpu_limit_per_host": 10,
             "max_concurrent_tasks_per_conversion_host": 10,
             "max_concurrent_tasks_per_ems": 10,
           },
@@ -207,7 +206,6 @@ Array [
         },
         "transformation": Object {
           "limits": Object {
-            "cpu_limit_per_host": 10,
             "max_concurrent_tasks_per_conversion_host": 10,
             "max_concurrent_tasks_per_ems": 10,
           },

--- a/app/javascript/react/screens/App/Settings/__tests__/__snapshots__/SettingsReducer.test.js.snap
+++ b/app/javascript/react/screens/App/Settings/__tests__/__snapshots__/SettingsReducer.test.js.snap
@@ -586,7 +586,6 @@ Object {
   "isSavingSettings": false,
   "postConversionHostsResults": Array [],
   "savedSettings": Object {
-    "cpu_limit_per_host": 10,
     "max_concurrent_tasks_per_conversion_host": 10,
     "max_concurrent_tasks_per_ems": 10,
   },
@@ -828,7 +827,6 @@ Object {
   "isSavingSettings": false,
   "postConversionHostsResults": Array [],
   "savedSettings": Object {
-    "cpu_limit_per_host": 10,
     "max_concurrent_tasks_per_conversion_host": 10,
     "max_concurrent_tasks_per_ems": 10,
   },

--- a/app/javascript/react/screens/App/Settings/helpers.js
+++ b/app/javascript/react/screens/App/Settings/helpers.js
@@ -3,16 +3,14 @@ import { RHV, OPENSTACK } from '../../../../common/constants';
 
 export const getFormValuesFromApiSettings = payload => ({
   max_concurrent_tasks_per_conversion_host: payload.transformation.limits.max_concurrent_tasks_per_conversion_host,
-  max_concurrent_tasks_per_ems: payload.transformation.limits.max_concurrent_tasks_per_ems,
-  cpu_limit_per_host: payload.transformation.limits.cpu_limit_per_host
+  max_concurrent_tasks_per_ems: payload.transformation.limits.max_concurrent_tasks_per_ems
 });
 
 export const getApiSettingsFromFormValues = values => ({
   transformation: {
     limits: {
       max_concurrent_tasks_per_conversion_host: values.max_concurrent_tasks_per_conversion_host,
-      max_concurrent_tasks_per_ems: values.max_concurrent_tasks_per_ems,
-      cpu_limit_per_host: values.cpu_limit_per_host
+      max_concurrent_tasks_per_ems: values.max_concurrent_tasks_per_ems
     }
   }
 });

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/ConversionHostWizardAuthenticationStep.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/ConversionHostWizardAuthenticationStep.js
@@ -79,6 +79,7 @@ export const ConversionHostWizardAuthenticationStep = ({
         />
       )}
       {selectedProviderType === OPENSTACK && (
+        // TODO collect CA certs for RHV too, see chat with Fabien for strings.
         <React.Fragment>
           <Field
             {...fieldBaseProps}

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/ConversionHostWizardAuthenticationStep.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/ConversionHostWizardAuthenticationStep.js
@@ -15,7 +15,7 @@ const requiredWithMessage = required({ msg: __('This field is required') });
 export const ConversionHostWizardAuthenticationStep = ({
   selectedProviderType,
   selectedTransformationMethod,
-  verifyOpenstackCerts
+  verifyCaCerts
 }) => {
   const fieldBaseProps = { labelWidth: 4, controlWidth: 7 };
 
@@ -78,40 +78,37 @@ export const ConversionHostWizardAuthenticationStep = ({
           validate={[requiredWithMessage]}
         />
       )}
-      {selectedProviderType === OPENSTACK && (
-        // TODO collect CA certs for RHV too, see chat with Fabien for strings.
-        <React.Fragment>
-          <Field
-            {...fieldBaseProps}
-            name="verifyOpenstackCerts"
-            label={__('Verify TLS Certificates for OpenStack')}
-            component={FormField}
-            controlId="verify-openstack-certs"
-            style={{ marginTop: 25 }}
-          >
-            {({ input: { value, onChange } }) => (
-              <Switch
-                bsSize="normal"
-                id="verify-openstack-certs-switch"
-                onText={__('Yes')}
-                offText={__('No')}
-                defaultValue={false}
-                value={value}
-                onChange={(element, state) => onChange(state)}
-              />
-            )}
-          </Field>
-          {verifyOpenstackCerts && (
-            <TextFileField
-              {...fieldBaseProps}
-              name="openstackCaCerts"
-              label={__('OpenStack Trusted CA Certificates')}
-              help={__('Upload your certificates file, in PEM format, or paste its contents below.')}
-              controlId="openstack-ca-certs-input"
+      <React.Fragment>
+        <Field
+          {...fieldBaseProps}
+          name="verifyCaCerts"
+          label={__('Verify TLS Certificates')}
+          component={FormField}
+          controlId="verify-ca-certs"
+          style={{ marginTop: 25 }}
+        >
+          {({ input: { value, onChange } }) => (
+            <Switch
+              bsSize="normal"
+              id="verify-ca-certs-switch"
+              onText={__('Yes')}
+              offText={__('No')}
+              defaultValue={false}
+              value={value}
+              onChange={(element, state) => onChange(state)}
             />
           )}
-        </React.Fragment>
-      )}
+        </Field>
+        {verifyCaCerts && (
+          <TextFileField
+            {...fieldBaseProps}
+            name="caCerts"
+            label={__('Trusted CA Certificates')}
+            help={__('Upload your certificates file, in PEM format, or paste its contents below.')}
+            controlId="ca-certs-input"
+          />
+        )}
+      </React.Fragment>
     </Form>
   );
 };
@@ -119,7 +116,7 @@ export const ConversionHostWizardAuthenticationStep = ({
 ConversionHostWizardAuthenticationStep.propTypes = {
   selectedProviderType: PropTypes.string,
   selectedTransformationMethod: PropTypes.string,
-  verifyOpenstackCerts: PropTypes.bool
+  verifyCaCerts: PropTypes.bool
 };
 
 export default reduxForm({
@@ -132,7 +129,7 @@ export default reduxForm({
     conversionHostSshKey: { filename: '', body: '' },
     transformationMethod: VDDK,
     vmwareSshKey: { filename: '', body: '' },
-    openstackCaCerts: { filename: '', body: '' },
-    verifyOpenstackCerts: false
+    caCerts: { filename: '', body: '' },
+    verifyCaCerts: false
   }
 })(ConversionHostWizardAuthenticationStep);

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/__tests__/ConversionHostWizardAuthenticationStep.test.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/__tests__/ConversionHostWizardAuthenticationStep.test.js
@@ -16,7 +16,7 @@ describe('conversion host wizard authentication step', () => {
   const baseProps = {
     selectedProviderType: RHV,
     selectedTransformationMethod: null,
-    verifyOpenstackCerts: null,
+    verifyCaCerts: null,
     store
   };
 
@@ -32,8 +32,8 @@ describe('conversion host wizard authentication step', () => {
     expect(component.find('Field[controlId="openstack-user-input"]')).toHaveLength(0);
     expect(component.find('TextFileField[controlId="vmware-ssh-key-input"]')).toHaveLength(0);
     expect(component.find('Field[controlId="vddk-library-path"]')).toHaveLength(0);
-    expect(component.find('Field[controlId="verify-openstack-certs"]')).toHaveLength(0);
-    expect(component.find('TextFileField[controlId="openstack-ca-certs-input"]')).toHaveLength(0);
+    expect(component.find('Field[controlId="verify-ca-certs"]')).toHaveLength(1);
+    expect(component.find('TextFileField[controlId="ca-certs-input"]')).toHaveLength(0);
     expect(component).toMatchSnapshot();
   });
 
@@ -44,8 +44,8 @@ describe('conversion host wizard authentication step', () => {
     expect(component.find('Field[controlId="openstack-user-input"]')).toHaveLength(1);
     expect(component.find('TextFileField[controlId="vmware-ssh-key-input"]')).toHaveLength(0);
     expect(component.find('Field[controlId="vddk-library-path"]')).toHaveLength(0);
-    expect(component.find('Field[controlId="verify-openstack-certs"]')).toHaveLength(1);
-    expect(component.find('TextFileField[controlId="openstack-ca-certs-input"]')).toHaveLength(0);
+    expect(component.find('Field[controlId="verify-ca-certs"]')).toHaveLength(1);
+    expect(component.find('TextFileField[controlId="ca-certs-input"]')).toHaveLength(0);
     expect(component).toMatchSnapshot();
   });
 
@@ -57,7 +57,7 @@ describe('conversion host wizard authentication step', () => {
     );
     const onSwitchChange = jest.fn();
     const switchRenderProp = component
-      .find('Field[controlId="verify-openstack-certs"]')
+      .find('Field[controlId="verify-ca-certs"]')
       .first()
       .props().children;
     const renderedSwitch = switchRenderProp({ input: { value: false, onChange: onSwitchChange } });
@@ -67,11 +67,11 @@ describe('conversion host wizard authentication step', () => {
     expect(onSwitchChange).toHaveBeenCalledWith(true);
   });
 
-  it('renders correctly with verify OSP TLS certs turned on', () => {
+  it('renders correctly with verify TLS certs turned on', () => {
     const component = shallow(
-      <ConversionHostWizardAuthenticationStep {...baseProps} selectedProviderType={OPENSTACK} verifyOpenstackCerts />
+      <ConversionHostWizardAuthenticationStep {...baseProps} selectedProviderType={OPENSTACK} verifyCaCerts />
     );
-    expect(component.find('TextFileField[controlId="openstack-ca-certs-input"]')).toHaveLength(1);
+    expect(component.find('TextFileField[controlId="ca-certs-input"]')).toHaveLength(1);
     expect(component).toMatchSnapshot();
   });
 

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/__tests__/__snapshots__/ConversionHostWizardAuthenticationStep.test.js.snap
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/__tests__/__snapshots__/ConversionHostWizardAuthenticationStep.test.js.snap
@@ -147,7 +147,6 @@ exports[`conversion host wizard authentication step renders correctly in the ini
         "marginTop": 25,
       }
     }
-    validate={[Function]}
   >
     <Component />
   </Field>
@@ -226,7 +225,6 @@ exports[`conversion host wizard authentication step renders correctly with SSH t
         "marginTop": 25,
       }
     }
-    validate={[Function]}
   >
     <Component />
   </Field>
@@ -312,7 +310,6 @@ exports[`conversion host wizard authentication step renders correctly with VDDK 
         "marginTop": 25,
       }
     }
-    validate={[Function]}
   >
     <Component />
   </Field>
@@ -475,7 +472,6 @@ exports[`conversion host wizard authentication step renders the redux-form wrapp
         "marginTop": 25,
       }
     }
-    validate={[Function]}
   >
     <Component />
   </Field>

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/__tests__/__snapshots__/ConversionHostWizardAuthenticationStep.test.js.snap
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/__tests__/__snapshots__/ConversionHostWizardAuthenticationStep.test.js.snap
@@ -68,11 +68,11 @@ exports[`conversion host wizard authentication step renders correctly in the ini
   />
   <Field
     component={[Function]}
-    controlId="verify-openstack-certs"
+    controlId="verify-ca-certs"
     controlWidth={7}
-    label="Verify TLS Certificates for OpenStack"
+    label="Verify TLS Certificates"
     labelWidth={4}
-    name="verifyOpenstackCerts"
+    name="verifyCaCerts"
     style={
       Object {
         "marginTop": 25,
@@ -135,6 +135,22 @@ exports[`conversion host wizard authentication step renders correctly in the ini
       ]
     }
   />
+  <Field
+    component={[Function]}
+    controlId="verify-ca-certs"
+    controlWidth={7}
+    label="Verify TLS Certificates"
+    labelWidth={4}
+    name="verifyCaCerts"
+    style={
+      Object {
+        "marginTop": 25,
+      }
+    }
+    validate={[Function]}
+  >
+    <Component />
+  </Field>
 </Form>
 `;
 
@@ -198,6 +214,22 @@ exports[`conversion host wizard authentication step renders correctly with SSH t
     labelWidth={4}
     name="vmwareSshKey"
   />
+  <Field
+    component={[Function]}
+    controlId="verify-ca-certs"
+    controlWidth={7}
+    label="Verify TLS Certificates"
+    labelWidth={4}
+    name="verifyCaCerts"
+    style={
+      Object {
+        "marginTop": 25,
+      }
+    }
+    validate={[Function]}
+  >
+    <Component />
+  </Field>
 </Form>
 `;
 
@@ -268,10 +300,26 @@ exports[`conversion host wizard authentication step renders correctly with VDDK 
       ]
     }
   />
+  <Field
+    component={[Function]}
+    controlId="verify-ca-certs"
+    controlWidth={7}
+    label="Verify TLS Certificates"
+    labelWidth={4}
+    name="verifyCaCerts"
+    style={
+      Object {
+        "marginTop": 25,
+      }
+    }
+    validate={[Function]}
+  >
+    <Component />
+  </Field>
 </Form>
 `;
 
-exports[`conversion host wizard authentication step renders correctly with verify OSP TLS certs turned on 1`] = `
+exports[`conversion host wizard authentication step renders correctly with verify TLS certs turned on 1`] = `
 <Form
   bsClass="form"
   className="form-horizontal"
@@ -339,11 +387,11 @@ exports[`conversion host wizard authentication step renders correctly with verif
   />
   <Field
     component={[Function]}
-    controlId="verify-openstack-certs"
+    controlId="verify-ca-certs"
     controlWidth={7}
-    label="Verify TLS Certificates for OpenStack"
+    label="Verify TLS Certificates"
     labelWidth={4}
-    name="verifyOpenstackCerts"
+    name="verifyCaCerts"
     style={
       Object {
         "marginTop": 25,
@@ -353,13 +401,13 @@ exports[`conversion host wizard authentication step renders correctly with verif
     <Component />
   </Field>
   <TextFileField
-    controlId="openstack-ca-certs-input"
+    controlId="ca-certs-input"
     controlWidth={7}
     help="Upload your certificates file, in PEM format, or paste its contents below."
     hideBody={false}
-    label="OpenStack Trusted CA Certificates"
+    label="Trusted CA Certificates"
     labelWidth={4}
-    name="openstackCaCerts"
+    name="caCerts"
   />
 </Form>
 `;
@@ -415,5 +463,21 @@ exports[`conversion host wizard authentication step renders the redux-form wrapp
       ]
     }
   />
+  <Field
+    component={[Function]}
+    controlId="verify-ca-certs"
+    controlWidth={7}
+    label="Verify TLS Certificates"
+    labelWidth={4}
+    name="verifyCaCerts"
+    style={
+      Object {
+        "marginTop": 25,
+      }
+    }
+    validate={[Function]}
+  >
+    <Component />
+  </Field>
 </Form>
 `;

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/__tests__/__snapshots__/index.test.js.snap
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/__tests__/__snapshots__/index.test.js.snap
@@ -8,17 +8,17 @@ Object {
   "form": "conversionHostWizardAuthenticationStep",
   "getFormState": [Function],
   "initialValues": Object {
-    "conversionHostSshKey": Object {
+    "caCerts": Object {
       "body": "",
       "filename": "",
     },
-    "openstackCaCerts": Object {
+    "conversionHostSshKey": Object {
       "body": "",
       "filename": "",
     },
     "openstackUser": "cloud-user",
     "transformationMethod": "VDDK",
-    "verifyOpenstackCerts": false,
+    "verifyCaCerts": false,
     "vmwareSshKey": Object {
       "body": "",
       "filename": "",
@@ -37,6 +37,6 @@ Object {
   "touchOnBlur": true,
   "touchOnChange": false,
   "updateUnregisteredFields": false,
-  "verifyOpenstackCerts": false,
+  "verifyCaCerts": false,
 }
 `;

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/__tests__/index.test.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/__tests__/index.test.js
@@ -63,12 +63,12 @@ describe('ConversionHostWizardAuthenticationStep integration test', () => {
     changeFormValue('transformationMethod', 'SSH');
     expect(form().syncErrors).toBeFalsy(); // <-------
 
-    // Turning on OpenStack TLS Certificates mounts an empty required field (openstackCaCerts)
-    changeFormValue('verifyOpenstackCerts', true);
-    expect(Object.keys(form().syncErrors)).toEqual(['openstackCaCerts']);
+    // Turning on TLS Certificates mounts an empty required field (caCerts)
+    changeFormValue('verifyCaCerts', true);
+    expect(Object.keys(form().syncErrors)).toEqual(['caCerts']);
 
-    // Turning it off unmounts openstackCaCerts while it's empty.
-    changeFormValue('verifyOpenstackCerts', false);
+    // Turning it off unmounts caCerts while it's empty.
+    changeFormValue('verifyCaCerts', false);
     expect(form().syncErrors).toBeFalsy(); // <-------
   });
 });

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/index.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/index.js
@@ -11,7 +11,7 @@ const mapStateToProps = ({ form }) => {
   return {
     selectedProviderType: locationStepValues && locationStepValues.providerType,
     selectedTransformationMethod: authStepValues && authStepValues.transformationMethod,
-    verifyOpenstackCerts: authStepValues && authStepValues.verifyOpenstackCerts
+    verifyCaCerts: authStepValues && authStepValues.verifyCaCerts
   };
 };
 

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardResultsStep/__tests__/__snapshots__/helpers.test.js.snap
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardResultsStep/__tests__/__snapshots__/helpers.test.js.snap
@@ -19,9 +19,9 @@ Array [
     "auth_user": "cloud-user",
     "conversion_host_ssh_private_key": "mock conversion host SSH key body",
     "name": "Mock Host",
-    "openstack_tls_ca_certs": "mock openstack CA certs body",
     "resource_id": "1",
     "resource_type": "mock host type",
+    "tls_ca_certs": "mock CA certs body",
     "vmware_ssh_private_key": "mock vmware SSH key body",
   },
 ]

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardResultsStep/__tests__/helpers.test.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardResultsStep/__tests__/helpers.test.js
@@ -8,7 +8,7 @@ describe('conversion host wizard results step helpers', () => {
   };
   const commonAuthStepValues = {
     conversionHostSshKey: { body: 'mock conversion host SSH key body' },
-    openstackCaCerts: { body: '' }
+    caCerts: { body: '' }
   };
   const vddkAuthStepValues = {
     ...commonAuthStepValues,
@@ -58,7 +58,7 @@ describe('conversion host wizard results step helpers', () => {
       const postBodies = getConfigureConversionHostPostBodies(locationStepValues, hostsStepValues, {
         ...sshAuthStepValues,
         openstackUser: 'cloud-user',
-        openstackCaCerts: { body: 'mock openstack CA certs body' }
+        caCerts: { body: 'mock CA certs body' }
       });
       expect(postBodies).toMatchSnapshot();
     });

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardResultsStep/__tests__/index.test.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardResultsStep/__tests__/index.test.js
@@ -20,7 +20,7 @@ describe('ConversionHostWizardLocationStep integration test', () => {
         conversionHostWizardAuthenticationStep: {
           values: {
             conversionHostSshKey: { body: 'mock conversion host SSH key body' },
-            openstackCaCerts: { body: '' },
+            caCerts: { body: '' },
             transformationMethod: VDDK,
             vddkLibraryPath: 'mock VDDK path'
           }

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardResultsStep/helpers.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardResultsStep/helpers.js
@@ -13,7 +13,7 @@ export const getConfigureConversionHostPostBodies = (locationStepValues, hostsSt
       resource_id: host.id,
       conversion_host_ssh_private_key: authStepValues.conversionHostSshKey.body,
       auth_user: locationStepValues.providerType === OPENSTACK ? authStepValues.openstackUser : 'root',
-      ...(authStepValues.openstackCaCerts.body && { openstack_tls_ca_certs: authStepValues.openstackCaCerts.body }),
+      ...(authStepValues.caCerts.body && { tls_ca_certs: authStepValues.caCerts.body }),
       ...vmwareAuthProperties
     };
   });

--- a/app/javascript/react/screens/App/Settings/screens/GeneralSettings/GeneralSettings.js
+++ b/app/javascript/react/screens/App/Settings/screens/GeneralSettings/GeneralSettings.js
@@ -3,7 +3,8 @@ import PropTypes from 'prop-types';
 import { reduxForm, Field } from 'redux-form';
 import { Form, Button, Icon, OverlayTrigger, Popover, Spinner } from 'patternfly-react';
 import NumberInput from '../../../common/forms/NumberInput';
-import TextInputWithCheckbox from '../../../common/forms/TextInputWithCheckbox';
+// import TextInputWithCheckbox from '../../../common/forms/TextInputWithCheckbox';
+// TODO use this ^ if/when we re-enable throttling in the UI.
 
 const FORM_NAME = 'settings';
 
@@ -51,16 +52,6 @@ export class GeneralSettings extends React.Component {
       settingsForm &&
       settingsForm.values &&
       Object.keys(savedSettings).some(key => savedSettings[key] !== settingsForm.values[key]);
-
-    const inputEnabledFunction = value => value !== 'unlimited';
-
-    const validatePercentInput = value => {
-      const numberRegex = /^\d+$/;
-      if ((inputEnabledFunction(value) && !numberRegex.test(value)) || value < 0 || value > 100) {
-        return __('The entered value must be between 0 and 100');
-      }
-      return null;
-    };
 
     return (
       <Spinner loading={isFetchingServers || isFetchingSettings} style={{ marginTop: 15 }}>
@@ -115,21 +106,6 @@ export class GeneralSettings extends React.Component {
                 />
               </div>
             </Form.FormGroup>
-            <Form.FormGroup />
-            <div>
-              <h3>{__('Resource Utilization Limits for Migrations') /* TODO remove CPU throttling */}</h3>
-            </div>
-            <Field
-              id="cpu_limit_per_host"
-              name="cpu_limit_per_host"
-              component={TextInputWithCheckbox}
-              validate={validatePercentInput}
-              label={__('Max CPU utilization per conversion host')}
-              postfix="％"
-              inputEnabledFunction={inputEnabledFunction}
-              initialUncheckedValue="unlimited"
-              vertical
-            />
             <Form.FormGroup style={{ marginTop: '40px' }}>
               <Button
                 bsStyle="primary"

--- a/app/javascript/react/screens/App/Settings/screens/GeneralSettings/GeneralSettings.js
+++ b/app/javascript/react/screens/App/Settings/screens/GeneralSettings/GeneralSettings.js
@@ -117,7 +117,7 @@ export class GeneralSettings extends React.Component {
             </Form.FormGroup>
             <Form.FormGroup />
             <div>
-              <h3>{__('Resource Utilization Limits for Migrations')}</h3>
+              <h3>{__('Resource Utilization Limits for Migrations') /* TODO remove CPU throttling */}</h3>
             </div>
             <Field
               id="cpu_limit_per_host"

--- a/app/javascript/react/screens/App/Settings/screens/GeneralSettings/__tests__/__snapshots__/GeneralSettings.test.js.snap
+++ b/app/javascript/react/screens/App/Settings/screens/GeneralSettings/__tests__/__snapshots__/GeneralSettings.test.js.snap
@@ -129,25 +129,6 @@ exports[`GeneralSettings component renders the general settings page 1`] = `
       </FormGroup>
       <FormGroup
         bsClass="form-group"
-      />
-      <div>
-        <h3>
-          Resource Utilization Limits for Migrations
-        </h3>
-      </div>
-      <Field
-        component={[Function]}
-        id="cpu_limit_per_host"
-        initialUncheckedValue="unlimited"
-        inputEnabledFunction={[Function]}
-        label="Max CPU utilization per conversion host"
-        name="cpu_limit_per_host"
-        postfix="％"
-        validate={[Function]}
-        vertical={true}
-      />
-      <FormGroup
-        bsClass="form-group"
         style={
           Object {
             "marginTop": "40px",

--- a/app/javascript/react/screens/App/Settings/settings.fixtures.js
+++ b/app/javascript/react/screens/App/Settings/settings.fixtures.js
@@ -19,8 +19,7 @@ export const settings = Immutable({
   transformation: {
     limits: {
       max_concurrent_tasks_per_conversion_host: 10,
-      max_concurrent_tasks_per_ems: 10,
-      cpu_limit_per_host: 10
+      max_concurrent_tasks_per_ems: 10
     }
   },
   otherSettings: {
@@ -30,8 +29,7 @@ export const settings = Immutable({
 
 export const settingsFormValues = Immutable({
   max_concurrent_tasks_per_conversion_host: 10,
-  max_concurrent_tasks_per_ems: 10,
-  cpu_limit_per_host: 10
+  max_concurrent_tasks_per_ems: 10
 });
 
 export const fetchServersData = {


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1789479
JIRA: https://issues.redhat.com/browse/MIGENG-316

Depends on: https://github.com/ManageIQ/manageiq/pull/19787
Depends on: https://github.com/ManageIQ/manageiq-api/pull/732

This will probably conflict with https://github.com/ManageIQ/manageiq-v2v/pull/1103 when backporting, and it would be harmless to backport #1103, so we may want to.

This PR wraps up the UI changes necessary for UCI support as discussed with @fdupont-redhat in the BZ:
* CPU throttling is removed from the General tab of the settings page.
* In the Configure Conversion Host wizard on the Authentication step, the "Verify TLS Certificates for OpenStack" toggle has been renamed to "Verify TLS Certificates" and made available for RHV targets in addition to OSP ones.
* The certificate field itself has been renamed from "OpenStack Trusted CA Certificates" to "Trusted CA Certificates".
* The API property used for certificates when POSTing the results of the wizard has been changed from `openstack_tls_ca_certs` to `tls_ca_certs`.

# Screens

## General settings, before:
<img width="1438" alt="Screenshot 2020-01-29 17 05 38" src="https://user-images.githubusercontent.com/811963/73406613-d4d56700-42c4-11ea-9f7a-57c5b04b1790.png">

## General settings, after:
<img width="1438" alt="Screenshot 2020-01-29 17 36 00" src="https://user-images.githubusercontent.com/811963/73406619-dacb4800-42c4-11ea-8c70-58939d7c89d3.png">

## Authentication step of the conversion host wizard:

<img width="903" alt="Screenshot 2020-02-07 16 04 22" src="https://user-images.githubusercontent.com/811963/74068141-df7cb400-49c8-11ea-85f7-211a6b4d2f43.png">
