### PR TITLE
Add search boxes to the source and target lists in the mapping wizard

### DIFF
--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/DualPaneMapper/DualPaneMapperList.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/DualPaneMapper/DualPaneMapperList.js
@@ -28,7 +28,7 @@ const DualPaneMapperList = ({
           type="text"
           aria-label={searchAriaLabel}
           value={searchText}
-          placeholder="Search..."
+          placeholder={__('Search...')}
           onChange={event => onSearchChange(event.target.value)}
         />
         <InputGroup.Button>

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/DualPaneMapper/DualPaneMapperList.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/DualPaneMapper/DualPaneMapperList.js
@@ -1,9 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import { Spinner } from 'patternfly-react';
+import { Spinner, InputGroup, FormControl, Icon, Button } from 'patternfly-react';
 
-const DualPaneMapperList = ({ children, listTitle, loading, id, counter }) => {
+const DualPaneMapperList = ({
+  children,
+  listTitle,
+  searchAriaLabel,
+  searchText,
+  onSearchChange,
+  loading,
+  id,
+  counter
+}) => {
   const classes = cx('dual-pane-mapper-items-container', {
     'has-counter': counter,
     loading
@@ -14,6 +23,20 @@ const DualPaneMapperList = ({ children, listTitle, loading, id, counter }) => {
       <label htmlFor="availableTitle">
         <span id="listTitle">{listTitle}</span>
       </label>
+      <InputGroup style={{ marginBottom: 8 }}>
+        <FormControl
+          type="text"
+          aria-label={searchAriaLabel}
+          value={searchText}
+          placeholder="Search..."
+          onChange={event => onSearchChange(event.target.value)}
+        />
+        <InputGroup.Button>
+          <Button onClick={() => onSearchChange('')} disabled={searchText === ''}>
+            <Icon type="pf" name="close" />
+          </Button>
+        </InputGroup.Button>
+      </InputGroup>
       <div className="dual-pane-mapper-list">
         <div className={classes} id={id}>
           {loading ? <Spinner loading /> : children}
@@ -27,6 +50,9 @@ const DualPaneMapperList = ({ children, listTitle, loading, id, counter }) => {
 DualPaneMapperList.propTypes = {
   children: PropTypes.node,
   listTitle: PropTypes.string,
+  searchAriaLabel: PropTypes.string,
+  searchText: PropTypes.string,
+  onSearchChange: PropTypes.func,
   id: PropTypes.string,
   loading: PropTypes.bool,
   counter: PropTypes.node

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardClustersStep/components/ClustersStepForm/ClustersStepForm.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardClustersStep/components/ClustersStepForm/ClustersStepForm.js
@@ -18,7 +18,9 @@ class ClustersStepForm extends React.Component {
   state = {
     selectedTargetCluster: null,
     selectedSourceClusters: [],
-    selectedMapping: null
+    selectedMapping: null,
+    sourceSearchText: '',
+    targetSearchText: ''
   };
 
   selectSourceCluster = sourceCluster => {
@@ -117,6 +119,11 @@ class ClustersStepForm extends React.Component {
       </div>
     );
 
+  noSearchResults = (results, searchText) =>
+    results.length === 0 && searchText !== '' ? (
+      <div className="dual-pane-mapper-item">{__('No clusters match your search.')}</div>
+    ) : null;
+
   render() {
     const {
       sourceClusters,
@@ -129,10 +136,28 @@ class ClustersStepForm extends React.Component {
       ospConversionHosts
     } = this.props;
 
-    const { selectedTargetCluster, selectedSourceClusters, selectedMapping } = this.state;
+    const {
+      selectedTargetCluster,
+      selectedSourceClusters,
+      selectedMapping,
+      sourceSearchText,
+      targetSearchText
+    } = this.state;
 
     const filteredSourceClusters = sortBy(clusterInfo)(sourceClustersFilter(sourceClusters, input.value));
     const sortedTargetClusters = sortBy(clusterInfo)(targetClusters);
+    const getSearchResults = (items, searchText) =>
+      !items
+        ? []
+        : items.filter(
+            item =>
+              searchText === '' ||
+              clusterInfo(item)
+                .toLowerCase()
+                .includes(searchText.toLowerCase())
+          );
+    const sourceResults = getSearchResults(filteredSourceClusters, sourceSearchText);
+    const targetResults = getSearchResults(sortedTargetClusters, targetSearchText);
 
     const sourceCounter = (
       <DualPaneMapperCount selectedItems={selectedSourceClusters.length} totalItems={filteredSourceClusters.length} />
@@ -153,10 +178,13 @@ class ClustersStepForm extends React.Component {
             <DualPaneMapperList
               id="source_clusters"
               listTitle={__('Source Provider \\ Datacenter \\ Cluster')}
+              searchAriaLabel="Search source clusters"
+              searchText={sourceSearchText}
+              onSearchChange={value => this.setState({ sourceSearchText: value })}
               loading={isFetchingSourceClusters}
               counter={sourceCounter}
             >
-              {filteredSourceClusters.map(item => (
+              {sourceResults.map(item => (
                 <DualPaneMapperListItem
                   item={item}
                   text={clusterInfo(item)}
@@ -170,16 +198,20 @@ class ClustersStepForm extends React.Component {
               ))}
               {this.noClustersFound(sourceClusters, isFetchingSourceClusters)}
               {this.allClustersMapped(sourceClusters, filteredSourceClusters, isFetchingSourceClusters)}
+              {this.noSearchResults(sourceResults, sourceSearchText)}
             </DualPaneMapperList>
           )}
           {targetClusters && (
             <DualPaneMapperList
               id="target_clusters"
               listTitle={multiProviderTargetLabel(targetProvider, 'cluster')}
+              searchAriaLabel="Search target clusters"
+              searchText={targetSearchText}
+              onSearchChange={value => this.setState({ targetSearchText: value })}
               loading={isFetchingTargetClusters}
               counter={targetCounter}
             >
-              {sortedTargetClusters.map(item => {
+              {targetResults.map(item => {
                 let associatedConversionHosts = [];
                 if (targetProvider === RHV) {
                   // RHV conversion hosts need to be in the target cluster itself
@@ -204,6 +236,7 @@ class ClustersStepForm extends React.Component {
                 );
               })}
               {this.noClustersFound(targetClusters, isFetchingTargetClusters)}
+              {this.noSearchResults(targetResults, targetSearchText)}
             </DualPaneMapperList>
           )}
         </DualPaneMapper>

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardClustersStep/components/ClustersStepForm/ClustersStepForm.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardClustersStep/components/ClustersStepForm/ClustersStepForm.js
@@ -178,7 +178,7 @@ class ClustersStepForm extends React.Component {
             <DualPaneMapperList
               id="source_clusters"
               listTitle={__('Source Provider \\ Datacenter \\ Cluster')}
-              searchAriaLabel="Search source clusters"
+              searchAriaLabel={__('Search source clusters')}
               searchText={sourceSearchText}
               onSearchChange={value => this.setState({ sourceSearchText: value })}
               loading={isFetchingSourceClusters}
@@ -205,7 +205,7 @@ class ClustersStepForm extends React.Component {
             <DualPaneMapperList
               id="target_clusters"
               listTitle={multiProviderTargetLabel(targetProvider, 'cluster')}
-              searchAriaLabel="Search target clusters"
+              searchAriaLabel={__('Search target clusters')}
               searchText={targetSearchText}
               onSearchChange={value => this.setState({ targetSearchText: value })}
               loading={isFetchingTargetClusters}

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardDatastoresStep/components/DatastoresStepForm/DatastoresStepForm.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardDatastoresStep/components/DatastoresStepForm/DatastoresStepForm.js
@@ -328,7 +328,7 @@ class DatastoresStepForm extends React.Component {
           <DualPaneMapperList
             id="source_datastores"
             listTitle={__('Source Provider \\ Datacenter \\ Datastore')}
-            searchAriaLabel="Search source datastores"
+            searchAriaLabel={__('Search source datastores')}
             searchText={sourceSearchText}
             onSearchChange={value => this.setState({ sourceSearchText: value })}
             loading={isFetchingSourceDatastores}
@@ -358,7 +358,7 @@ class DatastoresStepForm extends React.Component {
           <DualPaneMapperList
             id="target_datastores"
             listTitle={multiProviderTargetLabel(targetProvider, 'storage')}
-            searchAriaLabel="Search target datastores"
+            searchAriaLabel={__('Search target datastores')}
             searchText={targetSearchText}
             onSearchChange={value => this.setState({ targetSearchText: value })}
             loading={isFetchingTargetDatastores}

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardNetworksStep/components/NetworksStepForm/NetworksStepForm.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardNetworksStep/components/NetworksStepForm/NetworksStepForm.js
@@ -359,7 +359,7 @@ class NetworksStepForm extends React.Component {
             listTitle={__('Source Provider \\ Datacenter \\ Network')}
             searchText={sourceSearchText}
             onSearchChange={value => this.setState({ sourceSearchText: value })}
-            searchAriaLabel="Search source networks"
+            searchAriaLabel={__('Search source networks')}
             loading={isFetchingSourceNetworks}
             counter={sourceCounter}
           >
@@ -389,7 +389,7 @@ class NetworksStepForm extends React.Component {
           <DualPaneMapperList
             id="target_networks"
             listTitle={multiProviderTargetLabel(targetProvider, 'network')}
-            searchAriaLabel="Search target networks"
+            searchAriaLabel={__('Search target networks')}
             searchText={targetSearchText}
             onSearchChange={value => this.setState({ targetSearchText: value })}
             loading={isFetchingTargetNetworks}

--- a/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardNetworksStep/components/NetworksStepForm/NetworksStepForm.js
+++ b/app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardNetworksStep/components/NetworksStepForm/NetworksStepForm.js
@@ -29,7 +29,9 @@ class NetworksStepForm extends React.Component {
   state = {
     selectedSourceNetworks: [],
     selectedTargetNetwork: null,
-    selectedNode: null
+    selectedNode: null,
+    sourceSearchText: '',
+    targetSearchText: ''
   };
 
   UNSAFE_componentWillReceiveProps(nextProps) {
@@ -289,6 +291,11 @@ class NetworksStepForm extends React.Component {
       </div>
     );
 
+  noSearchResults = (results, searchText) =>
+    results.length === 0 && searchText !== '' ? (
+      <div className="dual-pane-mapper-item">{__('No networks match your search.')}</div>
+    ) : null;
+
   render() {
     const {
       groupedSourceNetworks,
@@ -300,7 +307,13 @@ class NetworksStepForm extends React.Component {
       targetProvider,
       preLoadingMappings
     } = this.props;
-    const { selectedSourceNetworks, selectedTargetNetwork, selectedNode } = this.state;
+    const {
+      selectedSourceNetworks,
+      selectedTargetNetwork,
+      selectedNode,
+      sourceSearchText,
+      targetSearchText
+    } = this.state;
 
     const classes = cx('dual-pane-mapper-form', {
       'is-hidden': !selectedCluster
@@ -310,6 +323,21 @@ class NetworksStepForm extends React.Component {
       sourceNetworksFilter(groupedSourceNetworks, input.value)
     );
     const sortedTargetNetworkReps = sortBy(targetNetworkInfo)(getRepresentatives(groupedTargetNetworks));
+
+    const getSearchResults = (items, searchText, getItemText) =>
+      !items
+        ? []
+        : items.filter(
+            item =>
+              searchText === '' ||
+              getItemText(item)
+                .toLowerCase()
+                .includes(searchText.toLowerCase())
+          );
+    const sourceResults = getSearchResults(filteredSourceNetworks, sourceSearchText, item =>
+      sourceNetworkInfo(item, selectedCluster)
+    );
+    const targetResults = getSearchResults(sortedTargetNetworkReps, targetSearchText, targetNetworkInfo);
 
     const sourceCounter = (
       <DualPaneMapperCount selectedItems={selectedSourceNetworks.length} totalItems={filteredSourceNetworks.length} />
@@ -329,12 +357,15 @@ class NetworksStepForm extends React.Component {
           <DualPaneMapperList
             id="source_networks"
             listTitle={__('Source Provider \\ Datacenter \\ Network')}
+            searchText={sourceSearchText}
+            onSearchChange={value => this.setState({ sourceSearchText: value })}
+            searchAriaLabel="Search source networks"
             loading={isFetchingSourceNetworks}
             counter={sourceCounter}
           >
             {groupedSourceNetworks && (
               <React.Fragment>
-                {filteredSourceNetworks.map(sourceNetwork => (
+                {sourceResults.map(sourceNetwork => (
                   <DualPaneMapperListItem
                     item={sourceNetwork}
                     text={sourceNetworkInfo(sourceNetwork, selectedCluster)}
@@ -351,26 +382,34 @@ class NetworksStepForm extends React.Component {
                 ))}
                 {this.noNetworksFound(groupedSourceNetworks, isFetchingSourceNetworks)}
                 {this.allNetworksMapped(groupedSourceNetworks, filteredSourceNetworks, isFetchingSourceNetworks)}
+                {this.noSearchResults(sourceResults, sourceSearchText)}
               </React.Fragment>
             )}
           </DualPaneMapperList>
           <DualPaneMapperList
             id="target_networks"
             listTitle={multiProviderTargetLabel(targetProvider, 'network')}
+            searchAriaLabel="Search target networks"
+            searchText={targetSearchText}
+            onSearchChange={value => this.setState({ targetSearchText: value })}
             loading={isFetchingTargetNetworks}
             counter={targetCounter}
           >
-            {groupedTargetNetworks &&
-              sortedTargetNetworkReps.map(targetNetwork => (
-                <DualPaneMapperListItem
-                  item={targetNetwork}
-                  text={targetNetworkInfo(targetNetwork)}
-                  key={targetNetwork.id}
-                  selected={selectedTargetNetwork && networkKey(selectedTargetNetwork) === networkKey(targetNetwork)}
-                  handleClick={this.selectTargetNetwork}
-                  handleKeyPress={this.selectTargetNetwork}
-                />
-              ))}
+            {groupedTargetNetworks && (
+              <React.Fragment>
+                {targetResults.map(targetNetwork => (
+                  <DualPaneMapperListItem
+                    item={targetNetwork}
+                    text={targetNetworkInfo(targetNetwork)}
+                    key={targetNetwork.id}
+                    selected={selectedTargetNetwork && networkKey(selectedTargetNetwork) === networkKey(targetNetwork)}
+                    handleClick={this.selectTargetNetwork}
+                    handleKeyPress={this.selectTargetNetwork}
+                  />
+                ))}
+                {this.noSearchResults(targetResults, targetSearchText)}
+              </React.Fragment>
+            )}
           </DualPaneMapperList>
         </DualPaneMapper>
         <MappingWizardTreeView


### PR DESCRIPTION
Per @fdupont-redhat's request. Adds a search box above each list of clusters/datastores/networks in the mapping wizard. Available options will be filtered as you type, and a "No <clusters/datastores/networks> match your search" message appears if there are no matches. Searching does not interfere with your current selection, and you can search and select multiple times without losing any selections.

For users with a large number of clusters/datastores/networks, this makes it easier to find what you're looking for.

<img width="905" alt="Screen Shot 2020-09-04 at 1 51 15 PM" src="https://user-images.githubusercontent.com/811963/92271598-1ad75680-eeb6-11ea-858a-c341ec102ad5.png">

<img width="355" alt="Screen Shot 2020-09-04 at 1 51 34 PM" src="https://user-images.githubusercontent.com/811963/92271624-262a8200-eeb6-11ea-9dba-3eaa0c17e574.png">

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1875987