### PR TITLE
[IVANCHUK] Backport for #1109 ([Part 3/3 of BZ#1789479] UI changes for UCI: Remove OpenStack User field from conversion host wizard, always pass "cloud-user")

### DIFF
--- a/app/javascript/react/screens/App/Settings/__tests__/__snapshots__/SettingsActions.test.js.snap
+++ b/app/javascript/react/screens/App/Settings/__tests__/__snapshots__/SettingsActions.test.js.snap
@@ -169,7 +169,6 @@ Array [
         },
         "transformation": Object {
           "limits": Object {
-            "cpu_limit_per_host": 10,
             "max_concurrent_tasks_per_ems": 10,
             "max_concurrent_tasks_per_host": 10,
           },
@@ -207,7 +206,6 @@ Array [
         },
         "transformation": Object {
           "limits": Object {
-            "cpu_limit_per_host": 10,
             "max_concurrent_tasks_per_ems": 10,
             "max_concurrent_tasks_per_host": 10,
           },

--- a/app/javascript/react/screens/App/Settings/__tests__/__snapshots__/SettingsReducer.test.js.snap
+++ b/app/javascript/react/screens/App/Settings/__tests__/__snapshots__/SettingsReducer.test.js.snap
@@ -586,7 +586,6 @@ Object {
   "isSavingSettings": false,
   "postConversionHostsResults": Array [],
   "savedSettings": Object {
-    "cpu_limit_per_host": 10,
     "max_concurrent_tasks_per_ems": 10,
     "max_concurrent_tasks_per_host": 10,
   },
@@ -828,7 +827,6 @@ Object {
   "isSavingSettings": false,
   "postConversionHostsResults": Array [],
   "savedSettings": Object {
-    "cpu_limit_per_host": 10,
     "max_concurrent_tasks_per_ems": 10,
     "max_concurrent_tasks_per_host": 10,
   },

--- a/app/javascript/react/screens/App/Settings/helpers.js
+++ b/app/javascript/react/screens/App/Settings/helpers.js
@@ -3,16 +3,14 @@ import { RHV, OPENSTACK } from '../../../../common/constants';
 
 export const getFormValuesFromApiSettings = payload => ({
   max_concurrent_tasks_per_host: payload.transformation.limits.max_concurrent_tasks_per_host,
-  max_concurrent_tasks_per_ems: payload.transformation.limits.max_concurrent_tasks_per_ems,
-  cpu_limit_per_host: payload.transformation.limits.cpu_limit_per_host
+  max_concurrent_tasks_per_ems: payload.transformation.limits.max_concurrent_tasks_per_ems
 });
 
 export const getApiSettingsFromFormValues = values => ({
   transformation: {
     limits: {
       max_concurrent_tasks_per_host: values.max_concurrent_tasks_per_host,
-      max_concurrent_tasks_per_ems: values.max_concurrent_tasks_per_ems,
-      cpu_limit_per_host: values.cpu_limit_per_host
+      max_concurrent_tasks_per_ems: values.max_concurrent_tasks_per_ems
     }
   }
 });

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/ConversionHostWizardAuthenticationStep.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/ConversionHostWizardAuthenticationStep.js
@@ -5,7 +5,6 @@ import { required } from 'redux-form-validators';
 import { Form, Switch } from 'patternfly-react';
 import { stepIDs, VDDK, SSH } from '../ConversionHostWizardConstants';
 import { FormField } from '../../../../../../common/forms/FormField';
-import { OPENSTACK } from '../../../../../../../../../common/constants';
 import { BootstrapSelect } from '../../../../../../common/forms/BootstrapSelect';
 import TextFileField from '../../../../../../common/forms/TextFileField';
 import { getConversionHostSshKeyInfoMessage } from '../../../../../helpers';
@@ -21,18 +20,6 @@ const ConversionHostWizardAuthenticationStep = ({
 
   return (
     <Form className="form-horizontal">
-      {selectedProviderType === OPENSTACK && (
-        <Field
-          {...fieldBaseProps}
-          name="openstackUser"
-          label={__('OpenStack User')}
-          component={FormField}
-          type="text"
-          controlId="openstack-user-input"
-          required
-          validate={[requiredWithMessage]}
-        />
-      )}
       <TextFileField
         {...fieldBaseProps}
         name="conversionHostSshKey"
@@ -125,7 +112,6 @@ export default reduxForm({
   destroyOnUnmount: false,
   forceUnregisterOnUnmount: true,
   initialValues: {
-    openstackUser: 'cloud-user',
     conversionHostSshKey: { filename: '', body: '' },
     transformationMethod: VDDK,
     vmwareSshKey: { filename: '', body: '' },

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/ConversionHostWizardAuthenticationStep.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/ConversionHostWizardAuthenticationStep.js
@@ -79,6 +79,7 @@ const ConversionHostWizardAuthenticationStep = ({
         />
       )}
       {selectedProviderType === OPENSTACK && (
+        // TODO collect CA certs for RHV too, see chat with Fabien for strings.
         <React.Fragment>
           <Field
             {...fieldBaseProps}

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/ConversionHostWizardAuthenticationStep.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/ConversionHostWizardAuthenticationStep.js
@@ -15,7 +15,7 @@ const requiredWithMessage = required({ msg: __('This field is required') });
 const ConversionHostWizardAuthenticationStep = ({
   selectedProviderType,
   selectedTransformationMethod,
-  verifyOpenstackCerts
+  verifyCaCerts
 }) => {
   const fieldBaseProps = { labelWidth: 4, controlWidth: 7 };
 
@@ -78,41 +78,38 @@ const ConversionHostWizardAuthenticationStep = ({
           validate={[requiredWithMessage]}
         />
       )}
-      {selectedProviderType === OPENSTACK && (
-        // TODO collect CA certs for RHV too, see chat with Fabien for strings.
-        <React.Fragment>
-          <Field
-            {...fieldBaseProps}
-            name="verifyOpenstackCerts"
-            label={__('Verify TLS Certificates for OpenStack')}
-            component={FormField}
-            controlId="verify-openstack-certs"
-            style={{ marginTop: 25 }}
-            validate={() => undefined} // Force redux-form to re-run validation when this field changes, since it can unmount openstackCaCerts
-          >
-            {({ input: { value, onChange } }) => (
-              <Switch
-                bsSize="normal"
-                id="verify-openstack-certs-switch"
-                onText={__('Yes')}
-                offText={__('No')}
-                defaultValue={false}
-                value={value}
-                onChange={(element, state) => onChange(state)}
-              />
-            )}
-          </Field>
-          {verifyOpenstackCerts && (
-            <TextFileField
-              {...fieldBaseProps}
-              name="openstackCaCerts"
-              label={__('OpenStack Trusted CA Certificates')}
-              help={__('Upload your certificates file, in PEM format, or paste its contents below.')}
-              controlId="openstack-ca-certs-input"
+      <React.Fragment>
+        <Field
+          {...fieldBaseProps}
+          name="verifyCaCerts"
+          label={__('Verify TLS Certificates')}
+          component={FormField}
+          controlId="verify-ca-certs"
+          style={{ marginTop: 25 }}
+          validate={() => undefined} // Force redux-form to re-run validation when this field changes, since it can unmount openstackCaCerts
+        >
+          {({ input: { value, onChange } }) => (
+            <Switch
+              bsSize="normal"
+              id="verify-ca-certs-switch"
+              onText={__('Yes')}
+              offText={__('No')}
+              defaultValue={false}
+              value={value}
+              onChange={(element, state) => onChange(state)}
             />
           )}
-        </React.Fragment>
-      )}
+        </Field>
+        {verifyCaCerts && (
+          <TextFileField
+            {...fieldBaseProps}
+            name="caCerts"
+            label={__('Trusted CA Certificates')}
+            help={__('Upload your certificates file, in PEM format, or paste its contents below.')}
+            controlId="ca-certs-input"
+          />
+        )}
+      </React.Fragment>
     </Form>
   );
 };
@@ -120,7 +117,7 @@ const ConversionHostWizardAuthenticationStep = ({
 ConversionHostWizardAuthenticationStep.propTypes = {
   selectedProviderType: PropTypes.string,
   selectedTransformationMethod: PropTypes.string,
-  verifyOpenstackCerts: PropTypes.bool
+  verifyCaCerts: PropTypes.bool
 };
 
 export default reduxForm({
@@ -132,7 +129,7 @@ export default reduxForm({
     conversionHostSshKey: { filename: '', body: '' },
     transformationMethod: VDDK,
     vmwareSshKey: { filename: '', body: '' },
-    openstackCaCerts: { filename: '', body: '' },
-    verifyOpenstackCerts: false
+    caCerts: { filename: '', body: '' },
+    verifyCaCerts: false
   }
 })(ConversionHostWizardAuthenticationStep);

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/__tests__/ConversionHostWizardAuthenticationStep.test.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/__tests__/ConversionHostWizardAuthenticationStep.test.js
@@ -31,7 +31,6 @@ describe('conversion host wizard authentication step', () => {
 
   it('renders correctly in the initial state for RHV', () => {
     const component = shallowDive(<ConversionHostWizardAuthenticationStep {...baseProps} />);
-    expect(component.find('Field[controlId="openstack-user-input"]')).toHaveLength(0);
     expect(component.find('TextFileField[controlId="vmware-ssh-key-input"]')).toHaveLength(0);
     expect(component.find('Field[controlId="vddk-library-path"]')).toHaveLength(0);
     expect(component.find('Field[controlId="verify-ca-certs"]')).toHaveLength(1);
@@ -43,7 +42,6 @@ describe('conversion host wizard authentication step', () => {
     const component = shallowDive(
       <ConversionHostWizardAuthenticationStep {...baseProps} selectedProviderType={OPENSTACK} />
     );
-    expect(component.find('Field[controlId="openstack-user-input"]')).toHaveLength(1);
     expect(component.find('TextFileField[controlId="vmware-ssh-key-input"]')).toHaveLength(0);
     expect(component.find('Field[controlId="vddk-library-path"]')).toHaveLength(0);
     expect(component.find('Field[controlId="verify-ca-certs"]')).toHaveLength(1);

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/__tests__/ConversionHostWizardAuthenticationStep.test.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/__tests__/ConversionHostWizardAuthenticationStep.test.js
@@ -13,7 +13,7 @@ describe('conversion host wizard authentication step', () => {
   const baseProps = {
     selectedProviderType: RHV,
     selectedTransformationMethod: null,
-    verifyOpenstackCerts: null,
+    verifyCaCerts: null,
     store
   };
 
@@ -34,8 +34,8 @@ describe('conversion host wizard authentication step', () => {
     expect(component.find('Field[controlId="openstack-user-input"]')).toHaveLength(0);
     expect(component.find('TextFileField[controlId="vmware-ssh-key-input"]')).toHaveLength(0);
     expect(component.find('Field[controlId="vddk-library-path"]')).toHaveLength(0);
-    expect(component.find('Field[controlId="verify-openstack-certs"]')).toHaveLength(0);
-    expect(component.find('TextFileField[controlId="openstack-ca-certs-input"]')).toHaveLength(0);
+    expect(component.find('Field[controlId="verify-ca-certs"]')).toHaveLength(1);
+    expect(component.find('TextFileField[controlId="ca-certs-input"]')).toHaveLength(0);
     expect(component).toMatchSnapshot();
   });
 
@@ -46,8 +46,8 @@ describe('conversion host wizard authentication step', () => {
     expect(component.find('Field[controlId="openstack-user-input"]')).toHaveLength(1);
     expect(component.find('TextFileField[controlId="vmware-ssh-key-input"]')).toHaveLength(0);
     expect(component.find('Field[controlId="vddk-library-path"]')).toHaveLength(0);
-    expect(component.find('Field[controlId="verify-openstack-certs"]')).toHaveLength(1);
-    expect(component.find('TextFileField[controlId="openstack-ca-certs-input"]')).toHaveLength(0);
+    expect(component.find('Field[controlId="verify-ca-certs"]')).toHaveLength(1);
+    expect(component.find('TextFileField[controlId="ca-certs-input"]')).toHaveLength(0);
     expect(component).toMatchSnapshot();
   });
 
@@ -56,7 +56,7 @@ describe('conversion host wizard authentication step', () => {
       <ConversionHostWizardAuthenticationStep {...baseProps} selectedProviderType={OPENSTACK} />
     );
     const onSwitchChange = jest.fn();
-    const switchRenderProp = component.find('Field[controlId="verify-openstack-certs"]').props().children;
+    const switchRenderProp = component.find('Field[controlId="verify-ca-certs"]').props().children;
     const renderedSwitch = switchRenderProp({ input: { value: false, onChange: onSwitchChange } });
     expect(renderedSwitch).toMatchSnapshot();
     mount(renderedSwitch)
@@ -65,11 +65,11 @@ describe('conversion host wizard authentication step', () => {
     expect(onSwitchChange).toHaveBeenCalledWith(true);
   });
 
-  it('renders correctly with verify OSP TLS certs turned on', () => {
+  it('renders correctly with verify TLS certs turned on', () => {
     const component = shallowDive(
-      <ConversionHostWizardAuthenticationStep {...baseProps} selectedProviderType={OPENSTACK} verifyOpenstackCerts />
+      <ConversionHostWizardAuthenticationStep {...baseProps} selectedProviderType={OPENSTACK} verifyCaCerts />
     );
-    expect(component.find('TextFileField[controlId="openstack-ca-certs-input"]')).toHaveLength(1);
+    expect(component.find('TextFileField[controlId="ca-certs-input"]')).toHaveLength(1);
     expect(component).toMatchSnapshot();
   });
 

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/__tests__/__snapshots__/ConversionHostWizardAuthenticationStep.test.js.snap
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/__tests__/__snapshots__/ConversionHostWizardAuthenticationStep.test.js.snap
@@ -66,18 +66,16 @@ exports[`conversion host wizard authentication step renders correctly in the ini
       ]
     }
   />
-  <React.Fragment>
-    <Field
-      component={[Function]}
-      controlId="verify-openstack-certs"
-      controlWidth={7}
-      label="Verify TLS Certificates for OpenStack"
-      labelWidth={4}
-      name="verifyOpenstackCerts"
-      style={
-        Object {
-          "marginTop": 25,
-        }
+  <Field
+    component={[Function]}
+    controlId="verify-ca-certs"
+    controlWidth={7}
+    label="Verify TLS Certificates"
+    labelWidth={4}
+    name="verifyCaCerts"
+    style={
+      Object {
+        "marginTop": 25,
       }
       validate={[Function]}
     />
@@ -136,6 +134,22 @@ exports[`conversion host wizard authentication step renders correctly in the ini
       ]
     }
   />
+  <Field
+    component={[Function]}
+    controlId="verify-ca-certs"
+    controlWidth={7}
+    label="Verify TLS Certificates"
+    labelWidth={4}
+    name="verifyCaCerts"
+    style={
+      Object {
+        "marginTop": 25,
+      }
+    }
+    validate={[Function]}
+  >
+    <Component />
+  </Field>
 </Form>
 `;
 
@@ -199,6 +213,22 @@ exports[`conversion host wizard authentication step renders correctly with SSH t
     labelWidth={4}
     name="vmwareSshKey"
   />
+  <Field
+    component={[Function]}
+    controlId="verify-ca-certs"
+    controlWidth={7}
+    label="Verify TLS Certificates"
+    labelWidth={4}
+    name="verifyCaCerts"
+    style={
+      Object {
+        "marginTop": 25,
+      }
+    }
+    validate={[Function]}
+  >
+    <Component />
+  </Field>
 </Form>
 `;
 
@@ -269,10 +299,26 @@ exports[`conversion host wizard authentication step renders correctly with VDDK 
       ]
     }
   />
+  <Field
+    component={[Function]}
+    controlId="verify-ca-certs"
+    controlWidth={7}
+    label="Verify TLS Certificates"
+    labelWidth={4}
+    name="verifyCaCerts"
+    style={
+      Object {
+        "marginTop": 25,
+      }
+    }
+    validate={[Function]}
+  >
+    <Component />
+  </Field>
 </Form>
 `;
 
-exports[`conversion host wizard authentication step renders correctly with verify OSP TLS certs turned on 1`] = `
+exports[`conversion host wizard authentication step renders correctly with verify TLS certs turned on 1`] = `
 <Form
   bsClass="form"
   className="form-horizontal"
@@ -338,31 +384,30 @@ exports[`conversion host wizard authentication step renders correctly with verif
       ]
     }
   />
-  <React.Fragment>
-    <Field
-      component={[Function]}
-      controlId="verify-openstack-certs"
-      controlWidth={7}
-      label="Verify TLS Certificates for OpenStack"
-      labelWidth={4}
-      name="verifyOpenstackCerts"
-      style={
-        Object {
-          "marginTop": 25,
-        }
+  <Field
+    component={[Function]}
+    controlId="verify-ca-certs"
+    controlWidth={7}
+    label="Verify TLS Certificates"
+    labelWidth={4}
+    name="verifyCaCerts"
+    style={
+      Object {
+        "marginTop": 25,
       }
-      validate={[Function]}
-    />
-    <TextFileField
-      controlId="openstack-ca-certs-input"
-      controlWidth={7}
-      help="Upload your certificates file, in PEM format, or paste its contents below."
-      hideBody={false}
-      label="OpenStack Trusted CA Certificates"
-      labelWidth={4}
-      name="openstackCaCerts"
-    />
-  </React.Fragment>
+    }
+  >
+    <Component />
+  </Field>
+  <TextFileField
+    controlId="ca-certs-input"
+    controlWidth={7}
+    help="Upload your certificates file, in PEM format, or paste its contents below."
+    hideBody={false}
+    label="Trusted CA Certificates"
+    labelWidth={4}
+    name="caCerts"
+  />
 </Form>
 `;
 
@@ -409,34 +454,22 @@ exports[`conversion host wizard authentication step renders the redux-form wrapp
       "subscribe": [Function],
       Symbol(observable): [Function],
     }
-  }
-  touchOnBlur={true}
-  touchOnChange={false}
-  updateUnregisteredFields={false}
-  verifyOpenstackCerts={null}
-/>
-`;
-
-exports[`conversion host wizard authentication step renders the verify TLS certs switch correctly 1`] = `
-<Switch
-  animate={true}
-  baseClass="bootstrap-switch"
-  bsSize="normal"
-  defaultValue={false}
-  disabled={false}
-  handleWidth="auto"
-  id="verify-openstack-certs-switch"
-  inverse={false}
-  labelText=" "
-  labelWidth="auto"
-  offColor="default"
-  offText="No"
-  onChange={[Function]}
-  onColor="primary"
-  onText="Yes"
-  readonly={false}
-  tristate={false}
-  value={false}
-  wrapperClass="wrapper"
-/>
+  />
+  <Field
+    component={[Function]}
+    controlId="verify-ca-certs"
+    controlWidth={7}
+    label="Verify TLS Certificates"
+    labelWidth={4}
+    name="verifyCaCerts"
+    style={
+      Object {
+        "marginTop": 25,
+      }
+    }
+    validate={[Function]}
+  >
+    <Component />
+  </Field>
+</Form>
 `;

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/__tests__/__snapshots__/ConversionHostWizardAuthenticationStep.test.js.snap
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/__tests__/__snapshots__/ConversionHostWizardAuthenticationStep.test.js.snap
@@ -66,16 +66,18 @@ exports[`conversion host wizard authentication step renders correctly in the ini
       ]
     }
   />
-  <Field
-    component={[Function]}
-    controlId="verify-ca-certs"
-    controlWidth={7}
-    label="Verify TLS Certificates"
-    labelWidth={4}
-    name="verifyCaCerts"
-    style={
-      Object {
-        "marginTop": 25,
+  <React.Fragment>
+    <Field
+      component={[Function]}
+      controlId="verify-ca-certs"
+      controlWidth={7}
+      label="Verify TLS Certificates"
+      labelWidth={4}
+      name="verifyCaCerts"
+      style={
+        Object {
+          "marginTop": 25,
+        }
       }
       validate={[Function]}
     />
@@ -134,22 +136,22 @@ exports[`conversion host wizard authentication step renders correctly in the ini
       ]
     }
   />
-  <Field
-    component={[Function]}
-    controlId="verify-ca-certs"
-    controlWidth={7}
-    label="Verify TLS Certificates"
-    labelWidth={4}
-    name="verifyCaCerts"
-    style={
-      Object {
-        "marginTop": 25,
+  <React.Fragment>
+    <Field
+      component={[Function]}
+      controlId="verify-ca-certs"
+      controlWidth={7}
+      label="Verify TLS Certificates"
+      labelWidth={4}
+      name="verifyCaCerts"
+      style={
+        Object {
+          "marginTop": 25,
+        }
       }
-    }
-    validate={[Function]}
-  >
-    <Component />
-  </Field>
+      validate={[Function]}
+    />
+  </React.Fragment>
 </Form>
 `;
 
@@ -213,22 +215,22 @@ exports[`conversion host wizard authentication step renders correctly with SSH t
     labelWidth={4}
     name="vmwareSshKey"
   />
-  <Field
-    component={[Function]}
-    controlId="verify-ca-certs"
-    controlWidth={7}
-    label="Verify TLS Certificates"
-    labelWidth={4}
-    name="verifyCaCerts"
-    style={
-      Object {
-        "marginTop": 25,
+  <React.Fragment>
+    <Field
+      component={[Function]}
+      controlId="verify-ca-certs"
+      controlWidth={7}
+      label="Verify TLS Certificates"
+      labelWidth={4}
+      name="verifyCaCerts"
+      style={
+        Object {
+          "marginTop": 25,
+        }
       }
-    }
-    validate={[Function]}
-  >
-    <Component />
-  </Field>
+      validate={[Function]}
+    />
+  </React.Fragment>
 </Form>
 `;
 
@@ -299,22 +301,22 @@ exports[`conversion host wizard authentication step renders correctly with VDDK 
       ]
     }
   />
-  <Field
-    component={[Function]}
-    controlId="verify-ca-certs"
-    controlWidth={7}
-    label="Verify TLS Certificates"
-    labelWidth={4}
-    name="verifyCaCerts"
-    style={
-      Object {
-        "marginTop": 25,
+  <React.Fragment>
+    <Field
+      component={[Function]}
+      controlId="verify-ca-certs"
+      controlWidth={7}
+      label="Verify TLS Certificates"
+      labelWidth={4}
+      name="verifyCaCerts"
+      style={
+        Object {
+          "marginTop": 25,
+        }
       }
-    }
-    validate={[Function]}
-  >
-    <Component />
-  </Field>
+      validate={[Function]}
+    />
+  </React.Fragment>
 </Form>
 `;
 
@@ -384,30 +386,31 @@ exports[`conversion host wizard authentication step renders correctly with verif
       ]
     }
   />
-  <Field
-    component={[Function]}
-    controlId="verify-ca-certs"
-    controlWidth={7}
-    label="Verify TLS Certificates"
-    labelWidth={4}
-    name="verifyCaCerts"
-    style={
-      Object {
-        "marginTop": 25,
+  <React.Fragment>
+    <Field
+      component={[Function]}
+      controlId="verify-ca-certs"
+      controlWidth={7}
+      label="Verify TLS Certificates"
+      labelWidth={4}
+      name="verifyCaCerts"
+      style={
+        Object {
+          "marginTop": 25,
+        }
       }
-    }
-  >
-    <Component />
-  </Field>
-  <TextFileField
-    controlId="ca-certs-input"
-    controlWidth={7}
-    help="Upload your certificates file, in PEM format, or paste its contents below."
-    hideBody={false}
-    label="Trusted CA Certificates"
-    labelWidth={4}
-    name="caCerts"
-  />
+      validate={[Function]}
+    />
+    <TextFileField
+      controlId="ca-certs-input"
+      controlWidth={7}
+      help="Upload your certificates file, in PEM format, or paste its contents below."
+      hideBody={false}
+      label="Trusted CA Certificates"
+      labelWidth={4}
+      name="caCerts"
+    />
+  </React.Fragment>
 </Form>
 `;
 
@@ -420,17 +423,17 @@ exports[`conversion host wizard authentication step renders the redux-form wrapp
   getFormState={[Function]}
   initialValues={
     Object {
-      "conversionHostSshKey": Object {
+      "caCerts": Object {
         "body": "",
         "filename": "",
       },
-      "openstackCaCerts": Object {
+      "conversionHostSshKey": Object {
         "body": "",
         "filename": "",
       },
       "openstackUser": "cloud-user",
       "transformationMethod": "VDDK",
-      "verifyOpenstackCerts": false,
+      "verifyCaCerts": false,
       "vmwareSshKey": Object {
         "body": "",
         "filename": "",
@@ -454,22 +457,34 @@ exports[`conversion host wizard authentication step renders the redux-form wrapp
       "subscribe": [Function],
       Symbol(observable): [Function],
     }
-  />
-  <Field
-    component={[Function]}
-    controlId="verify-ca-certs"
-    controlWidth={7}
-    label="Verify TLS Certificates"
-    labelWidth={4}
-    name="verifyCaCerts"
-    style={
-      Object {
-        "marginTop": 25,
-      }
-    }
-    validate={[Function]}
-  >
-    <Component />
-  </Field>
-</Form>
+  }
+  touchOnBlur={true}
+  touchOnChange={false}
+  updateUnregisteredFields={false}
+  verifyCaCerts={null}
+/>
+`;
+
+exports[`conversion host wizard authentication step renders the verify TLS certs switch correctly 1`] = `
+<Switch
+  animate={true}
+  baseClass="bootstrap-switch"
+  bsSize="normal"
+  defaultValue={false}
+  disabled={false}
+  handleWidth="auto"
+  id="verify-ca-certs-switch"
+  inverse={false}
+  labelText=" "
+  labelWidth="auto"
+  offColor="default"
+  offText="No"
+  onChange={[Function]}
+  onColor="primary"
+  onText="Yes"
+  readonly={false}
+  tristate={false}
+  value={false}
+  wrapperClass="wrapper"
+/>
 `;

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/__tests__/__snapshots__/ConversionHostWizardAuthenticationStep.test.js.snap
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/__tests__/__snapshots__/ConversionHostWizardAuthenticationStep.test.js.snap
@@ -8,21 +8,6 @@ exports[`conversion host wizard authentication step renders correctly in the ini
   horizontal={false}
   inline={false}
 >
-  <Field
-    component={[Function]}
-    controlId="openstack-user-input"
-    controlWidth={7}
-    label="OpenStack User"
-    labelWidth={4}
-    name="openstackUser"
-    required={true}
-    type="text"
-    validate={
-      Array [
-        [Function],
-      ]
-    }
-  />
   <TextFileField
     controlId="host-ssh-key-input"
     controlWidth={7}
@@ -328,21 +313,6 @@ exports[`conversion host wizard authentication step renders correctly with verif
   horizontal={false}
   inline={false}
 >
-  <Field
-    component={[Function]}
-    controlId="openstack-user-input"
-    controlWidth={7}
-    label="OpenStack User"
-    labelWidth={4}
-    name="openstackUser"
-    required={true}
-    type="text"
-    validate={
-      Array [
-        [Function],
-      ]
-    }
-  />
   <TextFileField
     controlId="host-ssh-key-input"
     controlWidth={7}
@@ -431,7 +401,6 @@ exports[`conversion host wizard authentication step renders the redux-form wrapp
         "body": "",
         "filename": "",
       },
-      "openstackUser": "cloud-user",
       "transformationMethod": "VDDK",
       "verifyCaCerts": false,
       "vmwareSshKey": Object {

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/__tests__/__snapshots__/index.test.js.snap
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/__tests__/__snapshots__/index.test.js.snap
@@ -2,8 +2,41 @@
 
 exports[`ConversionHostWizardAuthenticationStep integration test should mount ConversionHostWizardAuthenticationStep with mapStateToProps reduced 1`] = `
 Object {
+  "destroyOnUnmount": false,
+  "enableReinitialize": false,
+  "forceUnregisterOnUnmount": true,
+  "form": "conversionHostWizardAuthenticationStep",
+  "getFormState": [Function],
+  "initialValues": Object {
+    "caCerts": Object {
+      "body": "",
+      "filename": "",
+    },
+    "conversionHostSshKey": Object {
+      "body": "",
+      "filename": "",
+    },
+    "openstackUser": "cloud-user",
+    "transformationMethod": "VDDK",
+    "verifyCaCerts": false,
+    "vmwareSshKey": Object {
+      "body": "",
+      "filename": "",
+    },
+  },
+  "keepDirtyOnReinitialize": false,
+  "persistentSubmitErrors": false,
+  "pure": true,
   "selectedProviderType": "openstack",
   "selectedTransformationMethod": "VDDK",
-  "verifyOpenstackCerts": false,
+  "shouldAsyncValidate": [Function],
+  "shouldError": [Function],
+  "shouldValidate": [Function],
+  "shouldWarn": [Function],
+  "submitAsSideEffect": false,
+  "touchOnBlur": true,
+  "touchOnChange": false,
+  "updateUnregisteredFields": false,
+  "verifyCaCerts": false,
 }
 `;

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/__tests__/__snapshots__/index.test.js.snap
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/__tests__/__snapshots__/index.test.js.snap
@@ -2,41 +2,8 @@
 
 exports[`ConversionHostWizardAuthenticationStep integration test should mount ConversionHostWizardAuthenticationStep with mapStateToProps reduced 1`] = `
 Object {
-  "destroyOnUnmount": false,
-  "enableReinitialize": false,
-  "forceUnregisterOnUnmount": true,
-  "form": "conversionHostWizardAuthenticationStep",
-  "getFormState": [Function],
-  "initialValues": Object {
-    "caCerts": Object {
-      "body": "",
-      "filename": "",
-    },
-    "conversionHostSshKey": Object {
-      "body": "",
-      "filename": "",
-    },
-    "openstackUser": "cloud-user",
-    "transformationMethod": "VDDK",
-    "verifyCaCerts": false,
-    "vmwareSshKey": Object {
-      "body": "",
-      "filename": "",
-    },
-  },
-  "keepDirtyOnReinitialize": false,
-  "persistentSubmitErrors": false,
-  "pure": true,
   "selectedProviderType": "openstack",
   "selectedTransformationMethod": "VDDK",
-  "shouldAsyncValidate": [Function],
-  "shouldError": [Function],
-  "shouldValidate": [Function],
-  "shouldWarn": [Function],
-  "submitAsSideEffect": false,
-  "touchOnBlur": true,
-  "touchOnChange": false,
-  "updateUnregisteredFields": false,
   "verifyCaCerts": false,
 }
 `;

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/__tests__/index.test.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/__tests__/index.test.js
@@ -63,12 +63,12 @@ describe('ConversionHostWizardAuthenticationStep integration test', () => {
     changeFormValue('transformationMethod', 'SSH');
     expect(form().syncErrors).toBeFalsy(); // <-------
 
-    // Turning on OpenStack TLS Certificates mounts an empty required field (openstackCaCerts)
-    changeFormValue('verifyOpenstackCerts', true);
-    expect(Object.keys(form().syncErrors)).toEqual(['openstackCaCerts']);
+    // Turning on TLS Certificates mounts an empty required field (caCerts)
+    changeFormValue('verifyCaCerts', true);
+    expect(Object.keys(form().syncErrors)).toEqual(['caCerts']);
 
-    // Turning it off unmounts openstackCaCerts while it's empty.
-    changeFormValue('verifyOpenstackCerts', false);
+    // Turning it off unmounts caCerts while it's empty.
+    changeFormValue('verifyCaCerts', false);
     expect(form().syncErrors).toBeFalsy(); // <-------
   });
 });

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/index.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/index.js
@@ -11,7 +11,7 @@ const mapStateToProps = ({ form }) => {
   return {
     selectedProviderType: locationStepValues && locationStepValues.providerType,
     selectedTransformationMethod: authStepValues && authStepValues.transformationMethod,
-    verifyOpenstackCerts: authStepValues && authStepValues.verifyOpenstackCerts
+    verifyCaCerts: authStepValues && authStepValues.verifyCaCerts
   };
 };
 

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardResultsStep/__tests__/__snapshots__/helpers.test.js.snap
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardResultsStep/__tests__/__snapshots__/helpers.test.js.snap
@@ -1,6 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`conversion host wizard results step helpers for OSP hosts constructs a POST body for a VDDK conversion host without CA certs 1`] = `
+exports[`conversion host wizard results step helpers constructs a POST body for a VDDK conversion host with CA certs 1`] = `
+Array [
+  Object {
+    "auth_user": "cloud-user",
+    "conversion_host_ssh_private_key": "mock conversion host SSH key body",
+    "name": "Mock Host",
+    "resource_id": "1",
+    "resource_type": "mock host type",
+    "tls_ca_certs": "mock CA certs body",
+    "vmware_vddk_package_url": "mock VDDK path",
+  },
+]
+`;
+
+exports[`conversion host wizard results step helpers constructs a POST body for a VDDK conversion host without CA certs 1`] = `
 Array [
   Object {
     "auth_user": "cloud-user",
@@ -13,7 +27,7 @@ Array [
 ]
 `;
 
-exports[`conversion host wizard results step helpers for OSP hosts constructs a POST body for an SSH conversion host with CA certs 1`] = `
+exports[`conversion host wizard results step helpers constructs a POST body for an SSH conversion host with CA certs 1`] = `
 Array [
   Object {
     "auth_user": "cloud-user",
@@ -27,36 +41,10 @@ Array [
 ]
 `;
 
-exports[`conversion host wizard results step helpers for OSP hosts constructs a POST body for an SSH conversion host without CA certs 1`] = `
+exports[`conversion host wizard results step helpers constructs a POST body for an SSH conversion host without CA certs 1`] = `
 Array [
   Object {
     "auth_user": "cloud-user",
-    "conversion_host_ssh_private_key": "mock conversion host SSH key body",
-    "name": "Mock Host",
-    "resource_id": "1",
-    "resource_type": "mock host type",
-    "vmware_ssh_private_key": "mock vmware SSH key body",
-  },
-]
-`;
-
-exports[`conversion host wizard results step helpers for RHV hosts constructs a POST body for a VDDK conversion host 1`] = `
-Array [
-  Object {
-    "auth_user": "root",
-    "conversion_host_ssh_private_key": "mock conversion host SSH key body",
-    "name": "Mock Host",
-    "resource_id": "1",
-    "resource_type": "mock host type",
-    "vmware_vddk_package_url": "mock VDDK path",
-  },
-]
-`;
-
-exports[`conversion host wizard results step helpers for RHV hosts constructs a POST body for an SSH conversion host 1`] = `
-Array [
-  Object {
-    "auth_user": "root",
     "conversion_host_ssh_private_key": "mock conversion host SSH key body",
     "name": "Mock Host",
     "resource_id": "1",

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardResultsStep/__tests__/__snapshots__/helpers.test.js.snap
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardResultsStep/__tests__/__snapshots__/helpers.test.js.snap
@@ -19,9 +19,9 @@ Array [
     "auth_user": "cloud-user",
     "conversion_host_ssh_private_key": "mock conversion host SSH key body",
     "name": "Mock Host",
-    "openstack_tls_ca_certs": "mock openstack CA certs body",
     "resource_id": "1",
     "resource_type": "mock host type",
+    "tls_ca_certs": "mock CA certs body",
     "vmware_ssh_private_key": "mock vmware SSH key body",
   },
 ]

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardResultsStep/__tests__/__snapshots__/index.test.js.snap
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardResultsStep/__tests__/__snapshots__/index.test.js.snap
@@ -6,7 +6,7 @@ Object {
   "isRejectedPostingConversionHosts": false,
   "postBodies": Array [
     Object {
-      "auth_user": "root",
+      "auth_user": "cloud-user",
       "conversion_host_ssh_private_key": "mock conversion host SSH key body",
       "name": "Mock Host",
       "resource_id": "1",

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardResultsStep/__tests__/helpers.test.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardResultsStep/__tests__/helpers.test.js
@@ -8,7 +8,7 @@ describe('conversion host wizard results step helpers', () => {
   };
   const commonAuthStepValues = {
     conversionHostSshKey: { body: 'mock conversion host SSH key body' },
-    openstackCaCerts: { body: '' }
+    caCerts: { body: '' }
   };
   const vddkAuthStepValues = {
     ...commonAuthStepValues,
@@ -58,7 +58,7 @@ describe('conversion host wizard results step helpers', () => {
       const postBodies = getConfigureConversionHostPostBodies(locationStepValues, hostsStepValues, {
         ...sshAuthStepValues,
         openstackUser: 'cloud-user',
-        openstackCaCerts: { body: 'mock openstack CA certs body' }
+        caCerts: { body: 'mock CA certs body' }
       });
       expect(postBodies).toMatchSnapshot();
     });

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardResultsStep/__tests__/helpers.test.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardResultsStep/__tests__/helpers.test.js
@@ -1,4 +1,3 @@
-import { RHV, OPENSTACK } from '../../../../../../../../../../common/constants';
 import { getConfigureConversionHostPostBodies } from '../helpers';
 import { VDDK, SSH } from '../../ConversionHostWizardConstants';
 
@@ -21,46 +20,49 @@ describe('conversion host wizard results step helpers', () => {
     vmwareSshKey: { body: 'mock vmware SSH key body' }
   };
 
-  describe('for RHV hosts', () => {
-    const locationStepValues = { providerType: RHV };
-
-    it('constructs a POST body for a VDDK conversion host', () => {
-      const postBodies = getConfigureConversionHostPostBodies(locationStepValues, hostsStepValues, vddkAuthStepValues);
-      expect(postBodies).toMatchSnapshot();
-    });
-
-    it('constructs a POST body for an SSH conversion host', () => {
-      const postBodies = getConfigureConversionHostPostBodies(locationStepValues, hostsStepValues, sshAuthStepValues);
-      expect(postBodies).toMatchSnapshot();
-    });
+  it('constructs a POST body for a VDDK conversion host without CA certs', () => {
+    const postBodies = getConfigureConversionHostPostBodies({ hostsStepValues, authStepValues: vddkAuthStepValues });
+    expect(postBodies).toMatchSnapshot();
   });
 
-  describe('for OSP hosts', () => {
-    const locationStepValues = { providerType: OPENSTACK };
+  it('constructs a POST body for an SSH conversion host without CA certs', () => {
+    const postBodies = getConfigureConversionHostPostBodies({ hostsStepValues, authStepValues: sshAuthStepValues });
+    expect(postBodies).toMatchSnapshot();
+  });
 
-    it('constructs a POST body for a VDDK conversion host without CA certs', () => {
-      const postBodies = getConfigureConversionHostPostBodies(locationStepValues, hostsStepValues, {
+  it('constructs a POST body for a VDDK conversion host with CA certs', () => {
+    const postBodies = getConfigureConversionHostPostBodies({
+      hostsStepValues,
+      authStepValues: {
         ...vddkAuthStepValues,
-        openstackUser: 'cloud-user'
-      });
-      expect(postBodies).toMatchSnapshot();
-    });
-
-    it('constructs a POST body for an SSH conversion host without CA certs', () => {
-      const postBodies = getConfigureConversionHostPostBodies(locationStepValues, hostsStepValues, {
-        ...sshAuthStepValues,
-        openstackUser: 'cloud-user'
-      });
-      expect(postBodies).toMatchSnapshot();
-    });
-
-    it('constructs a POST body for an SSH conversion host with CA certs', () => {
-      const postBodies = getConfigureConversionHostPostBodies(locationStepValues, hostsStepValues, {
-        ...sshAuthStepValues,
-        openstackUser: 'cloud-user',
+        verifyCaCerts: true,
         caCerts: { body: 'mock CA certs body' }
-      });
-      expect(postBodies).toMatchSnapshot();
+      }
     });
+    expect(postBodies).toMatchSnapshot();
+  });
+
+  it('constructs a POST body for an SSH conversion host with CA certs', () => {
+    const postBodies = getConfigureConversionHostPostBodies({
+      hostsStepValues,
+      authStepValues: {
+        ...sshAuthStepValues,
+        verifyCaCerts: true,
+        caCerts: { body: 'mock CA certs body' }
+      }
+    });
+    expect(postBodies).toMatchSnapshot();
+  });
+
+  it('does not include the CA cert property if the verify certs switch is turned off even if there is form data for it', () => {
+    const postBodies = getConfigureConversionHostPostBodies({
+      hostsStepValues,
+      authStepValues: {
+        ...vddkAuthStepValues,
+        verifyCaCerts: false,
+        caCerts: { body: 'mock CA certs body' }
+      }
+    });
+    expect(postBodies[0].tls_ca_certs).toBeUndefined();
   });
 });

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardResultsStep/__tests__/index.test.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardResultsStep/__tests__/index.test.js
@@ -20,7 +20,7 @@ describe('ConversionHostWizardLocationStep integration test', () => {
         conversionHostWizardAuthenticationStep: {
           values: {
             conversionHostSshKey: { body: 'mock conversion host SSH key body' },
-            openstackCaCerts: { body: '' },
+            caCerts: { body: '' },
             transformationMethod: VDDK,
             vddkLibraryPath: 'mock VDDK path'
           }

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardResultsStep/helpers.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardResultsStep/helpers.js
@@ -13,7 +13,7 @@ export const getConfigureConversionHostPostBodies = (locationStepValues, hostsSt
       resource_id: host.id,
       conversion_host_ssh_private_key: authStepValues.conversionHostSshKey.body,
       auth_user: locationStepValues.providerType === OPENSTACK ? authStepValues.openstackUser : 'root',
-      ...(authStepValues.openstackCaCerts.body && { openstack_tls_ca_certs: authStepValues.openstackCaCerts.body }),
+      ...(authStepValues.caCerts.body && { tls_ca_certs: authStepValues.caCerts.body }),
       ...vmwareAuthProperties
     };
   });

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardResultsStep/helpers.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardResultsStep/helpers.js
@@ -1,7 +1,6 @@
-import { OPENSTACK } from '../../../../../../../../../common/constants';
 import { VDDK } from '../ConversionHostWizardConstants';
 
-export const getConfigureConversionHostPostBodies = (locationStepValues, hostsStepValues, authStepValues) =>
+export const getConfigureConversionHostPostBodies = ({ hostsStepValues, authStepValues }) =>
   hostsStepValues.hosts.map(host => {
     const vmwareAuthProperties =
       authStepValues.transformationMethod === VDDK
@@ -12,8 +11,8 @@ export const getConfigureConversionHostPostBodies = (locationStepValues, hostsSt
       resource_type: host.type,
       resource_id: host.id,
       conversion_host_ssh_private_key: authStepValues.conversionHostSshKey.body,
-      auth_user: locationStepValues.providerType === OPENSTACK ? authStepValues.openstackUser : 'root',
-      ...(authStepValues.caCerts.body && { tls_ca_certs: authStepValues.caCerts.body }),
+      auth_user: 'cloud-user',
+      ...(authStepValues.verifyCaCerts && authStepValues.caCerts.body && { tls_ca_certs: authStepValues.caCerts.body }),
       ...vmwareAuthProperties
     };
   });

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardResultsStep/index.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardResultsStep/index.js
@@ -9,10 +9,9 @@ const mapStateToProps = ({
   form,
   settings: { isPostingConversionHosts, isRejectedPostingConversionHosts, postConversionHostsResults }
 }) => {
-  const locationStepValues = form[stepIDs.locationStep] && form[stepIDs.locationStep].values;
   const hostsStepValues = form[stepIDs.hostsStep] && form[stepIDs.hostsStep].values;
   const authStepValues = form[stepIDs.authenticationStep] && form[stepIDs.authenticationStep].values;
-  const postBodies = getConfigureConversionHostPostBodies(locationStepValues, hostsStepValues, authStepValues);
+  const postBodies = getConfigureConversionHostPostBodies({ hostsStepValues, authStepValues });
   return {
     postBodies,
     isPostingConversionHosts,

--- a/app/javascript/react/screens/App/Settings/screens/GeneralSettings/GeneralSettings.js
+++ b/app/javascript/react/screens/App/Settings/screens/GeneralSettings/GeneralSettings.js
@@ -3,7 +3,8 @@ import PropTypes from 'prop-types';
 import { reduxForm, Field } from 'redux-form';
 import { Form, Button, Icon, OverlayTrigger, Popover, Spinner } from 'patternfly-react';
 import NumberInput from '../../../common/forms/NumberInput';
-import TextInputWithCheckbox from '../../../common/forms/TextInputWithCheckbox';
+// import TextInputWithCheckbox from '../../../common/forms/TextInputWithCheckbox';
+// TODO use this ^ if/when we re-enable throttling in the UI.
 
 const FORM_NAME = 'settings';
 
@@ -48,16 +49,6 @@ export class GeneralSettings extends React.Component {
       settingsForm &&
       settingsForm.values &&
       Object.keys(savedSettings).some(key => savedSettings[key] !== settingsForm.values[key]);
-
-    const inputEnabledFunction = value => value !== 'unlimited';
-
-    const validatePercentInput = value => {
-      const numberRegex = /^\d+$/;
-      if ((inputEnabledFunction(value) && !numberRegex.test(value)) || value < 0 || value > 100) {
-        return __('The entered value must be between 0 and 100');
-      }
-      return null;
-    };
 
     return (
       <Spinner loading={isFetchingServers || isFetchingSettings} style={{ marginTop: 15 }}>
@@ -112,21 +103,6 @@ export class GeneralSettings extends React.Component {
                 />
               </div>
             </Form.FormGroup>
-            <Form.FormGroup />
-            <div>
-              <h3>{__('Resource Utilization Limits for Migrations') /* TODO remove CPU throttling */}</h3>
-            </div>
-            <Field
-              id="cpu_limit_per_host"
-              name="cpu_limit_per_host"
-              component={TextInputWithCheckbox}
-              validate={validatePercentInput}
-              label={__('Max CPU utilization per conversion host')}
-              postfix="％"
-              inputEnabledFunction={inputEnabledFunction}
-              initialUncheckedValue="unlimited"
-              vertical
-            />
             <Form.FormGroup style={{ marginTop: '40px' }}>
               <Button
                 bsStyle="primary"

--- a/app/javascript/react/screens/App/Settings/screens/GeneralSettings/GeneralSettings.js
+++ b/app/javascript/react/screens/App/Settings/screens/GeneralSettings/GeneralSettings.js
@@ -114,7 +114,7 @@ export class GeneralSettings extends React.Component {
             </Form.FormGroup>
             <Form.FormGroup />
             <div>
-              <h3>{__('Resource Utilization Limits for Migrations')}</h3>
+              <h3>{__('Resource Utilization Limits for Migrations') /* TODO remove CPU throttling */}</h3>
             </div>
             <Field
               id="cpu_limit_per_host"

--- a/app/javascript/react/screens/App/Settings/screens/GeneralSettings/__tests__/__snapshots__/GeneralSettings.test.js.snap
+++ b/app/javascript/react/screens/App/Settings/screens/GeneralSettings/__tests__/__snapshots__/GeneralSettings.test.js.snap
@@ -129,25 +129,6 @@ exports[`GeneralSettings component renders the general settings page 1`] = `
       </FormGroup>
       <FormGroup
         bsClass="form-group"
-      />
-      <div>
-        <h3>
-          Resource Utilization Limits for Migrations
-        </h3>
-      </div>
-      <Field
-        component={[Function]}
-        id="cpu_limit_per_host"
-        initialUncheckedValue="unlimited"
-        inputEnabledFunction={[Function]}
-        label="Max CPU utilization per conversion host"
-        name="cpu_limit_per_host"
-        postfix="％"
-        validate={[Function]}
-        vertical={true}
-      />
-      <FormGroup
-        bsClass="form-group"
         style={
           Object {
             "marginTop": "40px",

--- a/app/javascript/react/screens/App/Settings/settings.fixtures.js
+++ b/app/javascript/react/screens/App/Settings/settings.fixtures.js
@@ -19,8 +19,7 @@ export const settings = Immutable({
   transformation: {
     limits: {
       max_concurrent_tasks_per_host: 10,
-      max_concurrent_tasks_per_ems: 10,
-      cpu_limit_per_host: 10
+      max_concurrent_tasks_per_ems: 10
     }
   },
   otherSettings: {
@@ -30,8 +29,7 @@ export const settings = Immutable({
 
 export const settingsFormValues = Immutable({
   max_concurrent_tasks_per_host: 10,
-  max_concurrent_tasks_per_ems: 10,
-  cpu_limit_per_host: 10
+  max_concurrent_tasks_per_ems: 10
 });
 
 export const fetchServersData = {


### PR DESCRIPTION
Ivanchuk-specific port of #1109 
Part of https://bugzilla.redhat.com/show_bug.cgi?id=1789479

Conflicts were related to https://github.com/ManageIQ/manageiq-v2v/pull/1030.

Note: this PR currently also contains the commits from #1113 , it should be rebased after that is merged before it is merged.

cc @simaishi 