### PR TITLE
Update react-router-dom & connected-react-router

### DIFF
--- a/app/javascript/react/config/Routes.js
+++ b/app/javascript/react/config/Routes.js
@@ -8,7 +8,7 @@ import componentRegistry from '../../components/componentRegistry';
 const Routes = ({ store }) =>
   links.map(({ path, component, redirect }) => {
     if (typeof redirect !== 'undefined') {
-      return <Route exact key={path} path={path} render={() => <Redirect to={redirect} />} />;
+      return <Route exact key={path} path={`/${path}`} render={() => <Redirect to={redirect} />} />;
     }
     const coreComponent = componentSettings(component);
     if (coreComponent) {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "dependencies": {
     "bootstrap-touchspin": "^4.2.5",
     "classnames": "^2.2.5",
-    "connected-react-router": "^6.5.2",
+    "connected-react-router": "^6.7.0",
     "core-js": "^2.5.7",
     "csv": "^2.0.0",
     "file-saver": "^1.3.8",
@@ -75,7 +75,7 @@
     "react-ellipsis-with-tooltip": "1.0.8",
     "react-intl": "^2.4.0",
     "react-redux": "^7.1.1",
-    "react-router-dom": "^4.2.2",
+    "react-router-dom": "^5.1.2",
     "recompose": "^0.26.0",
     "redux": "4.0.4",
     "redux-form": "^8.2.6",


### PR DESCRIPTION
With the new version, the following warning on settings screen will go away:
```
react-dom.development.js:11494 Warning: componentWillMount has been renamed, and is not recommended for use. See https://fb.me/react-async-component-lifecycle-hooks for details.

* Move code with side effects to componentDidMount, and set initial state in the constructor.
* Rename componentWillMount to UNSAFE_componentWillMount to suppress this warning in non-strict mode. In React 17.x, only the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run `npx react-codemod rename-unsafe-lifecycles` in your project source folder.

Please update the following components: Route, Router
printWarning @ react-dom.development.js:11494
lowPriorityWarning @ react-dom.development.js:11513
push../node_modules/react-dom/cjs/react-dom.development.js.ReactStrictModeWarnings.flushPendingUnsafeLifecycleWarnings @ react-dom.development.js:11674
flushRenderPhaseStrictModeWarningsInDEV @ react-dom.development.js:23134
commitRootImpl @ react-dom.development.js:22428
unstable_runWithPriority @ scheduler.development.js:643
runWithPriority$2 @ react-dom.development.js:11305
commitRoot @ react-dom.development.js:22414
runRootCallback @ react-dom.development.js:21554
(anonymous) @ react-dom.development.js:11353
unstable_runWithPriority @ scheduler.development.js:643
runWithPriority$2 @ react-dom.development.js:11305
flushSyncCallbackQueueImpl @ react-dom.development.js:11349
flushSyncCallbackQueue @ react-dom.development.js:11338
unbatchedUpdates @ react-dom.development.js:21692
legacyRenderSubtreeIntoContainer @ react-dom.development.js:24962
render @ react-dom.development.js:25042
render @ react-blueprint.jsx:7
create @ react-blueprint.jsx:17
newInstance @ registry.js:108
componentFactory @ helpers.js:15
(anonymous) @ migration:302
react-dom.development.js:11494 Warning: componentWillReceiveProps has been renamed, and is not recommended for use. See https://fb.me/react-async-component-lifecycle-hooks for details.

* Move data fetching code or side effects to componentDidUpdate.
* If you're updating state whenever props change, refactor your code to use memoization techniques or move it to static getDerivedStateFromProps. Learn more at: https://fb.me/react-derived-state
* Rename componentWillReceiveProps to UNSAFE_componentWillReceiveProps to suppress this warning in non-strict mode. In React 17.x, only the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run `npx react-codemod rename-unsafe-lifecycles` in your project source folder.

Please update the following components: Route, Router
```