### PR TITLE
[BZ#1810091] Conversion Host Wizard: hide powered-off VMs

### DIFF
--- a/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardHostsStep/ConversionHostWizardHostsStep.js
+++ b/app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardHostsStep/ConversionHostWizardHostsStep.js
@@ -25,6 +25,8 @@ const ConversionHostWizardHostsStep = ({
     emptyLabel = __('No VMs available for the selected project.');
   }
   const filteredHostOptions = hostOptions.filter(host => {
+    // Don't allow selection of hosts that are powered off
+    if (host.power_state === 'off') return false;
     // Don't allow selection of hosts already configured as conversion hosts
     if (conversionHosts.some(ch => ch.resource.type === host.type && ch.resource.id === host.id)) return false;
     // Don't allow selection of hosts in progress of being configured as conversion hosts


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1810091

When configuring a conversion host, on the Hosts step of the wizard, only powered-on VMs will appear as options.

To test this, you can use the `conversionhost-task-states` database from [here](https://drive.google.com/drive/folders/1psxWLopcPUFeJCoHcnMiOgF40x2V0h3Q?usp=sharing). Most clusters/projects in this database have some VMs powered on and some powered off. For example, If you choose the "admin" project in the "Brilliant OpenStack" provider, the only eligible VMs that are powered on are `ims_host_2`, `ims_host_1` and `tg-conv-vm`. The powered off VMs (`test_guest`, `check_ipset`, `test1` and `migration`) will no longer appear.  (You can see these VM objects in Redux dev tools at `targetResources.targetClusters[1].vms`.)