### PR TITLE
Remove patternfly sass gems dependencies

### DIFF
--- a/app/javascript/react/screens/App/App.scss
+++ b/app/javascript/react/screens/App/App.scss
@@ -1,4 +1,4 @@
-@import 'patternfly/color-variables';
+@import "./colors/colorVariables.scss";
 @import './Overview/Overview.scss';
 @import './Settings/Settings.scss';
 @import './Plan/Plan.scss';

--- a/app/javascript/react/screens/App/colors/colorVariables.scss
+++ b/app/javascript/react/screens/App/colors/colorVariables.scss
@@ -1,0 +1,12 @@
+// Added these color variables from patternfly colors to remove PF gems dependencies.
+$color-pf-black-150:             #f5f5f5 !default;
+$color-pf-black-400:             #bbb !default;
+$color-pf-black-500:             #8b8d8f !default;
+$color-pf-blue-25:               #edf8ff !default;
+$color-pf-blue-50:               #def3ff !default;
+$color-pf-blue-100:              #bee1f4 !default;
+$color-pf-blue-200:              #7dc3e8 !default;
+$color-pf-blue-400:              #0088ce !default;
+$color-pf-orange-400:            #ec7a08 !default;
+$color-pf-red-100:               #cc0000 !default;
+$color-pf-white:                 #fff !default;


### PR DESCRIPTION
In this PR, removed patternfly-sass gems dependencies `@import 'patternfly/color-variables';` and added only necessary colors variables. These colors comes from patternfly colors.


@miq-bot add-label enhancement
@miq-bot assign @Fryguy 
@miq-bot add_reviewer @Fryguy 

