### PR TITLE
Update react-dropzone version to 10.2.1

### DIFF
--- a/app/javascript/react/screens/App/common/forms/TextFileInput/TextFileInput.js
+++ b/app/javascript/react/screens/App/common/forms/TextFileInput/TextFileInput.js
@@ -20,9 +20,12 @@ const TextFileInput = ({ value: { filename, body }, onChange, onBlur, help, hide
   const clear = () => onChange({ filename: '', body: '' });
 
   return (
-    <Dropzone onDrop={onFileDrop} onClick={event => event.preventDefault()}>
+    <Dropzone onDrop={onFileDrop}>
       {({ getRootProps, getInputProps, isDragActive, open }) => (
-        <div {...getRootProps()} className={classNames('text-file-input__dropzone', { active: isDragActive })}>
+        <div
+          {...getRootProps({ onClick: event => event.stopPropagation() })}
+          className={classNames('text-file-input__dropzone', { active: isDragActive })}
+        >
           <input {...getInputProps()} />
           <Form.InputGroup>
             <Form.FormControl type="text" disabled value={filename} />

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "prop-types": "^15.6.0",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
-    "react-dropzone": "^8.1.0",
+    "react-dropzone": "^10.2.1",
     "react-ellipsis-with-tooltip": "1.0.8",
     "react-intl": "^2.4.0",
     "react-redux": "^7.1.1",


### PR DESCRIPTION
This is to resolve issue in conversion host wizard:
1. select RHV
2. proceed all the way to authentication tab
3. observe the following error:

```
Warning: The prop `disableClick` of `Dropzone` is deprecated. Use onClick={evt => evt.preventDefault()} instead. This prop will be removed in the next major version. 
    in TextFileInput (created by FormField)
    in FormField (created by ConnectedField)
    in ConnectedField (created by ConnectFunction)
    in ConnectFunction (created by Connect(ConnectedField))
    in Connect(ConnectedField) (created by Field)
    in Field (created by Context.Consumer)
    in Context.Consumer (created by Hoc)
    in Hoc (created by Field)
    in Field (created by TextFileField)
    in TextFileField (created by ConversionHostWizardAuthenticationStep)
    in ConversionHostWizardAuthenticationStep (created by Form(ConversionHostWizardAuthenticationStep))
    in Form(ConversionHostWizardAuthenticationStep) (created by ConnectFunction)
    in ConnectFunction (created by Connect(Form(ConversionHostWizardAuthenticationStep)))
    in Connect(Form(ConversionHostWizardAuthenticationStep)) (created by ReduxForm)
    in ReduxForm (created by Context.Consumer)
    in Context.Consumer (created by Hoc)
    in Hoc (created by ReduxForm)
    in ReduxForm (created by ConnectFunction)
    in ConnectFunction (created by ModalWizardBody)
    in ModalWizardBody (created by ConversionHostWizardBody)
    in ConversionHostWizardBody (created by ConversionHostWizard)
    in ConversionHostWizard (created by ConnectFunction)
    in ConnectFunction (created by ConversionHostsSettings)
    in ConversionHostsSettings (created by ConnectFunction)
    in ConnectFunction (created by Settings)
    in Settings (created by ConnectFunction)
    in ConnectFunction (created by I18nProviderWrapper(Connect(Settings)))
    in I18nProviderWrapper(Connect(Settings)) (created by Route)
    in Route (created by Routes)
    in Routes (created by App)
    in App (created by ConnectFunction)
    in ConnectFunction
```

The problem will disappear with new version of `react-dropzone`.

This fixes https://github.com/ManageIQ/manageiq-v2v/issues/1089#issuecomment-574234484