### PR TITLE
[#1069] [BZ#1775385] Mapping Wizard: Fix OSP conversion host check to be more strict

### DIFF
--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardClustersStep/MappingWizardClustersStep.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardClustersStep/MappingWizardClustersStep.js
@@ -6,22 +6,10 @@ import { length } from 'redux-form-validators';
 
 import ClustersStepForm from './components/ClustersStepForm/ClustersStepForm';
 import { FETCH_TARGET_COMPUTE_URLS } from '../../../../../../../../redux/common/targetResources/targetResourcesConstants';
-import { OPENSTACK } from '../../MappingWizardConstants';
 
 class MappingWizardClustersStep extends React.Component {
   componentDidMount() {
-    const { targetProvider, ospConversionHosts, showAlertAction } = this.props;
     this.fetchClusters();
-    if (targetProvider === OPENSTACK && ospConversionHosts.length === 0) {
-      showAlertAction(
-        __('No OpenStack conversion hosts are configured. You can continue to create an infrastructure mapping, but you must configure a conversion host before migration execution.'), // prettier-ignore
-        'warning'
-      );
-    }
-  }
-
-  componentWillUnmount() {
-    this.props.hideAlertAction();
   }
 
   fetchClusters = () => {
@@ -46,7 +34,8 @@ class MappingWizardClustersStep extends React.Component {
       isRejectedSourceClusters,
       isRejectedTargetClusters,
       targetProvider,
-      rhvConversionHosts
+      rhvConversionHosts,
+      ospConversionHosts
     } = this.props;
 
     if (isRejectedSourceClusters || isRejectedTargetClusters) {
@@ -76,6 +65,7 @@ class MappingWizardClustersStep extends React.Component {
         isFetchingTargetClusters={isFetchingTargetClusters}
         targetProvider={targetProvider}
         rhvConversionHosts={rhvConversionHosts}
+        ospConversionHosts={ospConversionHosts}
       />
     );
   }
@@ -86,8 +76,6 @@ MappingWizardClustersStep.propTypes = {
   fetchSourceClustersAction: PropTypes.func,
   fetchTargetComputeUrls: PropTypes.object,
   fetchTargetClustersAction: PropTypes.func,
-  showAlertAction: PropTypes.func,
-  hideAlertAction: PropTypes.func,
   sourceClusters: PropTypes.arrayOf(PropTypes.object),
   targetClusters: PropTypes.arrayOf(PropTypes.object),
   isFetchingSourceClusters: PropTypes.bool,

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardClustersStep/MappingWizardClustersStepActions.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardClustersStep/MappingWizardClustersStepActions.js
@@ -2,8 +2,6 @@ import URI from 'urijs';
 import API from '../../../../../../../../common/API';
 import { FETCH_V2V_SOURCE_CLUSTERS } from './MappingWizardClustersStepConstants';
 
-export { showAlertAction, hideAlertAction } from '../../MappingWizardActions';
-
 const _getSourceClustersActionCreator = url => dispatch =>
   dispatch({
     type: FETCH_V2V_SOURCE_CLUSTERS,

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardClustersStep/MappingWizardClustersStepConstants.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardClustersStep/MappingWizardClustersStepConstants.js
@@ -1,8 +1,9 @@
-import { RHV } from '../../MappingWizardConstants';
+import { RHV, OPENSTACK } from '../../MappingWizardConstants';
 
 export const FETCH_V2V_SOURCE_CLUSTERS = 'FETCH_V2V_SOURCE_CLUSTERS';
 export const FETCH_V2V_TARGET_CLUSTERS = 'FETCH_V2V_TARGET_CLUSTERS';
 
 export const CONVERSION_HOST_WARNING_MESSAGES = {
-  [RHV]: __('You must enable at least one conversion host in the cluster. You can continue to create an infrastructure mapping that includes the target cluster, but you must enable a conversion host before running the migration plan.') // prettier-ignore
+  [RHV]: __('You must enable at least one conversion host in the target cluster. You can continue to create an infrastructure mapping that includes this cluster, but you must enable a conversion host before running the migration plan.'), // prettier-ignore
+  [OPENSTACK]: __('You must enable at least one conversion host in the target provider. You can continue to create an infrastructure mapping that includes this project, but you must enable a conversion host before running the migration plan.') // prettier-ignore
 };

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardClustersStep/__tests__/MappingWizardClustersStep.test.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardClustersStep/__tests__/MappingWizardClustersStep.test.js
@@ -27,31 +27,17 @@ describe('target provider is OSP', () => {
     targetProvider: OPENSTACK
   });
 
-  test('cloud tenants are fetched and a conversion host alert is triggered', () => {
+  test('cloud tenants are fetched', () => {
     const baseProps = getBaseProps();
     const wrapper = mount(
       <Provider store={store}>
-        <MappingWizardClustersStep {...baseProps} ospConversionHosts={[]} />
+        <MappingWizardClustersStep {...baseProps} />
       </Provider>
     );
 
     expect(baseProps.fetchTargetClustersAction).toHaveBeenCalledWith(
       FETCH_TARGET_COMPUTE_URLS[baseProps.targetProvider]
     );
-    expect(baseProps.showAlertAction).toHaveBeenCalled();
-
-    wrapper.unmount();
-  });
-
-  test('no alert is triggered when there are conversion hosts', () => {
-    const baseProps = getBaseProps();
-    const wrapper = mount(
-      <Provider store={store}>
-        <MappingWizardClustersStep {...baseProps} ospConversionHosts={[{ mock: 'data' }]} />
-      </Provider>
-    );
-
-    expect(baseProps.showAlertAction).toHaveBeenCalledTimes(0);
 
     wrapper.unmount();
   });

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardClustersStep/__tests__/__snapshots__/index.test.js.snap
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardClustersStep/__tests__/__snapshots__/index.test.js.snap
@@ -10,7 +10,6 @@ Object {
   "forceUnregisterOnUnmount": false,
   "form": "mappingWizardClustersStep",
   "getFormState": [Function],
-  "hideAlertAction": [Function],
   "initialValues": Object {
     "clusterMappings": Array [],
   },
@@ -27,7 +26,6 @@ Object {
   "shouldError": [Function],
   "shouldValidate": [Function],
   "shouldWarn": [Function],
-  "showAlertAction": [Function],
   "sourceClusters": Array [],
   "submitAsSideEffect": false,
   "targetClusters": Array [],

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardClustersStep/components/ClustersStepForm/ClustersStepForm.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardClustersStep/components/ClustersStepForm/ClustersStepForm.js
@@ -125,7 +125,8 @@ class ClustersStepForm extends React.Component {
       isFetchingTargetClusters,
       input,
       targetProvider,
-      rhvConversionHosts
+      rhvConversionHosts,
+      ospConversionHosts
     } = this.props;
 
     const { selectedTargetCluster, selectedSourceClusters, selectedMapping } = this.state;
@@ -225,7 +226,8 @@ ClustersStepForm.propTypes = {
   isFetchingSourceClusters: PropTypes.bool,
   isFetchingTargetClusters: PropTypes.bool,
   targetProvider: PropTypes.string,
-  rhvConversionHosts: PropTypes.array
+  rhvConversionHosts: PropTypes.array,
+  ospConversionHosts: PropTypes.array
 };
 
 export default ClustersStepForm;

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardClustersStep/components/ClustersStepForm/ClustersStepForm.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardClustersStep/components/ClustersStepForm/ClustersStepForm.js
@@ -10,7 +10,7 @@ import ClustersStepTreeView from '../ClustersStepTreeView';
 import { createNewMapping, updateMapping, clusterInfo } from './helpers';
 import { sourceClustersFilter } from '../../MappingWizardClustersStepSelectors';
 import { CONVERSION_HOST_WARNING_MESSAGES } from '../../MappingWizardClustersStepConstants';
-import { RHV } from '../../../../MappingWizardConstants';
+import { RHV, OPENSTACK } from '../../../../MappingWizardConstants';
 import { multiProviderTargetLabel } from '../../../helpers';
 import { sortBy } from '../../../../helpers';
 
@@ -180,13 +180,16 @@ class ClustersStepForm extends React.Component {
               counter={targetCounter}
             >
               {sortedTargetClusters.map(item => {
-                let showConversionHostWarning = false;
+                let associatedConversionHosts = [];
                 if (targetProvider === RHV) {
-                  const conversionHostsInCluster = rhvConversionHosts.filter(
-                    ch => ch.resource.ems_cluster_id === item.id
-                  );
-                  showConversionHostWarning = conversionHostsInCluster.length === 0;
+                  // RHV conversion hosts need to be in the target cluster itself
+                  associatedConversionHosts = rhvConversionHosts.filter(ch => ch.resource.ems_cluster_id === item.id);
                 }
+                if (targetProvider === OPENSTACK) {
+                  // OSP conversion hosts only need to be in the same provider as the target cluster
+                  associatedConversionHosts = ospConversionHosts.filter(ch => ch.resource.ems_id === item.ems_id);
+                }
+                const showConversionHostWarning = associatedConversionHosts.length === 0;
 
                 return (
                   <DualPaneMapperListItem

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardClustersStep/components/ClustersStepForm/__tests__/ClustersStepForm.test.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardClustersStep/components/ClustersStepForm/__tests__/ClustersStepForm.test.js
@@ -4,7 +4,7 @@ import { shallow } from 'enzyme';
 import ClustersStepForm from '../ClustersStepForm';
 import { srcClusters, tgtClusters } from '../clustersStepForm.fixtures';
 import { targetClusterWithExtendedData, sourceClusterWithExtendedData } from '../helpers';
-import { RHV } from '../../../../../MappingWizardConstants';
+import { RHV, OPENSTACK } from '../../../../../MappingWizardConstants';
 
 let onChange;
 let baseProps;
@@ -97,7 +97,9 @@ describe('RHV conversion hosts', () => {
     ...baseProps,
     input: { value: [], onChange },
     sourceClusters: [],
-    targetClusters: [{ id: '1', name: 'target cluster', ems_id: '1', ext_management_system: { name: 'RHV' } }],
+    targetClusters: [
+      { id: 'cluster1', name: 'target cluster', ems_id: 'ems1', ext_management_system: { name: 'RHV' } }
+    ],
     targetProvider: RHV
   };
 
@@ -108,8 +110,33 @@ describe('RHV conversion hosts', () => {
   });
 
   test('does not display a warning icon if the target cluster has a configured conversion host', () => {
-    const rhvConversionHosts = [{ resource: { ems_cluster_id: '1' } }];
+    const rhvConversionHosts = [{ resource: { ems_cluster_id: 'cluster1' } }];
     const wrapper = shallow(<ClustersStepForm {...props} rhvConversionHosts={rhvConversionHosts} />);
+    const listItem = wrapper.find('DualPaneMapperListItem');
+    expect(listItem.prop('warningMessage')).toBeFalsy();
+  });
+});
+
+describe('OSP conversion hosts', () => {
+  const props = {
+    ...baseProps,
+    input: { value: [], onChange },
+    sourceClusters: [],
+    targetClusters: [
+      { id: 'project1', name: 'target project', ems_id: 'ems1', ext_management_system: { name: 'OSP' } }
+    ],
+    targetProvider: OPENSTACK
+  };
+
+  test('displays a warning icon if the target provider does not have a configured conversion host', () => {
+    const wrapper = shallow(<ClustersStepForm {...props} ospConversionHosts={[]} />);
+    const listItem = wrapper.find('DualPaneMapperListItem');
+    expect(listItem.prop('warningMessage')).toBeTruthy();
+  });
+
+  test('does not display a warning icon if there is a configured conversion host anywhere in the target provider', () => {
+    const ospConversionHosts = [{ resource: { ems_id: 'ems1', ems_cluster_id: 'project2' } }];
+    const wrapper = shallow(<ClustersStepForm {...props} ospConversionHosts={ospConversionHosts} />);
     const listItem = wrapper.find('DualPaneMapperListItem');
     expect(listItem.prop('warningMessage')).toBeFalsy();
   });


### PR DESCRIPTION
Fixes #1069 
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1775385

In the case where the user has more than one OpenStack provider configured, but only has conversion hosts configured in one of them, the mapping wizard was not able to warn them that migrations to the provider with no conversion hosts would fail (it only showed a warning if there were no OSP conversion hosts anywhere).

This PR moves the alert from a wizard-level inline alert into individual alert icons next to each target project (just like RHV conversion host warnings) and appears on any project which is in a provider where there are no OSP conversion hosts.

This also updates the text of the existing RHV warning to make it consistent with the new OSP one, based on @vconzola 's copy here: https://github.com/ManageIQ/manageiq-v2v/issues/1069#issuecomment-557281392

![Screenshot 2020-02-18 16 42 15](https://user-images.githubusercontent.com/811963/74780452-a0bee780-526d-11ea-8bff-f9ac2699d731.png)
