### PR TITLE
[BZ#1807477] Replace info message for Conversion Host SSH Private Key field

### DIFF
--- a/app/javascript/react/screens/App/Settings/SettingsConstants.js
+++ b/app/javascript/react/screens/App/Settings/SettingsConstants.js
@@ -17,3 +17,5 @@ export const HIDE_V2V_CONVERSION_HOST_RETRY_MODAL = 'HIDE_V2V_CONVERSION_HOST_RE
 export const V2V_CONVERSION_HOST_RETRY_MODAL_EXITED = 'V2V_CONVERSION_HOST_RETRY_MODAL_EXITED';
 
 export const FETCH_CONVERSION_HOSTS_URL = '/api/conversion_hosts?attributes=resource&expand=resources';
+
+export const CONVERSION_HOST_SSH_KEY_MESSAGE = __('This is the private key file used to connect to the conversion host instance for cloud-user.'); // prettier-ignore

--- a/app/javascript/react/screens/App/Settings/__tests__/helpers.test.js
+++ b/app/javascript/react/screens/App/Settings/__tests__/helpers.test.js
@@ -5,7 +5,6 @@ import {
   attachTasksToConversionHosts,
   getCombinedConversionHostListItems,
   getConversionHostTaskLogFile,
-  getConversionHostSshKeyInfoMessage,
   inferTransportMethod
 } from '../helpers';
 
@@ -15,7 +14,6 @@ import {
   exampleConversionHosts,
   inProgress
 } from '../settings.fixtures';
-import { RHV, OPENSTACK } from '../../../../../common/constants';
 
 describe('conversion host task parsing and indexing', () => {
   it('parses tasks correctly', () => {
@@ -190,19 +188,5 @@ describe('conversion host log file helper', () => {
       context_data: {}
     };
     expect(getConversionHostTaskLogFile(task)).toBe(null);
-  });
-});
-
-describe('conversion host ssh key info message', () => {
-  it('has a message for RHV hosts', () => {
-    expect(getConversionHostSshKeyInfoMessage(RHV).length).toBeGreaterThan(0);
-  });
-
-  it('has a message for OSP hosts', () => {
-    expect(getConversionHostSshKeyInfoMessage(OPENSTACK).length).toBeGreaterThan(0);
-  });
-
-  it('returns empty string for unknown hosts', () => {
-    expect(getConversionHostSshKeyInfoMessage('unknown')).toBe('');
   });
 });

--- a/app/javascript/react/screens/App/Settings/helpers.js
+++ b/app/javascript/react/screens/App/Settings/helpers.js
@@ -1,5 +1,4 @@
 import { FINISHED, ERROR } from './screens/ConversionHostsSettings/ConversionHostsSettingsConstants';
-import { RHV, OPENSTACK } from '../../../../common/constants';
 
 export const getFormValuesFromApiSettings = payload => ({
   max_concurrent_tasks_per_conversion_host: payload.transformation.limits.max_concurrent_tasks_per_conversion_host,
@@ -117,14 +116,4 @@ export const getConversionHostTaskLogFile = task => {
     return { fileName, fileBody: conversion_host_disable };
   }
   return null;
-};
-
-export const getConversionHostSshKeyInfoMessage = selectedProviderType => {
-  if (selectedProviderType === RHV) {
-    return __('RHV-M deploys a common SSH public key on all hosts when configuring them. This allows commands and playbooks to be run from RHV-M. The associated private key is in the file /etc/pki/ovirt-engine/keys/engine_id_rsa on RHV-M.'); // prettier-ignore
-  }
-  if (selectedProviderType === OPENSTACK) {
-    return __('This is the private key file used to connect to the conversion host instance for the OpenStack User.');
-  }
-  return '';
 };

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/ConversionHostWizardAuthenticationStep.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/ConversionHostWizardAuthenticationStep.js
@@ -7,15 +7,11 @@ import { stepIDs, VDDK, SSH } from '../ConversionHostWizardConstants';
 import { FormField } from '../../../../../../common/forms/FormField';
 import { BootstrapSelect } from '../../../../../../common/forms/BootstrapSelect';
 import TextFileField from '../../../../../../common/forms/TextFileField';
-import { getConversionHostSshKeyInfoMessage } from '../../../../../helpers';
+import { CONVERSION_HOST_SSH_KEY_MESSAGE } from '../../../../../SettingsConstants';
 
 const requiredWithMessage = required({ msg: __('This field is required') });
 
-export const ConversionHostWizardAuthenticationStep = ({
-  selectedProviderType,
-  selectedTransformationMethod,
-  verifyCaCerts
-}) => {
+export const ConversionHostWizardAuthenticationStep = ({ selectedTransformationMethod, verifyCaCerts }) => {
   const fieldBaseProps = { labelWidth: 4, controlWidth: 7 };
 
   return (
@@ -26,7 +22,7 @@ export const ConversionHostWizardAuthenticationStep = ({
         label={__('Conversion Host SSH private key')}
         help={__('Upload your SSH key file or paste its contents below.')}
         controlId="host-ssh-key-input"
-        info={getConversionHostSshKeyInfoMessage(selectedProviderType)}
+        info={CONVERSION_HOST_SSH_KEY_MESSAGE}
       />
       <Field
         {...fieldBaseProps}

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/__tests__/__snapshots__/ConversionHostWizardAuthenticationStep.test.js.snap
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardAuthenticationStep/__tests__/__snapshots__/ConversionHostWizardAuthenticationStep.test.js.snap
@@ -13,7 +13,7 @@ exports[`conversion host wizard authentication step renders correctly in the ini
     controlWidth={7}
     help="Upload your SSH key file or paste its contents below."
     hideBody={false}
-    info="This is the private key file used to connect to the conversion host instance for the OpenStack User."
+    info="This is the private key file used to connect to the conversion host instance for cloud-user."
     label="Conversion Host SSH private key"
     labelWidth={4}
     name="conversionHostSshKey"
@@ -82,7 +82,7 @@ exports[`conversion host wizard authentication step renders correctly in the ini
     controlWidth={7}
     help="Upload your SSH key file or paste its contents below."
     hideBody={false}
-    info="RHV-M deploys a common SSH public key on all hosts when configuring them. This allows commands and playbooks to be run from RHV-M. The associated private key is in the file /etc/pki/ovirt-engine/keys/engine_id_rsa on RHV-M."
+    info="This is the private key file used to connect to the conversion host instance for cloud-user."
     label="Conversion Host SSH private key"
     labelWidth={4}
     name="conversionHostSshKey"
@@ -151,7 +151,7 @@ exports[`conversion host wizard authentication step renders correctly with SSH t
     controlWidth={7}
     help="Upload your SSH key file or paste its contents below."
     hideBody={false}
-    info="RHV-M deploys a common SSH public key on all hosts when configuring them. This allows commands and playbooks to be run from RHV-M. The associated private key is in the file /etc/pki/ovirt-engine/keys/engine_id_rsa on RHV-M."
+    info="This is the private key file used to connect to the conversion host instance for cloud-user."
     label="Conversion Host SSH private key"
     labelWidth={4}
     name="conversionHostSshKey"
@@ -229,7 +229,7 @@ exports[`conversion host wizard authentication step renders correctly with VDDK 
     controlWidth={7}
     help="Upload your SSH key file or paste its contents below."
     hideBody={false}
-    info="RHV-M deploys a common SSH public key on all hosts when configuring them. This allows commands and playbooks to be run from RHV-M. The associated private key is in the file /etc/pki/ovirt-engine/keys/engine_id_rsa on RHV-M."
+    info="This is the private key file used to connect to the conversion host instance for cloud-user."
     label="Conversion Host SSH private key"
     labelWidth={4}
     name="conversionHostSshKey"
@@ -314,7 +314,7 @@ exports[`conversion host wizard authentication step renders correctly with verif
     controlWidth={7}
     help="Upload your SSH key file or paste its contents below."
     hideBody={false}
-    info="This is the private key file used to connect to the conversion host instance for the OpenStack User."
+    info="This is the private key file used to connect to the conversion host instance for cloud-user."
     label="Conversion Host SSH private key"
     labelWidth={4}
     name="conversionHostSshKey"
@@ -392,7 +392,7 @@ exports[`conversion host wizard authentication step renders the redux-form wrapp
     controlWidth={7}
     help="Upload your SSH key file or paste its contents below."
     hideBody={false}
-    info="RHV-M deploys a common SSH public key on all hosts when configuring them. This allows commands and playbooks to be run from RHV-M. The associated private key is in the file /etc/pki/ovirt-engine/keys/engine_id_rsa on RHV-M."
+    info="This is the private key file used to connect to the conversion host instance for cloud-user."
     label="Conversion Host SSH private key"
     labelWidth={4}
     name="conversionHostSshKey"

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/RetryConversionHostConfirmationModal/RetryConversionHostConfirmationModal.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/RetryConversionHostConfirmationModal/RetryConversionHostConfirmationModal.js
@@ -2,9 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { reduxForm } from 'redux-form';
 import { Button, Modal, Form, Grid } from 'patternfly-react';
-import { CONVERSION_HOST_TYPES } from '../../../../../../../../common/constants';
 import TextFileField from '../../../../../common/forms/TextFileField';
-import { getConversionHostSshKeyInfoMessage } from '../../../../helpers';
+import { CONVERSION_HOST_SSH_KEY_MESSAGE } from '../../../../SettingsConstants';
 
 const fieldBaseProps = { labelWidth: 4, controlWidth: 7 };
 
@@ -24,9 +23,6 @@ export const RetryConversionHostConfirmationModal = ({
     conversionHostTaskToRetry.context_data.request_params;
   const isUsingSshTransformation = !requestParams.vmware_vddk_package_url;
 
-  const selectedProviderType = Object.keys(CONVERSION_HOST_TYPES).find(key =>
-    CONVERSION_HOST_TYPES[key].includes(requestParams.resource_type)
-  );
   const formHasErrors = retryForm && !!retryForm.syncErrors;
 
   return (
@@ -62,7 +58,7 @@ export const RetryConversionHostConfirmationModal = ({
             label={__('Conversion Host SSH private key')}
             help={__('Upload your SSH key file or paste its contents below.')}
             controlId="host-ssh-key-input"
-            info={getConversionHostSshKeyInfoMessage(selectedProviderType)}
+            info={CONVERSION_HOST_SSH_KEY_MESSAGE}
           />
           {isUsingSshTransformation && (
             <TextFileField

--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/RetryConversionHostConfirmationModal/__tests__/__snapshots__/RetryConversionHostConfirmationModal.test.js.snap
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/RetryConversionHostConfirmationModal/__tests__/__snapshots__/RetryConversionHostConfirmationModal.test.js.snap
@@ -89,7 +89,7 @@ exports[`retry conversion host confirmation modal renders correctly for a VDDK t
         controlWidth={7}
         help="Upload your SSH key file or paste its contents below."
         hideBody={false}
-        info=""
+        info="This is the private key file used to connect to the conversion host instance for cloud-user."
         label="Conversion Host SSH private key"
         labelWidth={4}
         name="conversionHostSshKey"
@@ -214,7 +214,7 @@ exports[`retry conversion host confirmation modal renders correctly for an SSH t
         controlWidth={7}
         help="Upload your SSH key file or paste its contents below."
         hideBody={false}
-        info=""
+        info="This is the private key file used to connect to the conversion host instance for cloud-user."
         label="Conversion Host SSH private key"
         labelWidth={4}
         name="conversionHostSshKey"


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1807477

After discussing with @fdupont-redhat and @vconzola we determined that for both RHV and OpenStack, the info message on this field should say "This is the private key file used to connect to the conversion host instance for cloud-user", which is almost the same as the existing message for OpenStack (except that the old message referred to the OpenStack User field we removed, so instead it should specifically reference the `cloud-user` username).

<img width="906" alt="Screenshot 2020-02-26 10 29 40" src="https://user-images.githubusercontent.com/811963/75360020-30265500-5883-11ea-9869-b2fe60ba8a12.png">
