### PR TITLE
Menu - move Migration before Control

### DIFF
--- a/lib/manageiq/v2v/engine.rb
+++ b/lib/manageiq/v2v/engine.rb
@@ -20,7 +20,7 @@ module ManageIQ::V2V
           Menu::Item.new('plans', N_("Migration Plans"), 'migration', {:feature => 'migration', :any => true}, '/migration#/plans'),
           Menu::Item.new('mappings', N_("Infrastructure Mappings"), 'mappings', {:feature => 'mappings', :any => true}, '/migration#/mappings'),
           Menu::Item.new('settings', N_("Migration Settings"), 'migration_settings', {:feature => 'migration_settings', :any => true}, '/migration#/settings')
-        ], nil, :conf) # Place Migration before Configuration (after Compute)
+        ], nil, :con) # Place Migration before Control (after the various Provider kinds)
       )
     end
 


### PR DESCRIPTION
Follow-up to https://github.com/ManageIQ/manageiq-ui-classic/pull/6994,

we're changing the menu to put things with Providers together...

![](https://user-images.githubusercontent.com/289743/80232732-e40a4d80-8644-11ea-843b-6b839870f7d9.png)

Updating v2v to put the Migration section before Control, after the providers.

Cc @Fryguy 