### PR TITLE
[BZ#1796200] Mapping Wizard: sort items alphabetically and allow horizontal scroll in item lists

### DIFF
--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/DualPaneMapper/DualPaneMapper.scss
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/DualPaneMapper/DualPaneMapper.scss
@@ -23,6 +23,12 @@
   margin-left: 5px;
 }
 
+.dual-pane-mapper-list {
+  width: 300px;
+  overflow: auto;
+  border: 1px solid rgba(0, 0, 0, 0.3);
+}
+
 .dual-pane-mapper-list.dual-pane-mapper-list-left {
   margin-right: 5px;
 }
@@ -30,11 +36,11 @@
   margin-left: 5px;
 }
 .dual-pane-mapper-list .dual-pane-mapper-items-container {
-  border: 1px solid rgba(0, 0, 0, 0.3);
   height: 130px;
-  overflow-x: hidden;
-  overflow-y: auto;
-  width: 300px;
+  overflow: auto;
+  width: max-content;
+  min-width: 100%;
+  white-space: nowrap;
   &.has-counter {
     height: 110px;
   }
@@ -47,11 +53,8 @@
 .dual-pane-mapper-list .dual-pane-mapper-item {
   cursor: pointer;
   padding: 0 10px;
-  width: 100%;
 }
-.dual-pane-mapper-list
-  .dual-pane-mapper-item
-  .dual-pane-mapper-item-select-indicator {
+.dual-pane-mapper-list .dual-pane-mapper-item .dual-pane-mapper-item-select-indicator {
   display: inline-block;
   font-size: 12px;
   margin-left: 10px;
@@ -62,9 +65,7 @@
   background-color: #3397db;
   color: #fff;
 }
-.dual-pane-mapper-list
-  .dual-pane-mapper-item.selected
-  .dual-pane-mapper-item-select-indicator {
+.dual-pane-mapper-list .dual-pane-mapper-item.selected .dual-pane-mapper-item-select-indicator {
   visibility: visible;
 }
 .dual-pane-mapper-list .dual-pane-mapper-item:hover {
@@ -73,11 +74,8 @@
 }
 .dual-pane-mapper-list .dual-pane-mapper-item-container {
   display: inline-block;
-  overflow: hidden;
-  text-overflow: ellipsis;
   vertical-align: middle;
-  white-space: nowrap;
-  width: calc(100% - 26px);
+  min-width: calc(100% - 26px);
 }
 .dual-pane-mapper-list .dual-pane-mapper-item .clickable-icon {
   padding-left: 7px;

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/DualPaneMapper/DualPaneMapperList.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/DualPaneMapper/DualPaneMapperList.js
@@ -11,10 +11,10 @@ const DualPaneMapperList = ({ children, listTitle, loading, id, counter }) => {
 
   return (
     <div className="dual-pane-mapper-list-container">
+      <label htmlFor="availableTitle">
+        <span id="listTitle">{listTitle}</span>
+      </label>
       <div className="dual-pane-mapper-list">
-        <label htmlFor="availableTitle">
-          <span id="listTitle">{listTitle}</span>
-        </label>
         <div className={classes} id={id}>
           {loading ? <Spinner loading /> : children}
         </div>

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/DualPaneMapper/DualPaneMapperListItem.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/DualPaneMapper/DualPaneMapperListItem.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import EllipsisWithTooltip from 'react-ellipsis-with-tooltip';
 import { OverlayTrigger, Popover, Icon } from 'patternfly-react';
 
 const DualPaneMapperListItem = ({ item, text, warningMessage, selected, handleClick, handleKeyPress }) => {
@@ -33,15 +32,13 @@ const DualPaneMapperListItem = ({ item, text, warningMessage, selected, handleCl
       aria-selected={selected}
       role="option"
     >
-      <EllipsisWithTooltip id={text}>
-        <div className="dual-pane-mapper-info">
-          <span className="dual-pane-mapper-item-container">
-            {text}
-            {warningOverlay}
-          </span>
-          <span className="dual-pane-mapper-item-select-indicator fa fa-check" />
-        </div>
-      </EllipsisWithTooltip>
+      <div className="dual-pane-mapper-info">
+        <span className="dual-pane-mapper-item-container">
+          {text}
+          {warningOverlay}
+        </span>
+        <span className="dual-pane-mapper-item-select-indicator fa fa-check" />
+      </div>
     </div>
   );
 };

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardClustersStep/components/ClustersStepForm/ClustersStepForm.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardClustersStep/components/ClustersStepForm/ClustersStepForm.js
@@ -7,11 +7,12 @@ import DualPaneMapperList from '../../../DualPaneMapper/DualPaneMapperList';
 import DualPaneMapperCount from '../../../DualPaneMapper/DualPaneMapperCount';
 import DualPaneMapperListItem from '../../../DualPaneMapper/DualPaneMapperListItem';
 import ClustersStepTreeView from '../ClustersStepTreeView';
-import { createNewMapping, updateMapping } from './helpers';
+import { createNewMapping, updateMapping, clusterInfo } from './helpers';
 import { sourceClustersFilter } from '../../MappingWizardClustersStepSelectors';
 import { CONVERSION_HOST_WARNING_MESSAGES } from '../../MappingWizardClustersStepConstants';
 import { RHV } from '../../../../MappingWizardConstants';
 import { multiProviderTargetLabel } from '../../../helpers';
+import { sortBy } from '../../../../helpers';
 
 class ClustersStepForm extends React.Component {
   state = {
@@ -129,7 +130,8 @@ class ClustersStepForm extends React.Component {
 
     const { selectedTargetCluster, selectedSourceClusters, selectedMapping } = this.state;
 
-    const filteredSourceClusters = sourceClustersFilter(sourceClusters, input.value);
+    const filteredSourceClusters = sortBy(clusterInfo)(sourceClustersFilter(sourceClusters, input.value));
+    const sortedTargetClusters = sortBy(clusterInfo)(targetClusters);
 
     const sourceCounter = (
       <DualPaneMapperCount selectedItems={selectedSourceClusters.length} totalItems={filteredSourceClusters.length} />
@@ -156,11 +158,7 @@ class ClustersStepForm extends React.Component {
               {filteredSourceClusters.map(item => (
                 <DualPaneMapperListItem
                   item={item}
-                  text={
-                    item.v_parent_datacenter
-                      ? `${item.ext_management_system.name} \\ ${item.v_parent_datacenter} \\ ${item.name}`
-                      : `${item.name}`
-                  }
+                  text={clusterInfo(item)}
                   key={item.id}
                   selected={
                     selectedSourceClusters && selectedSourceClusters.some(sourceCluster => sourceCluster.id === item.id)
@@ -180,7 +178,7 @@ class ClustersStepForm extends React.Component {
               loading={isFetchingTargetClusters}
               counter={targetCounter}
             >
-              {targetClusters.map(item => {
+              {sortedTargetClusters.map(item => {
                 let showConversionHostWarning = false;
                 if (targetProvider === RHV) {
                   const conversionHostsInCluster = rhvConversionHosts.filter(
@@ -192,11 +190,7 @@ class ClustersStepForm extends React.Component {
                 return (
                   <DualPaneMapperListItem
                     item={item}
-                    text={
-                      item.v_parent_datacenter
-                        ? `${item.ext_management_system.name} \\ ${item.v_parent_datacenter} \\ ${item.name}`
-                        : `${item.ext_management_system.name} \\ ${item.name}`
-                    }
+                    text={clusterInfo(item)}
                     key={item.id}
                     selected={selectedTargetCluster && selectedTargetCluster.id === item.id}
                     handleClick={this.selectTargetCluster}

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardClustersStep/components/ClustersStepForm/helpers.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardClustersStep/components/ClustersStepForm/helpers.js
@@ -16,6 +16,9 @@ export const sourceClusterWithExtendedData = sourceCluster => ({
   icon: 'fa fa-file-o'
 });
 
+export const clusterInfo = ({ ext_management_system, v_parent_datacenter, name }) =>
+  `${ext_management_system.name} \\ ${v_parent_datacenter ? `${v_parent_datacenter} \\` : ''} ${name}`;
+
 export const updateMapping = (clustersStepMapping, targetClusterToAddTo, sourceClustersToAdd) => {
   const { nodes: sourceClusters, ...targetCluster } = clustersStepMapping;
 

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardDatastoresStep/components/DatastoresStepForm/DatastoresStepForm.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardDatastoresStep/components/DatastoresStepForm/DatastoresStepForm.js
@@ -12,6 +12,7 @@ import MappingWizardTreeView from '../../../MappingWizardTreeView/MappingWizardT
 import { sourceDatastoreFilter } from '../../MappingWizardDatastoresStepSelectors';
 import { targetDatastoreTreeViewInfo, sourceDatastoreInfo, targetDatastoreInfo, updateMappings } from './helpers';
 import { multiProviderTargetLabel } from '../../../helpers';
+import { sortBy } from '../../../../helpers';
 
 class DatastoresStepForm extends React.Component {
   state = {
@@ -277,7 +278,8 @@ class DatastoresStepForm extends React.Component {
       'is-hidden': !selectedCluster
     });
 
-    const filteredSourceDatastores = sourceDatastoreFilter(sourceDatastores, input.value);
+    const filteredSourceDatastores = sortBy(sourceDatastoreInfo)(sourceDatastoreFilter(sourceDatastores, input.value));
+    const sortedTargetDatastores = sortBy(targetDatastoreInfo)(targetDatastores);
 
     const sourceCounter = (
       <DualPaneMapperCount
@@ -330,7 +332,7 @@ class DatastoresStepForm extends React.Component {
             counter={targetCounter}
           >
             {targetDatastores &&
-              targetDatastores.map(item => (
+              sortedTargetDatastores.map(item => (
                 <DualPaneMapperListItem
                   item={item}
                   text={targetDatastoreInfo(item)}

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardNetworksStep/components/NetworksStepForm/NetworksStepForm.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardNetworksStep/components/NetworksStepForm/NetworksStepForm.js
@@ -10,6 +10,7 @@ import DualPaneMapperListItem from '../../../DualPaneMapper/DualPaneMapperListIt
 import MappingWizardTreeView from '../../../MappingWizardTreeView/MappingWizardTreeView';
 import { networkKey } from '../../../../../../../common/networkKey';
 import { multiProviderTargetLabel } from '../../../helpers';
+import { sortBy } from '../../../../helpers';
 
 import {
   sourceNetworksFilter,
@@ -19,7 +20,9 @@ import {
   mappingsForTreeView,
   mappingWithTargetNetworkRemoved,
   mappingWithSourceNetworkRemoved,
-  getRepresentatives
+  getRepresentatives,
+  sourceNetworkInfo,
+  targetNetworkInfo
 } from './helpers';
 
 class NetworksStepForm extends React.Component {
@@ -303,7 +306,10 @@ class NetworksStepForm extends React.Component {
       'is-hidden': !selectedCluster
     });
 
-    const filteredSourceNetworks = sourceNetworksFilter(groupedSourceNetworks, input.value);
+    const filteredSourceNetworks = sortBy(sourceNetwork => sourceNetworkInfo(sourceNetwork, selectedCluster))(
+      sourceNetworksFilter(groupedSourceNetworks, input.value)
+    );
+    const sortedTargetNetworkReps = sortBy(targetNetworkInfo)(getRepresentatives(groupedTargetNetworks));
 
     const sourceCounter = (
       <DualPaneMapperCount selectedItems={selectedSourceNetworks.length} totalItems={filteredSourceNetworks.length} />
@@ -331,9 +337,7 @@ class NetworksStepForm extends React.Component {
                 {filteredSourceNetworks.map(sourceNetwork => (
                   <DualPaneMapperListItem
                     item={sourceNetwork}
-                    text={`${sourceNetwork.providerName} \\ ${selectedCluster.v_parent_datacenter} \\ ${
-                      sourceNetwork.name
-                    }`}
+                    text={sourceNetworkInfo(sourceNetwork, selectedCluster)}
                     key={sourceNetwork.id}
                     selected={
                       selectedSourceNetworks &&
@@ -357,10 +361,10 @@ class NetworksStepForm extends React.Component {
             counter={targetCounter}
           >
             {groupedTargetNetworks &&
-              getRepresentatives(groupedTargetNetworks).map(targetNetwork => (
+              sortedTargetNetworkReps.map(targetNetwork => (
                 <DualPaneMapperListItem
                   item={targetNetwork}
-                  text={`${targetNetwork.providerName} \\ ${targetNetwork.name}`}
+                  text={targetNetworkInfo(targetNetwork)}
                   key={targetNetwork.id}
                   selected={selectedTargetNetwork && networkKey(selectedTargetNetwork) === networkKey(targetNetwork)}
                   handleClick={this.selectTargetNetwork}

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardNetworksStep/components/NetworksStepForm/helpers.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardNetworksStep/components/NetworksStepForm/helpers.js
@@ -42,6 +42,11 @@ export const sourceNetworksFilter = (groupedSourceNetworks, networksStepMappings
   );
 };
 
+export const sourceNetworkInfo = (sourceNetwork, selectedCluster) =>
+  `${sourceNetwork.providerName} \\ ${selectedCluster.v_parent_datacenter} \\ ${sourceNetwork.name}`;
+
+export const targetNetworkInfo = targetNetwork => `${targetNetwork.providerName} \\ ${targetNetwork.name}`;
+
 export const clustersMappingWithTreeViewAttrs = clusterMapping => ({
   ...clusterMapping,
   text: clusterMapping.name,

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/helpers.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/helpers.js
@@ -1,3 +1,4 @@
+import Immutable from 'seamless-immutable';
 import { TRANSFORMATION_MAPPING_ITEM_DESTINATION_TYPES } from './MappingWizardConstants';
 
 export const mappingUrlRegex = /\/api\/\w{1,}\/\d{1,}/;
@@ -120,3 +121,6 @@ export const determineTargetProvider = transformation =>
   ).length
     ? 'openstack'
     : 'rhevm';
+
+export const sortBy = getValue => items =>
+  Immutable(items ? Immutable.asMutable(items).sort((a, b) => (getValue(a) > getValue(b) ? 1 : -1)) : []);


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1796200

When creating a mapping from a long list of clusters/datastores/networks which include long names, it was frustrating to have them in no particular order and to have to hover the mouse over each overflowing string to see the full name.

This PR modifies the clusters, datastores, and networks steps of the mapping wizard so that all source and target clusters/datastores/networks will be sorted alphabetically, removes the ellipsis tooltip effect on these items, and modifies the markup and CSS of the list containers so they can properly scroll horizontally when necessary.

# Screens
## Before
<img width="948" alt="Screenshot 2020-02-14 13 24 51" src="https://user-images.githubusercontent.com/811963/74565178-a8fde680-4f3e-11ea-87c2-bd65b6b54ec9.png">

## After
<img width="947" alt="Screenshot 2020-02-14 13 26 29" src="https://user-images.githubusercontent.com/811963/74565201-b6b36c00-4f3e-11ea-8126-2215546e3452.png">

## Screen recording of horizontal scrolling
![55a0CLY9bD](https://user-images.githubusercontent.com/811963/74565216-c0d56a80-4f3e-11ea-96c9-e3b7fae113b2.gif)
