### PR TITLE
Add missing color variables

### DIFF
--- a/app/javascript/react/screens/App/colors/colorVariables.scss
+++ b/app/javascript/react/screens/App/colors/colorVariables.scss
@@ -1,7 +1,9 @@
 // Added these color variables from patternfly colors to remove PF gems dependencies.
 $color-pf-black-150:             #f5f5f5 !default;
+$color-pf-black-200:             #ededed !default;
 $color-pf-black-400:             #bbb !default;
 $color-pf-black-500:             #8b8d8f !default;
+$color-pf-black-600:             #72767b !default;
 $color-pf-blue-25:               #edf8ff !default;
 $color-pf-blue-50:               #def3ff !default;
 $color-pf-blue-100:              #bee1f4 !default;


### PR DESCRIPTION
I missed adding these colors in https://github.com/ManageIQ/manageiq-v2v/pull/1159

<img width="1115" alt="Screen Shot 2021-10-05 at 1 32 30 PM" src="https://user-images.githubusercontent.com/37085529/136073921-3e77db19-4fd8-4a74-a43a-9faeedf3b5c6.png">

@miq-bot assign @Fryguy 
@miq-bot add_reviewer @Fryguy 
@miq-bot add-label bug
