### PR TITLE
Fix update of vertical menu styles after menu click

### DIFF
--- a/app/javascript/common/menu.js
+++ b/app/javascript/common/menu.js
@@ -2,7 +2,7 @@ import http from './http';
 import { links } from '../react/config/config';
 
 const updateUrl = '/migration/menu_section_url?section=migration&url=/migration%23';
-const activeMenuItemSelector = '[data-target="#menu-migration"] > div > ul > li[class="list-group-item active"]';
+const activeMenuItemSelector = 'li[id="menu_section_migration"] > div > ul > li[class="menu-list-group-item active"]';
 
 export const updateVerticalMenu = path => {
   // POST /migration/menu_section_url to update session[:tab_url] on server


### PR DESCRIPTION
The layout, styles & classes changed a little bit when the vertical menu was re-done into React.

Previously, the menu items would not be correctly marked as inactive when navigating between sections. See screenshot.
![Screenshot from 2020-02-21 11-47-49](https://user-images.githubusercontent.com/6648365/75028293-4d80ab00-54a0-11ea-8cfd-9d6d62f1062f.png)
