### PR TITLE
Allow warm migration for OSP plans

### DIFF
--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/PlanWizardSelectors.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/PlanWizardSelectors.js
@@ -86,7 +86,6 @@ export const getWarmMigrationCompatibility = ({
     vms
   });
 
-  const isRhvTarget = targetProviderType === RHV;
   const isEveryVmCompatible = vms.every(vm => vm.warm_migration_compatible);
   const areConversionHostsConfigured = targetClustersInPlan.every(targetCluster =>
     getAvailableConversionHostsForCluster({ settings, targetProviderType, targetCluster }).some(
@@ -94,11 +93,10 @@ export const getWarmMigrationCompatibility = ({
     )
   );
 
-  const shouldEnableWarmMigration = isRhvTarget && isEveryVmCompatible && areConversionHostsConfigured;
+  const shouldEnableWarmMigration = isEveryVmCompatible && areConversionHostsConfigured;
 
   return {
     isFetchingTargetValidationData: false,
-    isRhvTarget,
     isEveryVmCompatible,
     areConversionHostsConfigured,
     shouldEnableWarmMigration

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardScheduleStep/PlanWizardScheduleStep.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardScheduleStep/PlanWizardScheduleStep.js
@@ -7,21 +7,9 @@ import { FormField } from '../../../../../common/forms/FormField';
 export class PlanWizardScheduleStep extends React.Component {
   componentDidMount() {
     const {
-      warmMigrationCompatibility: { isRhvTarget, isEveryVmCompatible, areConversionHostsConfigured },
+      warmMigrationCompatibility: { isEveryVmCompatible, areConversionHostsConfigured },
       showAlertAction
     } = this.props;
-    if (!isRhvTarget) {
-      showAlertAction({
-        alertId: 'warmMigrationNonRhvTarget',
-        alertText: (
-          <span>
-            <strong>{__('Warm migration not supported.')}</strong>{' '}
-            {__('Warm migration is currently only supported for Red Hat Virtualization targets.')}
-          </span>
-        ),
-        alertType: 'info'
-      });
-    }
     if (!isEveryVmCompatible) {
       showAlertAction({
         alertId: 'warmMigrationBadVms',
@@ -132,7 +120,6 @@ PlanWizardScheduleStep.propTypes = {
   migration_plan_choice_radio: PropTypes.string,
   warmMigrationCompatibility: PropTypes.shape({
     isFetchingTargetValidationData: PropTypes.bool,
-    isRhvTarget: PropTypes.bool,
     isEveryVmCompatible: PropTypes.bool,
     areConversionHostsConfigured: PropTypes.bool,
     shouldEnableWarmMigration: PropTypes.bool


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1819203

Removes restriction in `getWarmMigrationCompatibility` which checks for a RHV target, and the corresponding alert in the Type and Schedule step of the plan wizard.