### PR TITLE
Update node and ruby versions for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,24 @@
 matrix:
   include:
-  - name: "Node.js: 8"
+  - name: "Node.js: 12"
     language: node_js
     cache: yarn
     node_js:
-    - '8' # current stable
+    - '12' # current stable
     script: yarn test --runInBand
-  - name: "Ruby: 2.5.7"
+  - name: "Ruby: 2.5.8"
     language: ruby
     cache: bundler
     rvm:
-    - 2.5.7
+    - 2.5.8
     addons:
       postgresql: '10'
     install: bin/setup
     after_script: bin/ci/after_script
-  - name: "Ruby: 2.6.5"
+  - name: "Ruby: 2.6.6"
     language: ruby
     rvm:
-    - 2.6.5
+    - 2.6.6
     cache: bundler
     addons:
       postgresql: '10'


### PR DESCRIPTION
The node and ruby versions are outdated, matching to the rest of the manageiq repos.

Noticed because of Travis failure in https://github.com/ManageIQ/manageiq-v2v/pull/1149:

`error file-selector@0.1.18: The engine "node" is incompatible with this module. Expected version ">= 10". Got "8.17.0"`

Kasparov/Jansa: #1151 

cc @himdel 

