### PR TITLE
Set the version of file-selector to be stricter than in react-dropzone

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "core-js": "^2.5.7",
     "csv-parse": "~4.12.0",
     "file-saver": "^1.3.8",
+    "file-selector": "=0.1.12",
     "lodash.orderby": "^4.6.0",
     "moment": "^2.22.0",
     "numeral": "^2.0.6",


### PR DESCRIPTION
The `react-dropzone` package is breaking the CI/webpack on the ui-classic repo. The issue is probably with the `0.2.x` version of the `file-selector` dependency of this package that came out a few hours ago. A quick band-aid is to fixate the version of this secondary dependency more stricter than [`react-dropzone`](https://github.com/react-dropzone/react-dropzone/blob/master/package.json#L94).

```
ERROR in /home/skateman/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/bundler/gems/manageiq-v2v-0a7e157c539f/node_modules/react-dropzone/dist/es/index.js
Module not found: Error: Can't resolve 'file-selector' in '/home/skateman/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/bundler/gems/manageiq-v2v-0a7e157c539f/node_modules/react-dropzone/dist/es'
 @ /home/skateman/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/bundler/gems/manageiq-v2v-0a7e157c539f/node_modules/react-dropzone/dist/es/index.js 30:0-42 378:61-70
```