### PR TITLE
[Part 3/3 of BZ#1789479] UI changes for UCI: Remove OpenStack User field from conversion host wizard, always pass "cloud-user".

### DIFF
--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/ConversionHostWizardAuthenticationStep.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/ConversionHostWizardAuthenticationStep.js
@@ -5,7 +5,6 @@ import { required } from 'redux-form-validators';
 import { Form, Switch } from 'patternfly-react';
 import { stepIDs, VDDK, SSH } from '../ConversionHostWizardConstants';
 import { FormField } from '../../../../../../common/forms/FormField';
-import { OPENSTACK } from '../../../../../../../../../common/constants';
 import { BootstrapSelect } from '../../../../../../common/forms/BootstrapSelect';
 import TextFileField from '../../../../../../common/forms/TextFileField';
 import { getConversionHostSshKeyInfoMessage } from '../../../../../helpers';
@@ -21,18 +20,6 @@ export const ConversionHostWizardAuthenticationStep = ({
 
   return (
     <Form className="form-horizontal">
-      {selectedProviderType === OPENSTACK && (
-        <Field
-          {...fieldBaseProps}
-          name="openstackUser"
-          label={__('OpenStack User')}
-          component={FormField}
-          type="text"
-          controlId="openstack-user-input"
-          required
-          validate={[requiredWithMessage]}
-        />
-      )}
       <TextFileField
         {...fieldBaseProps}
         name="conversionHostSshKey"
@@ -125,7 +112,6 @@ export default reduxForm({
   forceUnregisterOnUnmount: true,
   shouldError: () => true, // Force validation to re-run on every field change so unmounted fields get excluded
   initialValues: {
-    openstackUser: 'cloud-user',
     conversionHostSshKey: { filename: '', body: '' },
     transformationMethod: VDDK,
     vmwareSshKey: { filename: '', body: '' },

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/__tests__/ConversionHostWizardAuthenticationStep.test.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/__tests__/ConversionHostWizardAuthenticationStep.test.js
@@ -29,7 +29,6 @@ describe('conversion host wizard authentication step', () => {
 
   it('renders correctly in the initial state for RHV', () => {
     const component = shallow(<ConversionHostWizardAuthenticationStep {...baseProps} />);
-    expect(component.find('Field[controlId="openstack-user-input"]')).toHaveLength(0);
     expect(component.find('TextFileField[controlId="vmware-ssh-key-input"]')).toHaveLength(0);
     expect(component.find('Field[controlId="vddk-library-path"]')).toHaveLength(0);
     expect(component.find('Field[controlId="verify-ca-certs"]')).toHaveLength(1);
@@ -41,7 +40,6 @@ describe('conversion host wizard authentication step', () => {
     const component = shallow(
       <ConversionHostWizardAuthenticationStep {...baseProps} selectedProviderType={OPENSTACK} />
     );
-    expect(component.find('Field[controlId="openstack-user-input"]')).toHaveLength(1);
     expect(component.find('TextFileField[controlId="vmware-ssh-key-input"]')).toHaveLength(0);
     expect(component.find('Field[controlId="vddk-library-path"]')).toHaveLength(0);
     expect(component.find('Field[controlId="verify-ca-certs"]')).toHaveLength(1);

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/__tests__/__snapshots__/ConversionHostWizardAuthenticationStep.test.js.snap
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/__tests__/__snapshots__/ConversionHostWizardAuthenticationStep.test.js.snap
@@ -8,21 +8,6 @@ exports[`conversion host wizard authentication step renders correctly in the ini
   horizontal={false}
   inline={false}
 >
-  <Field
-    component={[Function]}
-    controlId="openstack-user-input"
-    controlWidth={7}
-    label="OpenStack User"
-    labelWidth={4}
-    name="openstackUser"
-    required={true}
-    type="text"
-    validate={
-      Array [
-        [Function],
-      ]
-    }
-  />
   <TextFileField
     controlId="host-ssh-key-input"
     controlWidth={7}
@@ -324,21 +309,6 @@ exports[`conversion host wizard authentication step renders correctly with verif
   horizontal={false}
   inline={false}
 >
-  <Field
-    component={[Function]}
-    controlId="openstack-user-input"
-    controlWidth={7}
-    label="OpenStack User"
-    labelWidth={4}
-    name="openstackUser"
-    required={true}
-    type="text"
-    validate={
-      Array [
-        [Function],
-      ]
-    }
-  />
   <TextFileField
     controlId="host-ssh-key-input"
     controlWidth={7}

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/__tests__/__snapshots__/index.test.js.snap
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/__tests__/__snapshots__/index.test.js.snap
@@ -16,7 +16,6 @@ Object {
       "body": "",
       "filename": "",
     },
-    "openstackUser": "cloud-user",
     "transformationMethod": "VDDK",
     "verifyCaCerts": false,
     "vmwareSshKey": Object {

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardResultsStep/__tests__/__snapshots__/helpers.test.js.snap
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardResultsStep/__tests__/__snapshots__/helpers.test.js.snap
@@ -1,6 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`conversion host wizard results step helpers for OSP hosts constructs a POST body for a VDDK conversion host without CA certs 1`] = `
+exports[`conversion host wizard results step helpers constructs a POST body for a VDDK conversion host with CA certs 1`] = `
+Array [
+  Object {
+    "auth_user": "cloud-user",
+    "conversion_host_ssh_private_key": "mock conversion host SSH key body",
+    "name": "Mock Host",
+    "resource_id": "1",
+    "resource_type": "mock host type",
+    "tls_ca_certs": "mock CA certs body",
+    "vmware_vddk_package_url": "mock VDDK path",
+  },
+]
+`;
+
+exports[`conversion host wizard results step helpers constructs a POST body for a VDDK conversion host without CA certs 1`] = `
 Array [
   Object {
     "auth_user": "cloud-user",
@@ -13,7 +27,7 @@ Array [
 ]
 `;
 
-exports[`conversion host wizard results step helpers for OSP hosts constructs a POST body for an SSH conversion host with CA certs 1`] = `
+exports[`conversion host wizard results step helpers constructs a POST body for an SSH conversion host with CA certs 1`] = `
 Array [
   Object {
     "auth_user": "cloud-user",
@@ -27,36 +41,10 @@ Array [
 ]
 `;
 
-exports[`conversion host wizard results step helpers for OSP hosts constructs a POST body for an SSH conversion host without CA certs 1`] = `
+exports[`conversion host wizard results step helpers constructs a POST body for an SSH conversion host without CA certs 1`] = `
 Array [
   Object {
     "auth_user": "cloud-user",
-    "conversion_host_ssh_private_key": "mock conversion host SSH key body",
-    "name": "Mock Host",
-    "resource_id": "1",
-    "resource_type": "mock host type",
-    "vmware_ssh_private_key": "mock vmware SSH key body",
-  },
-]
-`;
-
-exports[`conversion host wizard results step helpers for RHV hosts constructs a POST body for a VDDK conversion host 1`] = `
-Array [
-  Object {
-    "auth_user": "root",
-    "conversion_host_ssh_private_key": "mock conversion host SSH key body",
-    "name": "Mock Host",
-    "resource_id": "1",
-    "resource_type": "mock host type",
-    "vmware_vddk_package_url": "mock VDDK path",
-  },
-]
-`;
-
-exports[`conversion host wizard results step helpers for RHV hosts constructs a POST body for an SSH conversion host 1`] = `
-Array [
-  Object {
-    "auth_user": "root",
     "conversion_host_ssh_private_key": "mock conversion host SSH key body",
     "name": "Mock Host",
     "resource_id": "1",

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardResultsStep/__tests__/__snapshots__/index.test.js.snap
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardResultsStep/__tests__/__snapshots__/index.test.js.snap
@@ -6,7 +6,7 @@ Object {
   "isRejectedPostingConversionHosts": false,
   "postBodies": Array [
     Object {
-      "auth_user": "root",
+      "auth_user": "cloud-user",
       "conversion_host_ssh_private_key": "mock conversion host SSH key body",
       "name": "Mock Host",
       "resource_id": "1",

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardResultsStep/__tests__/helpers.test.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardResultsStep/__tests__/helpers.test.js
@@ -1,4 +1,3 @@
-import { RHV, OPENSTACK } from '../../../../../../../../../../common/constants';
 import { getConfigureConversionHostPostBodies } from '../helpers';
 import { VDDK, SSH } from '../../ConversionHostWizardConstants';
 
@@ -21,46 +20,49 @@ describe('conversion host wizard results step helpers', () => {
     vmwareSshKey: { body: 'mock vmware SSH key body' }
   };
 
-  describe('for RHV hosts', () => {
-    const locationStepValues = { providerType: RHV };
-
-    it('constructs a POST body for a VDDK conversion host', () => {
-      const postBodies = getConfigureConversionHostPostBodies(locationStepValues, hostsStepValues, vddkAuthStepValues);
-      expect(postBodies).toMatchSnapshot();
-    });
-
-    it('constructs a POST body for an SSH conversion host', () => {
-      const postBodies = getConfigureConversionHostPostBodies(locationStepValues, hostsStepValues, sshAuthStepValues);
-      expect(postBodies).toMatchSnapshot();
-    });
+  it('constructs a POST body for a VDDK conversion host without CA certs', () => {
+    const postBodies = getConfigureConversionHostPostBodies({ hostsStepValues, authStepValues: vddkAuthStepValues });
+    expect(postBodies).toMatchSnapshot();
   });
 
-  describe('for OSP hosts', () => {
-    const locationStepValues = { providerType: OPENSTACK };
+  it('constructs a POST body for an SSH conversion host without CA certs', () => {
+    const postBodies = getConfigureConversionHostPostBodies({ hostsStepValues, authStepValues: sshAuthStepValues });
+    expect(postBodies).toMatchSnapshot();
+  });
 
-    it('constructs a POST body for a VDDK conversion host without CA certs', () => {
-      const postBodies = getConfigureConversionHostPostBodies(locationStepValues, hostsStepValues, {
+  it('constructs a POST body for a VDDK conversion host with CA certs', () => {
+    const postBodies = getConfigureConversionHostPostBodies({
+      hostsStepValues,
+      authStepValues: {
         ...vddkAuthStepValues,
-        openstackUser: 'cloud-user'
-      });
-      expect(postBodies).toMatchSnapshot();
-    });
-
-    it('constructs a POST body for an SSH conversion host without CA certs', () => {
-      const postBodies = getConfigureConversionHostPostBodies(locationStepValues, hostsStepValues, {
-        ...sshAuthStepValues,
-        openstackUser: 'cloud-user'
-      });
-      expect(postBodies).toMatchSnapshot();
-    });
-
-    it('constructs a POST body for an SSH conversion host with CA certs', () => {
-      const postBodies = getConfigureConversionHostPostBodies(locationStepValues, hostsStepValues, {
-        ...sshAuthStepValues,
-        openstackUser: 'cloud-user',
+        verifyCaCerts: true,
         caCerts: { body: 'mock CA certs body' }
-      });
-      expect(postBodies).toMatchSnapshot();
+      }
     });
+    expect(postBodies).toMatchSnapshot();
+  });
+
+  it('constructs a POST body for an SSH conversion host with CA certs', () => {
+    const postBodies = getConfigureConversionHostPostBodies({
+      hostsStepValues,
+      authStepValues: {
+        ...sshAuthStepValues,
+        verifyCaCerts: true,
+        caCerts: { body: 'mock CA certs body' }
+      }
+    });
+    expect(postBodies).toMatchSnapshot();
+  });
+
+  it('does not include the CA cert property if the verify certs switch is turned off even if there is form data for it', () => {
+    const postBodies = getConfigureConversionHostPostBodies({
+      hostsStepValues,
+      authStepValues: {
+        ...vddkAuthStepValues,
+        verifyCaCerts: false,
+        caCerts: { body: 'mock CA certs body' }
+      }
+    });
+    expect(postBodies[0].tls_ca_certs).toBeUndefined();
   });
 });

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardResultsStep/helpers.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardResultsStep/helpers.js
@@ -1,7 +1,6 @@
-import { OPENSTACK } from '../../../../../../../../../common/constants';
 import { VDDK } from '../ConversionHostWizardConstants';
 
-export const getConfigureConversionHostPostBodies = (locationStepValues, hostsStepValues, authStepValues) =>
+export const getConfigureConversionHostPostBodies = ({ hostsStepValues, authStepValues }) =>
   hostsStepValues.hosts.map(host => {
     const vmwareAuthProperties =
       authStepValues.transformationMethod === VDDK
@@ -12,8 +11,8 @@ export const getConfigureConversionHostPostBodies = (locationStepValues, hostsSt
       resource_type: host.type,
       resource_id: host.id,
       conversion_host_ssh_private_key: authStepValues.conversionHostSshKey.body,
-      auth_user: locationStepValues.providerType === OPENSTACK ? authStepValues.openstackUser : 'root',
-      ...(authStepValues.caCerts.body && { tls_ca_certs: authStepValues.caCerts.body }),
+      auth_user: 'cloud-user',
+      ...(authStepValues.verifyCaCerts && authStepValues.caCerts.body && { tls_ca_certs: authStepValues.caCerts.body }),
       ...vmwareAuthProperties
     };
   });

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardResultsStep/index.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardResultsStep/index.js
@@ -9,10 +9,9 @@ const mapStateToProps = ({
   form,
   settings: { isPostingConversionHosts, isRejectedPostingConversionHosts, postConversionHostsResults }
 }) => {
-  const locationStepValues = form[stepIDs.locationStep] && form[stepIDs.locationStep].values;
   const hostsStepValues = form[stepIDs.hostsStep] && form[stepIDs.hostsStep].values;
   const authStepValues = form[stepIDs.authenticationStep] && form[stepIDs.authenticationStep].values;
-  const postBodies = getConfigureConversionHostPostBodies(locationStepValues, hostsStepValues, authStepValues);
+  const postBodies = getConfigureConversionHostPostBodies({ hostsStepValues, authStepValues });
   return {
     postBodies,
     isPostingConversionHosts,


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1789479
JIRA: https://issues.redhat.com/browse/MIGENG-316

UCI conversion hosts all use the username `cloud-user`, so there is no longer a reason to ask for it for OSP or default it to `root` for RHV.

<img width="933" alt="Screenshot 2020-02-19 13 19 55" src="https://user-images.githubusercontent.com/811963/74864955-63666280-531e-11ea-9496-fd2980d757dc.png">

<img width="931" alt="Screenshot 2020-02-19 13 22 42" src="https://user-images.githubusercontent.com/811963/74864973-682b1680-531e-11ea-800f-7d85b6e8d180.png">

This PR also fixes a minor issue with the `caCerts` field where it would still be included in the API request if the user entered data there and then turned off the "verify certs" switch. I added a new unit test for that while I was updating these tests.
